### PR TITLE
Split config into config and auth

### DIFF
--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -24,7 +24,7 @@ class BfabricAuth:
 
 @dataclasses.dataclass(frozen=True)
 class BfabricConfig:
-    """Holds the configuration for the B-Fabric client, and provides methods to load the configuration from a file.
+    """Holds the configuration for the B-Fabric client for connecting to particular instance of B-Fabric.
 
     Attributes:
         base_url (optional): The API base url

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -4,95 +4,96 @@ import io
 import json
 import logging
 import os
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
+import dataclasses
 
 
+@dataclasses.dataclass(frozen=True)
+class BfabricAuth:
+    """Holds the configuration for authenticating a particular user with B-Fabric."""
+
+    login: str
+    password: str
+
+    def __repr__(self):
+        return f"BfabricAuth(login={repr(self.login)}, password=...)"
+
+    def __str__(self):
+        return repr(self)
+
+
+@dataclasses.dataclass(frozen=True)
 class BfabricConfig:
     """Holds the configuration for the B-Fabric client, and provides methods to load the configuration from a file.
 
     Attributes:
-        login: The username
-        password: The web service password (i.e. not the regular user password)
         base_url (optional): The API base url
         application_ids (optional): Map of application names to ids.
         job_notification_emails (optional): Space-separated list of email addresses to notify when a job finishes.
     """
 
-    def __init__(
-        self,
-        login: str,
-        password: str,
-        base_url: Optional[str] = None,
-        application_ids: Optional[Dict[str, int]] = None,
-        job_notification_emails: Optional[str] = None,
-    ):
-        self.login = login
-        self.password = password
-        self.base_url = base_url or "https://fgcz-bfabric.uzh.ch/bfabric"
-        self.application_ids = application_ids or {}
-        self.job_notification_emails = job_notification_emails or ""
+    base_url: str = "https://fgcz-bfabric.uzh.ch/bfabric"
+    application_ids: Dict[str, int] = dataclasses.field(default_factory=dict)
+    job_notification_emails: str = ""
 
     def with_overrides(
         self,
-        login: Optional[str] = None,
-        password: Optional[str] = None,
         base_url: Optional[str] = None,
         application_ids: Optional[Dict[str, int]] = None,
     ) -> BfabricConfig:
         """Returns a copy of the configuration with new values applied, if they are not None."""
         return BfabricConfig(
-            login=login if login is not None else self.login,
-            password=password if password is not None else self.password,
             base_url=base_url if base_url is not None else self.base_url,
             application_ids=application_ids
             if application_ids is not None
             else self.application_ids,
         )
 
-    @classmethod
-    def read_bfabricrc_py(cls, file: io.FileIO) -> BfabricConfig:
-        """Reads a .bfabricrc.py file into a BfabricConfig object."""
-        values = {}
-        file_path = os.path.realpath(file.name)
-        logger = logging.getLogger(f"{cls.__module__}.{cls.__name__}")
-        logger.info(f"Reading configuration from: {file_path}")
 
-        for line in file:
-            if line.startswith("#"):
-                continue
+def parse_bfabricrc_py(file: io.FileIO) -> Tuple[BfabricConfig, Optional[BfabricAuth]]:
+    """Parses a .bfabricrc.py file and returns a tuple of BfabricConfig and BfabricAuth objects."""
+    values = {}
+    file_path = os.path.realpath(file.name)
+    logger = logging.getLogger(__name__)
+    logger.info(f"Reading configuration from: {file_path}")
 
-            key, _, value = [part.strip() for part in line.partition("=")]
-            if key not in ["_PASSWD", "_LOGIN", "_WEBBASE", "_APPLICATION", "_JOB_NOTIFICATION_EMAILS"]:
-                continue
+    for line in file:
+        if line.startswith("#"):
+            continue
 
-            # In case of multiple definitions, the first rule counts!
-            if key not in values:
-                if key in ["_APPLICATION"]:
-                    try:
-                        values[key] = json.loads(value)
-                    except json.JSONDecodeError as e:
-                        raise ValueError(
-                            f"While reading {file_path}. '{key}' is not a valid JSON string."
-                        ) from e
-                else:
-                    # to make it downward compatible; so we replace quotes in login and password
-                    values[key] = value.replace('"', "").replace("'", "")
+        key, _, value = [part.strip() for part in line.partition("=")]
+        if key not in [
+            "_PASSWD",
+            "_LOGIN",
+            "_WEBBASE",
+            "_APPLICATION",
+            "_JOB_NOTIFICATION_EMAILS",
+        ]:
+            continue
+
+        # In case of multiple definitions, the first rule counts!
+        if key not in values:
+            if key in ["_APPLICATION"]:
+                try:
+                    values[key] = json.loads(value)
+                except json.JSONDecodeError as e:
+                    raise ValueError(
+                        f"While reading {file_path}. '{key}' is not a valid JSON string."
+                    ) from e
             else:
-                logger.warning(f"While reading {file_path}. '{key}' is already set.")
+                # to make it downward compatible; so we replace quotes in login and password
+                values[key] = value.replace('"', "").replace("'", "")
+        else:
+            logger.warning(f"While reading {file_path}. '{key}' is already set.")
 
-        return BfabricConfig(
-            login=values.get("_LOGIN"),
-            password=values.get("_PASSWD"),
-            base_url=values.get("_WEBBASE"),
-            application_ids=values.get("_APPLICATION"),
-            job_notification_emails=values.get("_JOB_NOTIFICATION_EMAILS"),
-        )
-
-    def __repr__(self):
-        return (
-            f"BfabricConfig(login={repr(self.login)}, "
-            f"password=..., "
-            f"base_url={repr(self.base_url)}, "
-            f"application_ids={repr(self.application_ids)}, "
-            f"job_notification_emails={repr(self.job_notification_emails)})"
-        )
+    args = dict(
+        base_url=values.get("_WEBBASE"),
+        application_ids=values.get("_APPLICATION"),
+        job_notification_emails=values.get("_JOB_NOTIFICATION_EMAILS"),
+    )
+    config = BfabricConfig(**{k: v for k, v in args.items() if v is not None})
+    if "_LOGIN" in values and "_PASSWD" in values:
+        auth = BfabricAuth(login=values["_LOGIN"], password=values["_PASSWD"])
+    else:
+        auth = None
+    return config, auth

--- a/bfabric/tests/test_bfabric_functional.py
+++ b/bfabric/tests/test_bfabric_functional.py
@@ -38,7 +38,7 @@ class BfabricFunctionalTestCase(unittest.TestCase):
         logging.info("Running functional test on bfabricPy")
 
         msg = "This test case requires user 'pfeeder'."
-        self.assertEqual(B.config.login, 'pfeeder', msg)
+        self.assertEqual(B.auth.login, 'pfeeder', msg)
 
         msg = "This test case requires a bfabric test system!"
         self.assertIn("bfabric-test", B.config.base_url, msg)


### PR DESCRIPTION
This is a preparation for multi-user support and a from-the-start clean implementation in the new interface.
The config will be fixed per client, whereas the auth can be provided per-client or per-request (as needed).