### PR TITLE
Configurable job emails

### DIFF
--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -654,8 +654,7 @@ class BfabricSubmitter():
 set -e
 set -o pipefail
 
-## TODO: #59
-export EMAIL="cp@fgcz.ethz.ch wew@fgcz.ethz.ch"
+export EMAIL="{job_notification_emails}"
 export EXTERNALJOB_ID={3}
 export RESSOURCEID_OUTPUT={4}
 export RESSOURCEID_STDOUT_STDERR="{5} {6}"
@@ -734,7 +733,8 @@ exit 0
                config['job_configuration']['executable'],
                config['job_configuration']['workunit_id'],
                self.nodelist,
-               self.memory)
+               self.memory,
+               job_notification_emails=self.B.config.job_notification_emails)
 
         return _cmd_template
 

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -15,19 +15,22 @@ class BfabricConfig:
         password: The web service password (i.e. not the regular user password)
         base_url (optional): The API base url
         application_ids (optional): Map of application names to ids.
+        job_notification_emails (optional): Space-separated list of email addresses to notify when a job finishes.
     """
 
     def __init__(
         self,
         login: str,
         password: str,
-        base_url: str = None,
-        application_ids: Dict[str, int] = None,
+        base_url: Optional[str] = None,
+        application_ids: Optional[Dict[str, int]] = None,
+        job_notification_emails: Optional[str] = None,
     ):
         self.login = login
         self.password = password
         self.base_url = base_url or "https://fgcz-bfabric.uzh.ch/bfabric"
         self.application_ids = application_ids or {}
+        self.job_notification_emails = job_notification_emails or ""
 
     def with_overrides(
         self,
@@ -59,7 +62,7 @@ class BfabricConfig:
                 continue
 
             key, _, value = [part.strip() for part in line.partition("=")]
-            if key not in ["_PASSWD", "_LOGIN", "_WEBBASE", "_APPLICATION"]:
+            if key not in ["_PASSWD", "_LOGIN", "_WEBBASE", "_APPLICATION", "_JOB_NOTIFICATION_EMAILS"]:
                 continue
 
             # In case of multiple definitions, the first rule counts!
@@ -82,10 +85,14 @@ class BfabricConfig:
             password=values.get("_PASSWD"),
             base_url=values.get("_WEBBASE"),
             application_ids=values.get("_APPLICATION"),
+            job_notification_emails=values.get("_JOB_NOTIFICATION_EMAILS"),
         )
 
     def __repr__(self):
         return (
-            f"BfabricConfig(login={repr(self.login)}, password=..., base_url={repr(self.base_url)}, "
-            f"application_ids={repr(self.application_ids)})"
+            f"BfabricConfig(login={repr(self.login)}, "
+            f"password=..., "
+            f"base_url={repr(self.base_url)}, "
+            f"application_ids={repr(self.application_ids)}, "
+            f"job_notification_emails={repr(self.job_notification_emails)})"
         )

--- a/bfabric/tests/unit/test_bfabric_config.py
+++ b/bfabric/tests/unit/test_bfabric_config.py
@@ -51,6 +51,7 @@ class TestBfabricConfig(unittest.TestCase):
             "# Another comment\n"
             """_WEBBASE = "url"\n"""
             """_APPLICATION = {"app": 1}\n"""
+            """_JOB_NOTIFICATION_EMAILS = "email1 email2"\n"""
         )
         file = io.StringIO(input_text)
         setattr(file, "name", "/file")
@@ -60,6 +61,7 @@ class TestBfabricConfig(unittest.TestCase):
         self.assertEqual("user", config.password)
         self.assertEqual("url", config.base_url)
         self.assertEqual({"app": 1}, config.application_ids)
+        self.assertEqual("email1 email2", config.job_notification_emails)
         self.assertEqual(
             [
                 "INFO:bfabric.bfabric_config.BfabricConfig:Reading configuration from: /file"
@@ -77,11 +79,13 @@ class TestBfabricConfig(unittest.TestCase):
         self.assertIsNone(config.password)
         self.assertEqual("https://fgcz-bfabric.uzh.ch/bfabric", config.base_url)
         self.assertEqual({}, config.application_ids)
+        self.assertEqual("", config.job_notification_emails)
 
     def test_repr(self):
         rep = repr(self.config)
         self.assertEqual(
-            "BfabricConfig(login='login', password=..., base_url='url', application_ids={'app': 1})",
+            "BfabricConfig(login='login', password=..., base_url='url', application_ids={'app': 1}, "
+            "job_notification_emails='')",
             rep,
         )
 


### PR DESCRIPTION
This PR introduces a new configuration key `_JOB_NOTIFICATION_EMAILS` which is then used by `BfabricSubmitter`.

Resolves #59