### PR TITLE
Extract BfabricConfig

### DIFF
--- a/bfabric/__init__.py
+++ b/bfabric/__init__.py
@@ -45,4 +45,4 @@ from bfabric.bfabric import Bfabric
 from bfabric.bfabric import BfabricWrapperCreator
 from bfabric.bfabric import BfabricSubmitter
 from bfabric.bfabric import BfabricFeeder
-
+from bfabric.bfabric_config import BfabricConfig

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+from typing import Optional, Dict
+
+
+class BfabricConfig:
+    """Holds the configuration for the B-Fabric client, and provides methods to load the configuration from a file.
+
+    Attributes:
+        login: The username
+        password: The web service password (i.e. not the regular user password)
+        base_url (optional): The API base url
+        application_ids (optional): Map of application names to ids.
+    """
+
+    def __init__(
+        self,
+        login: str,
+        password: str,
+        base_url: str = None,
+        application_ids: Dict[str, int] = None,
+    ):
+        self.login = login
+        self.password = password
+        self.base_url = base_url or "https://fgcz-bfabric.uzh.ch/bfabric"
+        self.application_ids = application_ids or {}
+
+    def with_overrides(
+        self,
+        login: Optional[str] = None,
+        password: Optional[str] = None,
+        base_url: Optional[str] = None,
+        application_ids: Optional[Dict[str, int]] = None,
+    ) -> BfabricConfig:
+        """Returns a copy of the configuration with new values applied, if they are not None."""
+        return BfabricConfig(
+            login=login if login is not None else self.login,
+            password=password if password is not None else self.password,
+            base_url=base_url if base_url is not None else self.base_url,
+            application_ids=application_ids
+            if application_ids is not None
+            else self.application_ids,
+        )
+
+    @classmethod
+    def read_bfabricrc_py(cls, file: io.FileIO) -> BfabricConfig:
+        """Reads a .bfabricrc.py file into a BfabricConfig object."""
+        values = {}
+        file_path = os.path.realpath(file.name)
+        logger = logging.getLogger(f"{cls.__module__}.{cls.__name__}")
+        logger.info(f"Reading configuration from: {file_path}")
+
+        for line in file:
+            if line.startswith("#"):
+                continue
+
+            key, _, value = [part.strip() for part in line.partition("=")]
+            if key not in ["_PASSWD", "_LOGIN", "_WEBBASE", "_APPLICATION"]:
+                continue
+
+            # In case of multiple definitions, the first rule counts!
+            if key not in values:
+                if key in ["_APPLICATION"]:
+                    try:
+                        values[key] = json.loads(value)
+                    except json.JSONDecodeError as e:
+                        raise ValueError(
+                            f"While reading {file_path}. '{key}' is not a valid JSON string."
+                        ) from e
+                else:
+                    # to make it downward compatible; so we replace quotes in login and password
+                    values[key] = value.replace('"', "").replace("'", "")
+            else:
+                logger.warning(f"While reading {file_path}. '{key}' is already set.")
+
+        return BfabricConfig(
+            login=values.get("_LOGIN"),
+            password=values.get("_PASSWD"),
+            base_url=values.get("_WEBBASE"),
+            application_ids=values.get("_APPLICATION"),
+        )
+
+    def __repr__(self):
+        return (
+            f"BfabricConfig(login={repr(self.login)}, password=..., base_url={repr(self.base_url)}, "
+            f"application_ids={repr(self.application_ids)})"
+        )

--- a/bfabric/tests/unit/test_bfabric_config.py
+++ b/bfabric/tests/unit/test_bfabric_config.py
@@ -1,0 +1,90 @@
+import io
+import unittest
+
+from bfabric.bfabric_config import BfabricConfig
+
+
+class TestBfabricConfig(unittest.TestCase):
+    def setUp(self):
+        self.config = BfabricConfig(
+            login="login",
+            password="user",
+            base_url="url",
+            application_ids={"app": 1},
+        )
+
+    def test_with_overrides(self):
+        new_config = self.config.with_overrides(
+            login="new_login",
+            password="new_user",
+            base_url="new_url",
+            application_ids={"new": 2},
+        )
+        self.assertEqual("new_login", new_config.login)
+        self.assertEqual("new_user", new_config.password)
+        self.assertEqual("new_url", new_config.base_url)
+        self.assertEqual({"new": 2}, new_config.application_ids)
+        self.assertEqual("login", self.config.login)
+        self.assertEqual("user", self.config.password)
+        self.assertEqual("url", self.config.base_url)
+        self.assertEqual({"app": 1}, self.config.application_ids)
+
+    def test_with_replaced_when_none(self):
+        new_config = self.config.with_overrides(
+            login=None, password=None, base_url=None, application_ids=None
+        )
+        self.assertEqual("login", new_config.login)
+        self.assertEqual("user", new_config.password)
+        self.assertEqual("url", new_config.base_url)
+        self.assertEqual({"app": 1}, new_config.application_ids)
+        self.assertEqual("login", self.config.login)
+        self.assertEqual("user", self.config.password)
+        self.assertEqual("url", self.config.base_url)
+        self.assertEqual({"app": 1}, self.config.application_ids)
+
+    def test_read_bfabricrc_py(self):
+        input_text = (
+            "# Some comment\n"
+            "_LOGIN = login\n"
+            "_PASSWD = 'user'\n"
+            "_UKNOWNKEY = 'value'\n"
+            "# Another comment\n"
+            """_WEBBASE = "url"\n"""
+            """_APPLICATION = {"app": 1}\n"""
+        )
+        file = io.StringIO(input_text)
+        setattr(file, "name", "/file")
+        with self.assertLogs(level="INFO") as log_context:
+            config = BfabricConfig.read_bfabricrc_py(file)
+        self.assertEqual("login", config.login)
+        self.assertEqual("user", config.password)
+        self.assertEqual("url", config.base_url)
+        self.assertEqual({"app": 1}, config.application_ids)
+        self.assertEqual(
+            [
+                "INFO:bfabric.bfabric_config.BfabricConfig:Reading configuration from: /file"
+            ],
+            log_context.output,
+        )
+
+    def test_read_bfabricrc_py_when_empty(self):
+        input_text = ""
+        file = io.StringIO(input_text)
+        setattr(file, "name", "/file")
+        with self.assertLogs(level="INFO"):
+            config = BfabricConfig.read_bfabricrc_py(file)
+        self.assertIsNone(config.login)
+        self.assertIsNone(config.password)
+        self.assertEqual("https://fgcz-bfabric.uzh.ch/bfabric", config.base_url)
+        self.assertEqual({}, config.application_ids)
+
+    def test_repr(self):
+        rep = repr(self.config)
+        self.assertEqual(
+            "BfabricConfig(login='login', password=..., base_url='url', application_ids={'app': 1})",
+            rep,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Configuration handling is moved to the`BfabricConfig` class.
- The new class uses the `logging` module, if changing the printed outputs is unacceptable at the moment, we can temporarily remove that again.
- For now, backwards compatibility has been added to the `Bfabric` class providing the same properties as before. Further refactoring will be done in future PRs.