### PR TITLE
migrated bfabricpy to .yml config files

### DIFF
--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -26,7 +26,7 @@ import json
 import sys
 from pprint import pprint
 
-from bfabric.bfabric_config import BfabricAuth, BfabricConfig, parse_bfabricrc_py
+from bfabric.bfabric_config import BfabricAuth, BfabricConfig, read_bfabricrc_py
 from suds.client import Client
 from suds.wsdl import Service
 
@@ -84,32 +84,45 @@ class Bfabric(object):
     def warning(self, msg):
         sys.stderr.write("\033[93m{}\033[0m\n".format(msg))
 
-    def __init__(self, login=None, password=None, webbase=None, externaljobid=None, bfabricrc=None, verbose=False):
+    def __init__(self, login: str = None, password: str = None, webbase: str = None, externaljobid=None,
+                 config_path: str = None, config_env: str = None, optional_auth: bool = False, verbose: bool = False):
         self.verbose = verbose
 
         self.cl = {}
         self.verbose = False
         self.query_counter = 0
 
-        bfabricrc = bfabricrc or os.path.normpath(os.path.expanduser("~/.bfabricrc.py"))
-        if not os.path.isfile(bfabricrc):
-            self.warning("could not find '.bfabricrc.py' file in home directory.")
-            self.config = BfabricConfig(base_url=webbase)
-            self.auth = BfabricAuth(login=login, password=password)
-        else:
-            with open(bfabricrc, "r", encoding="utf-8") as file:
-                config, auth = parse_bfabricrc_py(file)
-                self.config = config.with_overrides(base_url=webbase)
-                self.auth = auth if login is None and password is None else BfabricAuth(login=login, password=password)
+        # Get default path config file path
+        config_path = config_path or os.path.normpath(os.path.expanduser("~/.bfabricpy.yml"))
 
-        if not self.auth.login or not self.auth.password:
-            raise ValueError("login or password missing")
+        # Use the provided config data from arguments instead of the file
+        if not os.path.isfile(config_path):
+            self.warning("could not find '.bfabricpy.yml' file in home directory.")
+            self.config = BfabricConfig(webbase=webbase)
+            self.auth = BfabricAuth(login=login, password=password)
+
+        # Load config from file, override some of the fields with the provided ones
+        else:
+            config, auth = read_bfabricrc_py(config_path, config_env=config_env, optional_auth=optional_auth)
+            self.config = config.with_overrides(webbase=webbase)
+            if (login is not None) and (password is not None):
+                self.auth = BfabricAuth(login=login, password=password)
+            elif (login is None) and (password is None):
+                self.auth = auth
+            else:
+                raise IOError("Must provide both username and password, or neither.")
+
+        if not self.config.webbase:
+            raise ValueError("webbase missing")
+        if not optional_auth:
+            if not self.auth or not self.auth.login or not self.auth.password:
+                raise ValueError("Authentification not initialized but required")
+
+            msg = f"\033[93m--- webbase {self.config.webbase}; login; {self.auth.login} ---\033[0m\n"
+            sys.stderr.write(msg)
 
         if self.verbose:
             pprint(self.config)
-
-        msg = f"\033[93m--- webbase {self.config.base_url}; login; {self.auth.login} ---\033[0m\n"
-        sys.stderr.write(msg)
 
     def read_object(self, endpoint, obj, page=1, plain=False, idonly=False):
         """
@@ -189,7 +202,7 @@ class Bfabric(object):
     def _get_service(self, endpoint: str) -> Service:
         """Returns a `suds.client.Service` object for the given endpoint name."""
         if endpoint not in self.cl:
-            self.cl[endpoint] = Client(f"{self.config.base_url}/{endpoint}?wsdl", cache=None)
+            self.cl[endpoint] = Client(f"{self.config.webbase}/{endpoint}?wsdl", cache=None)
         return self.cl[endpoint].service
 
     def _perform_request(
@@ -835,12 +848,12 @@ exit 0
                 sample_id = self.get_sampleid(int(resource_iterator._id))
 
                 _resource_sample = {'resource_id': int(resource_iterator._id),
-                                        'resource_url': "{0}/userlab/show-resource.html?id={1}".format(self.config.base_url,resource_iterator._id)}
+                                        'resource_url': "{0}/userlab/show-resource.html?id={1}".format(self.config.webbase, resource_iterator._id)}
 
 
                 if not sample_id is None:
                     _resource_sample['sample_id'] = int(sample_id)
-                    _resource_sample['sample_url'] = "{0}/userlab/show-sample.html?id={1}".format(self.config.base_url, sample_id)
+                    _resource_sample['sample_url'] = "{0}/userlab/show-sample.html?id={1}".format(self.config.webbase, sample_id)
 
                 resource_ids[_application_name].append(_resource_sample)
             except:
@@ -935,7 +948,7 @@ exit 0
                     },
                 'workunit_id': int(workunit._id),
                 'workunit_createdby': str(workunit.createdby),
-                'workunit_url': "{0}/userlab/show-workunit.html?workunitId={1}".format(self.config.base_url, workunit._id),
+                'workunit_url': "{0}/userlab/show-workunit.html?workunitId={1}".format(self.config.webbase, workunit._id),
                 'external_job_id': int(yaml_workunit_externaljob._id),
                 'order_id': order_id,
                 'project_id': project_id,

--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -107,6 +107,11 @@ class Bfabric(object):
         # Get default path config file path
         config_path = config_path or os.path.normpath(os.path.expanduser("~/.bfabricpy.yml"))
 
+        # TODO: Convert to an exception when this branch becomes main
+        config_path_old = config_path or os.path.normpath(os.path.expanduser("~/.bfabricrc.py"))
+        if os.path.isfile(config_path):
+            self.warning("WARNING! The old .bfabricrc.py was found in the home directory. Delete and make sure to use the new .bfabricpy.yml")
+
         # Use the provided config data from arguments instead of the file
         if not os.path.isfile(config_path):
             self.warning("could not find '.bfabricpy.yml' file in home directory.")

--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -84,12 +84,12 @@ class Bfabric(object):
     def warning(self, msg):
         sys.stderr.write("\033[93m{}\033[0m\n".format(msg))
 
-    def __init__(self, login: str = None, password: str = None, webbase: str = None, externaljobid=None,
+    def __init__(self, login: str = None, password: str = None, base_url: str = None, externaljobid=None,
                  config_path: str = None, config_env: str = None, optional_auth: bool = False, verbose: bool = False):
         """
         :param login:           Login string for overriding config file
         :param password:        Password for overriding config file
