### PR TITLE
Trigger CI manually for a particular branch

### DIFF
--- a/.github/workflows/run_functional_test.yml
+++ b/.github/workflows/run_functional_test.yml
@@ -10,6 +10,7 @@ on:
     - cron: "00 08 * * *"
   pull_request:
     branches: [ bfabric12 ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This change makes it possible to trigger a Github Actions run for the pipeline without actually creating a PR (as I did before), this could be helpful the next time we have to troubleshoot an issue there.