-        :param webbase:         Webbase for overriding config file
+        :param base_url:        Base url of the BFabric server for overriding config file
         :param externaljobid:   ?
         :param config_path:     Path to the config file, in case it is different from default
         :param config_env:      Which config environment to use. Can also specify via environment variable or use
@@ -110,13 +110,13 @@ class Bfabric(object):
         # Use the provided config data from arguments instead of the file
         if not os.path.isfile(config_path):
             self.warning("could not find '.bfabricpy.yml' file in home directory.")
-            self.config = BfabricConfig(webbase=webbase)
+            self.config = BfabricConfig(base_url=base_url)
             self.auth = BfabricAuth(login=login, password=password)
 
         # Load config from file, override some of the fields with the provided ones
         else:
             config, auth = read_bfabricrc_py(config_path, config_env=config_env, optional_auth=optional_auth)
-            self.config = config.with_overrides(webbase=webbase)
+            self.config = config.with_overrides(base_url=base_url)
             if (login is not None) and (password is not None):
                 self.auth = BfabricAuth(login=login, password=password)
             elif (login is None) and (password is None):
@@ -124,13 +124,13 @@ class Bfabric(object):
             else:
                 raise IOError("Must provide both username and password, or neither.")
 
-        if not self.config.webbase:
-            raise ValueError("webbase missing")
+        if not self.config.base_url:
+            raise ValueError("base server url missing")
         if not optional_auth:
             if not self.auth or not self.auth.login or not self.auth.password:
                 raise ValueError("Authentification not initialized but required")
 
-            msg = f"\033[93m--- webbase {self.config.webbase}; login; {self.auth.login} ---\033[0m\n"
+            msg = f"\033[93m--- base_url {self.config.base_url}; login; {self.auth.login} ---\033[0m\n"
             sys.stderr.write(msg)
 
         if self.verbose:
@@ -214,7 +214,7 @@ class Bfabric(object):
     def _get_service(self, endpoint: str) -> Service:
         """Returns a `suds.client.Service` object for the given endpoint name."""
         if endpoint not in self.cl:
-            self.cl[endpoint] = Client(f"{self.config.webbase}/{endpoint}?wsdl", cache=None)
+            self.cl[endpoint] = Client(f"{self.config.base_url}/{endpoint}?wsdl", cache=None)
         return self.cl[endpoint].service
 
     def _perform_request(
@@ -860,12 +860,12 @@ exit 0
                 sample_id = self.get_sampleid(int(resource_iterator._id))
 
                 _resource_sample = {'resource_id': int(resource_iterator._id),
-                                        'resource_url': "{0}/userlab/show-resource.html?id={1}".format(self.config.webbase, resource_iterator._id)}
+                                        'resource_url': "{0}/userlab/show-resource.html?id={1}".format(self.config.base_url, resource_iterator._id)}
 
 
                 if not sample_id is None:
                     _resource_sample['sample_id'] = int(sample_id)
-                    _resource_sample['sample_url'] = "{0}/userlab/show-sample.html?id={1}".format(self.config.webbase, sample_id)
+                    _resource_sample['sample_url'] = "{0}/userlab/show-sample.html?id={1}".format(self.config.base_url, sample_id)
 
                 resource_ids[_application_name].append(_resource_sample)
             except:
@@ -960,7 +960,7 @@ exit 0
                     },
                 'workunit_id': int(workunit._id),
                 'workunit_createdby': str(workunit.createdby),
-                'workunit_url': "{0}/userlab/show-workunit.html?workunitId={1}".format(self.config.webbase, workunit._id),
+                'workunit_url': "{0}/userlab/show-workunit.html?workunitId={1}".format(self.config.base_url, workunit._id),
                 'external_job_id': int(yaml_workunit_externaljob._id),
                 'order_id': order_id,
                 'project_id': project_id,

--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -26,7 +26,7 @@ import json
 import sys
 from pprint import pprint
 
-from bfabric.bfabric_config import BfabricAuth, BfabricConfig, read_bfabricrc_py
+from bfabric.bfabric_config import BfabricAuth, BfabricConfig, read_config
 from suds.client import Client
 from suds.wsdl import Service
 
@@ -115,7 +115,7 @@ class Bfabric(object):
 
         # Load config from file, override some of the fields with the provided ones
         else:
-            config, auth = read_bfabricrc_py(config_path, config_env=config_env, optional_auth=optional_auth)
+            config, auth = read_config(config_path, config_env=config_env, optional_auth=optional_auth)
             self.config = config.with_overrides(base_url=base_url)
             if (login is not None) and (password is not None):
                 self.auth = BfabricAuth(login=login, password=password)

--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -86,6 +86,18 @@ class Bfabric(object):
 
     def __init__(self, login: str = None, password: str = None, webbase: str = None, externaljobid=None,
                  config_path: str = None, config_env: str = None, optional_auth: bool = False, verbose: bool = False):
+        """
+        :param login:           Login string for overriding config file
+        :param password:        Password for overriding config file
+        :param webbase:         Webbase for overriding config file
+        :param externaljobid:   ?
+        :param config_path:     Path to the config file, in case it is different from default
+        :param config_env:      Which config environment to use. Can also specify via environment variable or use
+           default in the config file (at your own risk)
+        :param optional_auth:   Whether authentification is optional. If yes, missing authentification will be ignored,
+           otherwise an exception will be raised
+        :param verbose:         Verbosity (TODO: resolve potential redundancy with logger)
+        """
         self.verbose = verbose
 
         self.cl = {}

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -82,10 +82,6 @@ def _read_config_env_as_dict(config_path: str, config_env: str = None) -> Tuple[
     # Read the config file
     config_dict = yaml.safe_load(Path(config_path).read_text())
 
-    # config = ConfigParser()
-    # config.read(config_path)
-    # config_dict = {s: dict(config.items(s)) for s in config.sections()}
-
     if "GENERAL" not in config_dict:
         raise IOError("Config file must have a general section")
     if 'default_config' not in config_dict['GENERAL']:

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -54,7 +54,7 @@ class BfabricConfig:
 
 
 '''
-NOTE: BFabricPy expects a bfabricpy.yml of the format, as seen in bfabricPy/tests/unit/example_config.yml
+NOTE: BFabricPy expects a .bfabricpy.yml of the format, as seen in bfabricPy/tests/unit/example_config.yml
 * The general field always has to be present
 * There may be any number of environments, and they may have arbitrary names. Here, they are called PRODUCTION and TEST
 * Must specify correct login, password and webbase for each environment.
@@ -62,7 +62,7 @@ NOTE: BFabricPy expects a bfabricpy.yml of the format, as seen in bfabricPy/test
 * The default environment will be selected as follows:
     - First, parser will check if the optional argument `config_env` is provided directly to the parser function
     - If not, secondly, the parser will check if the environment variable `BFABRICPY_CONFIG_ENV` is declared
-    - If not, finally, the parser will select the default_config specified in [GENERAL] of the .bfabricpy.ini file 
+    - If not, finally, the parser will select the default_config specified in [GENERAL] of the .bfabricpy.yml file 
 '''
 
 

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -98,7 +98,7 @@ def _read_config_env_as_dict(config_path: str, config_env: str = None) -> Tuple[
         else:
             logger.info(f"found BFABRICPY_CONFIG_ENV = {config_env}")
     else:
-        logger.log(20, "config environment specified explicitly as " + config_env)
+        logger.info(f"config environment specified explicitly as {config_env}")
 
     if config_env not in config_dict:
         raise IOError("The requested config environment", config_env, "is not present in the config file")

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -52,19 +52,6 @@ class BfabricConfig:
         )
 
 
-'''
-NOTE: BFabricPy expects a .bfabricpy.yml of the format, as seen in bfabricPy/tests/unit/example_config.yml
-* The general field always has to be present
-* There may be any number of environments, and they may have arbitrary names. Here, they are called PRODUCTION and TEST
-* Must specify correct login, password and base_url for each environment.
-* application and job_notification_emails fields are optional
-* The default environment will be selected as follows:
-    - First, parser will check if the optional argument `config_env` is provided directly to the parser function
-    - If not, secondly, the parser will check if the environment variable `BFABRICPY_CONFIG_ENV` is declared
-    - If not, finally, the parser will select the default_config specified in [GENERAL] of the .bfabricpy.yml file 
-'''
-
-
 def _read_config_env_as_dict(config_path: str, config_env: str = None) -> Tuple[str, dict]:
     """
     Reads and partially parses a bfabricpy.yml file
@@ -137,8 +124,8 @@ def _parse_dict(d: dict, mandatory_keys: list, optional_keys: list = None, error
     # Ignore all other fields
     return d_rez
 
-def read_bfabricrc_py(config_path: str, config_env: str = None,
-                      optional_auth: bool = False) -> Tuple[BfabricConfig, Optional[BfabricAuth]]:
+def read_config(config_path: str, config_env: str = None,
+                optional_auth: bool = False) -> Tuple[BfabricConfig, Optional[BfabricAuth]]:
     """
     Reads bfabricpy.yml file, parses it, extracting authentication and configuration data
     :param config_path:   Path to the configuration file. It is assumed the file exists
@@ -147,6 +134,17 @@ def read_bfabricrc_py(config_path: str, config_env: str = None,
         If not, both login and password must be present in the config file, otherwise an exception is thrown
         If yes, missing login and password would result in authentication class being None, but no exception
     :return: Configuration and Authentication class instances
+
+    
+    NOTE: BFabricPy expects a .bfabricpy.yml of the format, as seen in bfabricPy/tests/unit/example_config.yml
+    * The general field always has to be present
+    * There may be any number of environments, and they may have arbitrary names. Here, they are called PRODUCTION and TEST
+    * Must specify correct login, password and base_url for each environment.
+    * application and job_notification_emails fields are optional
+    * The default environment will be selected as follows:
+        - First, parser will check if the optional argument `config_env` is provided directly to the parser function
+        - If not, secondly, the parser will check if the environment variable `BFABRICPY_CONFIG_ENV` is declared
+        - If not, finally, the parser will select the default_config specified in [GENERAL] of the .bfabricpy.yml file
     """
 
 

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -6,6 +6,9 @@ import logging
 import os
 from typing import Optional, Dict, Tuple
 import dataclasses
+# from configparser import ConfigParser
+import yaml
+from pathlib import Path
 
 
 @dataclasses.dataclass(frozen=True)
@@ -27,73 +30,146 @@ class BfabricConfig:
     """Holds the configuration for the B-Fabric client for connecting to particular instance of B-Fabric.
 
     Attributes:
-        base_url (optional): The API base url
+        webbase (optional): The API base url
         application_ids (optional): Map of application names to ids.
         job_notification_emails (optional): Space-separated list of email addresses to notify when a job finishes.
     """
 
-    base_url: str = "https://fgcz-bfabric.uzh.ch/bfabric"
+    webbase: str = "https://fgcz-bfabric.uzh.ch/bfabric"
     application_ids: Dict[str, int] = dataclasses.field(default_factory=dict)
     job_notification_emails: str = ""
 
     def with_overrides(
         self,
-        base_url: Optional[str] = None,
+        webbase: Optional[str] = None,
         application_ids: Optional[Dict[str, int]] = None,
     ) -> BfabricConfig:
         """Returns a copy of the configuration with new values applied, if they are not None."""
         return BfabricConfig(
-            base_url=base_url if base_url is not None else self.base_url,
+            webbase=webbase if webbase is not None else self.webbase,
             application_ids=application_ids
             if application_ids is not None
             else self.application_ids,
         )
 
 
-def parse_bfabricrc_py(file: io.FileIO) -> Tuple[BfabricConfig, Optional[BfabricAuth]]:
+'''
+NOTE: BFabricPy expects a bfabricpy.yml of the format, as seen in bfabricPy/tests/unit/example_config.yml
+* The general field always has to be present
+* There may be any number of environments, and they may have arbitrary names. Here, they are called PRODUCTION and TEST
+* Must specify correct login, password and webbase for each environment.
+* application and job_notification_emails fields are optional
+* The default environment will be selected as follows:
+    - First, parser will check if the optional argument `config_env` is provided directly to the parser function
+    - If not, secondly, the parser will check if the environment variable `BFABRICPY_CONFIG_ENV` is declared
+    - If not, finally, the parser will select the default_config specified in [GENERAL] of the .bfabricpy.ini file 
+'''
+
+
+def _read_config_env_as_dict(config_path: str, config_env: str = None) -> Tuple[str, dict]:
+    """
+    Reads and partially parses a bfabricpy.yml file
+    :param config_path:  Path to the configuration file. It is assumed that it exists
+    :param config_env:   Specific environment to parse. If not provided, it is deduced from an environment variable
+       or the config file itself.
+    :return: Returns a target environment name, and the corresponding data from bfabricpy.yml file as a dictionary
+    """
+
     """Parses a .bfabricrc.py file and returns a tuple of BfabricConfig and BfabricAuth objects."""
-    values = {}
-    file_path = os.path.realpath(file.name)
     logger = logging.getLogger(__name__)
-    logger.info(f"Reading configuration from: {file_path}")
+    logger.info(f"Reading configuration from: {config_path}")
 
-    for line in file:
-        if line.startswith("#"):
-            continue
+    # Read the config file
+    config_dict = yaml.safe_load(Path(config_path).read_text())
 
-        key, _, value = [part.strip() for part in line.partition("=")]
-        if key not in [
-            "_PASSWD",
-            "_LOGIN",
-            "_WEBBASE",
-            "_APPLICATION",
-            "_JOB_NOTIFICATION_EMAILS",
-        ]:
-            continue
+    # config = ConfigParser()
+    # config.read(config_path)
+    # config_dict = {s: dict(config.items(s)) for s in config.sections()}
 
-        # In case of multiple definitions, the first rule counts!
-        if key not in values:
-            if key in ["_APPLICATION"]:
-                try:
-                    values[key] = json.loads(value)
-                except json.JSONDecodeError as e:
-                    raise ValueError(
-                        f"While reading {file_path}. '{key}' is not a valid JSON string."
-                    ) from e
-            else:
-                # to make it downward compatible; so we replace quotes in login and password
-                values[key] = value.replace('"', "").replace("'", "")
+    if "GENERAL" not in config_dict:
+        raise IOError("Config file must have a general section")
+    if 'default_config' not in config_dict['GENERAL']:
+        raise IOError("Config file must provide a default environment")
+    config_env_default = config_dict['GENERAL']['default_config']
+
+    # Determine which environment we will use
+    # By default, use the one provided by config_env
+    if config_env is None:
+        # Try to find a relevant
+        config_env = os.getenv("BFABRICPY_CONFIG_ENV")
+        if config_env is None:
+            logger.log(20, "BFABRICPY_CONFIG_ENV not found, using default environment " + config_env_default)
+            config_env = config_env_default
         else:
-            logger.warning(f"While reading {file_path}. '{key}' is already set.")
-
-    args = dict(
-        base_url=values.get("_WEBBASE"),
-        application_ids=values.get("_APPLICATION"),
-        job_notification_emails=values.get("_JOB_NOTIFICATION_EMAILS"),
-    )
-    config = BfabricConfig(**{k: v for k, v in args.items() if v is not None})
-    if "_LOGIN" in values and "_PASSWD" in values:
-        auth = BfabricAuth(login=values["_LOGIN"], password=values["_PASSWD"])
+            logger.log(20, "found BFABRICPY_CONFIG_ENV = " + config_env)
     else:
+        logger.log(20, "config environment specified explicitly as " + config_env)
+
+    if config_env not in config_dict:
+        raise IOError("The requested config environment", config_env, "is not present in the config file")
+
+    return config_env, config_dict[config_env]
+
+def _have_all_keys(d: dict, l: list) -> bool:
+    """True if all elements in list l are present as keys in dict d, otherwise false"""
+    return all([k in d for k in l])
+
+def _parse_dict(d: dict, mandatory_keys: list, optional_keys: list = None, error_prefix: str = None):
+    """
+    Returns a copy of an existing dictionary, only keeping mandatory and optional keys
+    If a mandatory key is not found, an exception is raised
+    :param d:                 Starting dictionary
+    :param mandatory_keys:    A list of mandatory keys
+    :param optional_keys:     A list of optional keys
+    :param error_prefix:      A string to print if a mandatory key is not found
+    :return:                  Copy of a starting dictionary, only containing mandatory and optional keys
+    """
+    d_rez = {}
+
+    # Get all mandatory fields, and complain if not found
+    for k in mandatory_keys:
+        if k in d:
+            d_rez[k] = d[k]
+        else:
+            raise ValueError(error_prefix + k)
+
+    # Get all optional fields
+    if optional_keys is not None:
+        for k in optional_keys:
+            if k in d:
+                d_rez[k] = d[k]
+
+    # Ignore all other fields
+    return d_rez
+
+def read_bfabricrc_py(config_path: str, config_env: str = None,
+                      optional_auth: bool = False) -> Tuple[BfabricConfig, Optional[BfabricAuth]]:
+    """
+    Reads bfabricpy.yml file, parses it, extracting authentication and configuration data
+    :param config_path:   Path to the configuration file. It is assumed the file exists
+    :param config_env:    Configuration environment to use. If not given, it is deduced.
+    :param optional_auth: Whether authentication is optional.
+        If not, both login and password must be present in the config file, otherwise an exception is thrown
+        If yes, missing login and password would result in authentication class being None, but no exception
+    :return: Configuration and Authentication class instances
+    """
+
+
+    config_env_final, config_dict = _read_config_env_as_dict(config_path, config_env=config_env)
+
+    error_prefix = "Config environment " + config_env_final + " does not have a compulsory field: "
+
+    # Parse authentification
+    if optional_auth and not _have_all_keys(config_dict, ['login', 'password']):
+        # Allow returning None auth if enabled
         auth = None
+    else:
+        auth_dict = _parse_dict(config_dict, ['login', 'password'], error_prefix=error_prefix)
+        auth = BfabricAuth(**auth_dict)
+
+    # Parse config
+    config_dict = _parse_dict(config_dict, ['webbase'], optional_keys=['application_ids', 'job_notification_emails'],
+                              error_prefix=error_prefix)
+    config = BfabricConfig(**config_dict)
+
     return config, auth

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -6,7 +6,6 @@ import logging
 import os
 from typing import Optional, Dict, Tuple
 import dataclasses
-# from configparser import ConfigParser
 import yaml
 from pathlib import Path
 

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -96,7 +96,7 @@ def _read_config_env_as_dict(config_path: str, config_env: str = None) -> Tuple[
             logger.info(f"BFABRICPY_CONFIG_ENV not found, using default environment {config_env_default}")
             config_env = config_env_default
         else:
-            logger.log(20, "found BFABRICPY_CONFIG_ENV = " + config_env)
+            logger.info(f"found BFABRICPY_CONFIG_ENV = {config_env}")
     else:
         logger.log(20, "config environment specified explicitly as " + config_env)
 

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -94,7 +94,7 @@ def _have_all_keys(d: dict, l: list) -> bool:
     """True if all elements in list l are present as keys in dict d, otherwise false"""
     return all([k in d for k in l])
 
-def _parse_dict(d: dict, mandatory_keys: list, optional_keys: list = None, error_prefix: str = " "):
+def _parse_dict(d: dict, mandatory_keys: list, optional_keys: list = None, error_prefix: str = " ") -> dict:
     """
     Returns a copy of an existing dictionary, only keeping mandatory and optional keys
     If a mandatory key is not found, an exception is raised
@@ -107,8 +107,8 @@ def _parse_dict(d: dict, mandatory_keys: list, optional_keys: list = None, error
     missing_keys = set(mandatory_keys) - set(d)
     if missing_keys:
         raise ValueError(f"{error_prefix}{missing_keys}")
-    result_keys = set(mandatory_keys) + set(optional_keys or [])
-    d_rez = {d[k] for k in result_keys}
+    result_keys = set(mandatory_keys) | set(optional_keys or [])
+    d_rez = {k: d[k] for k in result_keys if k in d}
 
     # Ignore all other fields
     return d_rez

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -30,23 +30,23 @@ class BfabricConfig:
     """Holds the configuration for the B-Fabric client for connecting to particular instance of B-Fabric.
 
     Attributes:
-        webbase (optional): The API base url
+        base_url (optional): The API base url
         application_ids (optional): Map of application names to ids.
         job_notification_emails (optional): Space-separated list of email addresses to notify when a job finishes.
     """
 
-    webbase: str = "https://fgcz-bfabric.uzh.ch/bfabric"
+    base_url: str = "https://fgcz-bfabric.uzh.ch/bfabric"
     application_ids: Dict[str, int] = dataclasses.field(default_factory=dict)
     job_notification_emails: str = ""
 
     def with_overrides(
         self,
-        webbase: Optional[str] = None,
+        base_url: Optional[str] = None,
         application_ids: Optional[Dict[str, int]] = None,
     ) -> BfabricConfig:
         """Returns a copy of the configuration with new values applied, if they are not None."""
         return BfabricConfig(
-            webbase=webbase if webbase is not None else self.webbase,
+            base_url=base_url if base_url is not None else self.base_url,
             application_ids=application_ids
             if application_ids is not None
             else self.application_ids,
@@ -57,7 +57,7 @@ class BfabricConfig:
 NOTE: BFabricPy expects a .bfabricpy.yml of the format, as seen in bfabricPy/tests/unit/example_config.yml
 * The general field always has to be present
 * There may be any number of environments, and they may have arbitrary names. Here, they are called PRODUCTION and TEST
-* Must specify correct login, password and webbase for each environment.
+* Must specify correct login, password and base_url for each environment.
 * application and job_notification_emails fields are optional
 * The default environment will be selected as follows:
     - First, parser will check if the optional argument `config_env` is provided directly to the parser function
@@ -168,7 +168,7 @@ def read_bfabricrc_py(config_path: str, config_env: str = None,
         auth = BfabricAuth(**auth_dict)
 
     # Parse config
-    config_dict = _parse_dict(config_dict, ['webbase'], optional_keys=['application_ids', 'job_notification_emails'],
+    config_dict = _parse_dict(config_dict, ['base_url'], optional_keys=['application_ids', 'job_notification_emails'],
                               error_prefix=error_prefix)
     config = BfabricConfig(**config_dict)
 

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -93,7 +93,7 @@ def _read_config_env_as_dict(config_path: str, config_env: str = None) -> Tuple[
         # Try to find a relevant
         config_env = os.getenv("BFABRICPY_CONFIG_ENV")
         if config_env is None:
-            logger.log(20, "BFABRICPY_CONFIG_ENV not found, using default environment " + config_env_default)
+            logger.info(f"BFABRICPY_CONFIG_ENV not found, using default environment {config_env_default}")
             config_env = config_env_default
         else:
             logger.log(20, "found BFABRICPY_CONFIG_ENV = " + config_env)

--- a/bfabric/scripts/bfabric_flask.py
+++ b/bfabric/scripts/bfabric_flask.py
@@ -430,9 +430,9 @@ def query():
 
     print ("PASSWORD CLEARTEXT", content['webservicepassword'])
     
-    bf = bfabric.Bfabric(login=content['login'], 
-      password=content['webservicepassword'], 
-      webbase='http://fgcz-bfabric.uzh.ch/bfabric')
+    bf = bfabric.Bfabric(login=content['login'],
+                         password=content['webservicepassword'],
+                         base_url='http://fgcz-bfabric.uzh.ch/bfabric')
 
     for i in content.keys():
       print ("{}\t{}".format(i, content[i]))

--- a/bfabric/tests/test_bfabric_functional.py
+++ b/bfabric/tests/test_bfabric_functional.py
@@ -41,7 +41,7 @@ class BfabricFunctionalTestCase(unittest.TestCase):
         self.assertEqual(B.auth.login, 'pfeeder', msg)
 
         msg = "This test case requires a bfabric test system!"
-        self.assertIn("bfabric-test", B.config.webbase, msg)
+        self.assertIn("bfabric-test", B.config.base_url, msg)
         # TODO
         # create input resource
 

--- a/bfabric/tests/test_bfabric_functional.py
+++ b/bfabric/tests/test_bfabric_functional.py
@@ -41,7 +41,7 @@ class BfabricFunctionalTestCase(unittest.TestCase):
         self.assertEqual(B.auth.login, 'pfeeder', msg)
 
         msg = "This test case requires a bfabric test system!"
-        self.assertIn("bfabric-test", B.config.base_url, msg)
+        self.assertIn("bfabric-test", B.config.webbase, msg)
         # TODO
         # create input resource
 

--- a/bfabric/tests/unit/example_config.yml
+++ b/bfabric/tests/unit/example_config.yml
@@ -1,0 +1,20 @@
+GENERAL:
+  default_config: PRODUCTION
+
+PRODUCTION:
+  login: my_epic_production_login
+  password: my_secret_production_password
+  webbase: https://mega-production-server.uzh.ch/myprod
+
+TEST:
+  login: my_epic_test_login
+  password: my_secret_test_password
+  webbase: https://mega-test-server.uzh.ch/mytest
+  application_ids:
+    Proteomics/CAT_123: 7
+    Proteomics/DOG_552: 6
+    Proteomics/DUCK_666: 12
+  job_notification_emails: john.snow@fgcz.uzh.ch billy.the.kid@fgcz.ethz.ch
+
+STANDBY:
+  webbase: https://standby-server.uzh.ch/mystandby

--- a/bfabric/tests/unit/example_config.yml
+++ b/bfabric/tests/unit/example_config.yml
@@ -4,12 +4,12 @@ GENERAL:
 PRODUCTION:
   login: my_epic_production_login
   password: my_secret_production_password
-  webbase: https://mega-production-server.uzh.ch/myprod
+  base_url: https://mega-production-server.uzh.ch/myprod
 
 TEST:
   login: my_epic_test_login
   password: my_secret_test_password
-  webbase: https://mega-test-server.uzh.ch/mytest
+  base_url: https://mega-test-server.uzh.ch/mytest
   application_ids:
     Proteomics/CAT_123: 7
     Proteomics/DOG_552: 6
@@ -17,4 +17,4 @@ TEST:
   job_notification_emails: john.snow@fgcz.uzh.ch billy.the.kid@fgcz.ethz.ch
 
 STANDBY:
-  webbase: https://standby-server.uzh.ch/mystandby
+  base_url: https://standby-server.uzh.ch/mystandby

--- a/bfabric/tests/unit/test_bfabric_config.py
+++ b/bfabric/tests/unit/test_bfabric_config.py
@@ -2,7 +2,7 @@ import os
 import io
 import unittest
 
-from bfabric.bfabric_config import BfabricConfig, BfabricAuth, read_bfabricrc_py
+from bfabric.bfabric_config import BfabricConfig, BfabricAuth, read_config
 
 
 class TestBfabricAuth(unittest.TestCase):
@@ -47,7 +47,7 @@ class TestBfabricConfig(unittest.TestCase):
         # Ensure environment variable is not available, and the default is environment is loaded
         os.environ.pop('BFABRICPY_CONFIG_ENV', None)
 
-        config, auth = read_bfabricrc_py('example_config.yml')  # Should deduce
+        config, auth = read_config('example_config.yml')  # Should deduce
         self.assertEqual("my_epic_production_login", auth.login)
         self.assertEqual("my_secret_production_password", auth.password)
         self.assertEqual("https://mega-production-server.uzh.ch/myprod", config.base_url)
@@ -58,7 +58,7 @@ class TestBfabricConfig(unittest.TestCase):
         # Explicitly set the environment variable for this process
         os.environ["BFABRICPY_CONFIG_ENV"] = "TEST"
 
-        config, auth = read_bfabricrc_py('example_config.yml')  # Should deduce
+        config, auth = read_config('example_config.yml')  # Should deduce
         self.assertEqual("my_epic_test_login", auth.login)
         self.assertEqual("my_secret_test_password", auth.password)
         self.assertEqual("https://mega-test-server.uzh.ch/mytest", config.base_url)
@@ -67,7 +67,7 @@ class TestBfabricConfig(unittest.TestCase):
     # TODO: Test that logging is consistent with default config
     def test_read_yml_bypath_allfields(self):
         with self.assertLogs(level="INFO") as log_context:
-            config, auth = read_bfabricrc_py('example_config.yml', config_env='TEST')
+            config, auth = read_config('example_config.yml', config_env='TEST')
 
         # # Testing log
         # self.assertEqual(
@@ -96,7 +96,7 @@ class TestBfabricConfig(unittest.TestCase):
     # Testing that we can load base_url without authentication if correctly requested
     def test_read_yml_when_empty_optional(self):
         with self.assertLogs(level="INFO"):
-            config, auth = read_bfabricrc_py('example_config.yml', config_env='STANDBY', optional_auth=True)
+            config, auth = read_config('example_config.yml', config_env='STANDBY', optional_auth=True)
 
         self.assertIsNone(auth)
         self.assertEqual("https://standby-server.uzh.ch/mystandby", config.base_url)
@@ -106,7 +106,7 @@ class TestBfabricConfig(unittest.TestCase):
     # Test that missing authentication will raise an error if required
     def test_read_yml_when_empty_mandatory(self):
         with self.assertRaises(ValueError):
-            read_bfabricrc_py('example_config.yml', config_env='STANDBY', optional_auth=False)
+            read_config('example_config.yml', config_env='STANDBY', optional_auth=False)
 
     def test_repr(self):
         rep = repr(self.config)

--- a/bfabric/tests/unit/test_bfabric_config.py
+++ b/bfabric/tests/unit/test_bfabric_config.py
@@ -20,25 +20,25 @@ class TestBfabricAuth(unittest.TestCase):
 class TestBfabricConfig(unittest.TestCase):
     def setUp(self):
         self.config = BfabricConfig(
-            webbase="url",
+            base_url="url",
             application_ids={"app": 1},
         )
 
     def test_with_overrides(self):
         new_config = self.config.with_overrides(
-            webbase="new_url",
+            base_url="new_url",
             application_ids={"new": 2},
         )
-        self.assertEqual("new_url", new_config.webbase)
+        self.assertEqual("new_url", new_config.base_url)
         self.assertEqual({"new": 2}, new_config.application_ids)
-        self.assertEqual("url", self.config.webbase)
+        self.assertEqual("url", self.config.base_url)
         self.assertEqual({"app": 1}, self.config.application_ids)
 
     def test_with_replaced_when_none(self):
-        new_config = self.config.with_overrides(webbase=None, application_ids=None)
-        self.assertEqual("url", new_config.webbase)
+        new_config = self.config.with_overrides(base_url=None, application_ids=None)
+        self.assertEqual("url", new_config.base_url)
         self.assertEqual({"app": 1}, new_config.application_ids)
-        self.assertEqual("url", self.config.webbase)
+        self.assertEqual("url", self.config.base_url)
         self.assertEqual({"app": 1}, self.config.application_ids)
 
     # Testing default initialization
@@ -50,7 +50,7 @@ class TestBfabricConfig(unittest.TestCase):
         config, auth = read_bfabricrc_py('example_config.yml')  # Should deduce
         self.assertEqual("my_epic_production_login", auth.login)
         self.assertEqual("my_secret_production_password", auth.password)
-        self.assertEqual("https://mega-production-server.uzh.ch/myprod", config.webbase)
+        self.assertEqual("https://mega-production-server.uzh.ch/myprod", config.base_url)
 
     # Testing environment variable initialization
     # TODO: Test that logging is consistent with default config
@@ -61,7 +61,7 @@ class TestBfabricConfig(unittest.TestCase):
         config, auth = read_bfabricrc_py('example_config.yml')  # Should deduce
         self.assertEqual("my_epic_test_login", auth.login)
         self.assertEqual("my_secret_test_password", auth.password)
-        self.assertEqual("https://mega-test-server.uzh.ch/mytest", config.webbase)
+        self.assertEqual("https://mega-test-server.uzh.ch/mytest", config.base_url)
 
     # Testing explicit initialization, as well as extra fields (application_ids, job_notification_emails)
     # TODO: Test that logging is consistent with default config
@@ -80,7 +80,7 @@ class TestBfabricConfig(unittest.TestCase):
 
         self.assertEqual("my_epic_test_login", auth.login)
         self.assertEqual("my_secret_test_password", auth.password)
-        self.assertEqual("https://mega-test-server.uzh.ch/mytest", config.webbase)
+        self.assertEqual("https://mega-test-server.uzh.ch/mytest", config.base_url)
 
         applications_dict_ground_truth = {
             'Proteomics/CAT_123': 7,
@@ -93,13 +93,13 @@ class TestBfabricConfig(unittest.TestCase):
         self.assertEqual(applications_dict_ground_truth, config.application_ids)
         self.assertEqual(job_notification_emails_ground_truth, config.job_notification_emails)
 
-    # Testing that we can load webbase without authentication if correctly requested
+    # Testing that we can load base_url without authentication if correctly requested
     def test_read_yml_when_empty_optional(self):
         with self.assertLogs(level="INFO"):
             config, auth = read_bfabricrc_py('example_config.yml', config_env='STANDBY', optional_auth=True)
 
         self.assertIsNone(auth)
-        self.assertEqual("https://standby-server.uzh.ch/mystandby", config.webbase)
+        self.assertEqual("https://standby-server.uzh.ch/mystandby", config.base_url)
         self.assertEqual({}, config.application_ids)
         self.assertEqual("", config.job_notification_emails)
 
@@ -111,14 +111,14 @@ class TestBfabricConfig(unittest.TestCase):
     def test_repr(self):
         rep = repr(self.config)
         self.assertEqual(
-            "BfabricConfig(webbase='url', application_ids={'app': 1}, job_notification_emails='')",
+            "BfabricConfig(base_url='url', application_ids={'app': 1}, job_notification_emails='')",
             rep,
         )
 
     def test_str(self):
         rep = str(self.config)
         self.assertEqual(
-            "BfabricConfig(webbase='url', application_ids={'app': 1}, job_notification_emails='')",
+            "BfabricConfig(base_url='url', application_ids={'app': 1}, job_notification_emails='')",
             rep,
         )
 

--- a/bfabric/tests/unit/test_bfabric_config.py
+++ b/bfabric/tests/unit/test_bfabric_config.py
@@ -1,7 +1,8 @@
+import os
 import io
 import unittest
 
-from bfabric.bfabric_config import BfabricConfig, BfabricAuth, parse_bfabricrc_py
+from bfabric.bfabric_config import BfabricConfig, BfabricAuth, read_bfabricrc_py
 
 
 class TestBfabricAuth(unittest.TestCase):
@@ -19,76 +20,105 @@ class TestBfabricAuth(unittest.TestCase):
 class TestBfabricConfig(unittest.TestCase):
     def setUp(self):
         self.config = BfabricConfig(
-            base_url="url",
+            webbase="url",
             application_ids={"app": 1},
         )
 
     def test_with_overrides(self):
         new_config = self.config.with_overrides(
-            base_url="new_url",
+            webbase="new_url",
             application_ids={"new": 2},
         )
-        self.assertEqual("new_url", new_config.base_url)
+        self.assertEqual("new_url", new_config.webbase)
         self.assertEqual({"new": 2}, new_config.application_ids)
-        self.assertEqual("url", self.config.base_url)
+        self.assertEqual("url", self.config.webbase)
         self.assertEqual({"app": 1}, self.config.application_ids)
 
     def test_with_replaced_when_none(self):
-        new_config = self.config.with_overrides(base_url=None, application_ids=None)
-        self.assertEqual("url", new_config.base_url)
+        new_config = self.config.with_overrides(webbase=None, application_ids=None)
+        self.assertEqual("url", new_config.webbase)
         self.assertEqual({"app": 1}, new_config.application_ids)
-        self.assertEqual("url", self.config.base_url)
+        self.assertEqual("url", self.config.webbase)
         self.assertEqual({"app": 1}, self.config.application_ids)
 
-    def test_read_bfabricrc_py(self):
-        input_text = (
-            "# Some comment\n"
-            "_LOGIN = login\n"
-            "_PASSWD = 'user'\n"
-            "_UKNOWNKEY = 'value'\n"
-            "# Another comment\n"
-            """_WEBBASE = "url"\n"""
-            """_APPLICATION = {"app": 1}\n"""
-            """_JOB_NOTIFICATION_EMAILS = "email1 email2"\n"""
-        )
-        file = io.StringIO(input_text)
-        setattr(file, "name", "/file")
-        with self.assertLogs(level="INFO") as log_context:
-            config, auth = parse_bfabricrc_py(file)
-        self.assertEqual("login", auth.login)
-        self.assertEqual("user", auth.password)
-        self.assertEqual("url", config.base_url)
-        self.assertEqual({"app": 1}, config.application_ids)
-        self.assertEqual("email1 email2", config.job_notification_emails)
-        self.assertEqual(
-            [
-                "INFO:bfabric.bfabric_config:Reading configuration from: /file"
-            ],
-            log_context.output,
-        )
+    # Testing default initialization
+    # TODO: Test that logging is consistent with initialization
+    def test_read_yml_bypath_default(self):
+        # Ensure environment variable is not available, and the default is environment is loaded
+        os.environ.pop('BFABRICPY_CONFIG_ENV', None)
 
-    def test_read_bfabricrc_py_when_empty(self):
-        input_text = ""
-        file = io.StringIO(input_text)
-        setattr(file, "name", "/file")
+        config, auth = read_bfabricrc_py('example_config.yml')  # Should deduce
+        self.assertEqual("my_epic_production_login", auth.login)
+        self.assertEqual("my_secret_production_password", auth.password)
+        self.assertEqual("https://mega-production-server.uzh.ch/myprod", config.webbase)
+
+    # Testing environment variable initialization
+    # TODO: Test that logging is consistent with default config
+    def test_read_yml_bypath_environment_variable(self):
+        # Explicitly set the environment variable for this process
+        os.environ["BFABRICPY_CONFIG_ENV"] = "TEST"
+
+        config, auth = read_bfabricrc_py('example_config.yml')  # Should deduce
+        self.assertEqual("my_epic_test_login", auth.login)
+        self.assertEqual("my_secret_test_password", auth.password)
+        self.assertEqual("https://mega-test-server.uzh.ch/mytest", config.webbase)
+
+    # Testing explicit initialization, as well as extra fields (application_ids, job_notification_emails)
+    # TODO: Test that logging is consistent with default config
+    def test_read_yml_bypath_allfields(self):
+        with self.assertLogs(level="INFO") as log_context:
+            config, auth = read_bfabricrc_py('example_config.yml', config_env='TEST')
+
+        # # Testing log
+        # self.assertEqual(
+        #     [
+        #         "INFO:bfabric.bfabric_config:Reading configuration from: example_config.yml"
+        #         "INFO:bfabric.bfabric_config:config environment specified explicitly as TEST"
+        #     ],
+        #     log_context.output,
+        # )
+
+        self.assertEqual("my_epic_test_login", auth.login)
+        self.assertEqual("my_secret_test_password", auth.password)
+        self.assertEqual("https://mega-test-server.uzh.ch/mytest", config.webbase)
+
+        applications_dict_ground_truth = {
+            'Proteomics/CAT_123': 7,
+            'Proteomics/DOG_552': 6,
+            'Proteomics/DUCK_666': 12
+        }
+
+        job_notification_emails_ground_truth = "john.snow@fgcz.uzh.ch billy.the.kid@fgcz.ethz.ch"
+
+        self.assertEqual(applications_dict_ground_truth, config.application_ids)
+        self.assertEqual(job_notification_emails_ground_truth, config.job_notification_emails)
+
+    # Testing that we can load webbase without authentication if correctly requested
+    def test_read_yml_when_empty_optional(self):
         with self.assertLogs(level="INFO"):
-            config, auth = parse_bfabricrc_py(file)
+            config, auth = read_bfabricrc_py('example_config.yml', config_env='STANDBY', optional_auth=True)
+
         self.assertIsNone(auth)
-        self.assertEqual("https://fgcz-bfabric.uzh.ch/bfabric", config.base_url)
+        self.assertEqual("https://standby-server.uzh.ch/mystandby", config.webbase)
         self.assertEqual({}, config.application_ids)
         self.assertEqual("", config.job_notification_emails)
+
+    # Test that missing authentication will raise an error if required
+    def test_read_yml_when_empty_mandatory(self):
+        with self.assertRaises(ValueError):
+            read_bfabricrc_py('example_config.yml', config_env='STANDBY', optional_auth=False)
 
     def test_repr(self):
         rep = repr(self.config)
         self.assertEqual(
-            "BfabricConfig(base_url='url', application_ids={'app': 1}, job_notification_emails='')",
+            "BfabricConfig(webbase='url', application_ids={'app': 1}, job_notification_emails='')",
             rep,
         )
 
     def test_str(self):
         rep = str(self.config)
         self.assertEqual(
-            "BfabricConfig(base_url='url', application_ids={'app': 1}, job_notification_emails='')",
+            "BfabricConfig(webbase='url', application_ids={'app': 1}, job_notification_emails='')",
             rep,
         )
 


### PR DESCRIPTION
Sorry for naming, half-way through we decided to move to .yml files instead

This is a major change, it will require a new config file ".bfabricpy.yml" to appear in home directory.
The original ".bfabricrc.py" config file would be depreciated with this commit

The exact expected format of this config file can be found in "bfabricPy/tests/unit/example_config.yml"
For more details on the expected format, consult the comment in the bfabric_config.py. I will duplicate it here

```
NOTE: BFabricPy expects a .bfabricpy.yml of the format, as seen in bfabricPy/tests/unit/example_config.yml
* The general field always has to be present
* There may be any number of environments, and they may have arbitrary names. Here, they are called PRODUCTION and TEST
* Must specify correct login, password and webbase for each environment.
* application and job_notification_emails fields are optional
* The default environment will be selected as follows:
    - First, parser will check if the optional argument `config_env` is provided directly to the parser function
    - If not, secondly, the parser will check if the environment variable `BFABRICPY_CONFIG_ENV` is declared
    - If not, finally, the parser will select the default_config specified in [GENERAL] of the .bfabricpy.yml file 
```