### PR TITLE
Handle default `None` parameters in BfabricConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea/
+__pycache__
 bfabric.egg-info/
-bfabric/__pycache__/
 bfabric/scripts/query_result.txt
 dist/

--- a/README.md
+++ b/README.md
@@ -35,10 +35,17 @@ python3 setup.py install --user
 ## Configuration
 
 ```{bash}
-cat ~/.bfabricrc.py 
-_WEBBASE="https://fgcz-bfabric-test.uzh.ch/bfabric"
-_LOGIN="yourBfabricLogin"
-_PASSWD='yourBfabricWebPassword'
+cat ~/.bfabricpy.yml
+```
+
+```{yaml}
+GENERAL:
+  default_config: PRODUCTION
+  
+PRODUCTION:
+  login: yourBfabricLogin
+  password: yourBfabricWebPassword
+  base_url: https://fgcz-bfabric.uzh.ch/bfabric
 ```
 
 ## CheatSheet

--- a/bfabric/bfabric_config.py
+++ b/bfabric/bfabric_config.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import io
-import json
 import logging
 import os
 from typing import Optional, Dict, Tuple
@@ -24,7 +22,6 @@ class BfabricAuth:
         return repr(self)
 
 
-@dataclasses.dataclass(frozen=True)
 class BfabricConfig:
     """Holds the configuration for the B-Fabric client for connecting to particular instance of B-Fabric.
 
@@ -34,9 +31,30 @@ class BfabricConfig:
         job_notification_emails (optional): Space-separated list of email addresses to notify when a job finishes.
     """
 
-    base_url: str = "https://fgcz-bfabric.uzh.ch/bfabric"
-    application_ids: Dict[str, int] = dataclasses.field(default_factory=dict)
-    job_notification_emails: str = ""
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        application_ids: Optional[Dict[str, int]] = None,
+        job_notification_emails: Optional[str] = None
+    ):
+        self._base_url = base_url or "https://fgcz-bfabric.uzh.ch/bfabric"
+        self._application_ids = application_ids or {}
+        self._job_notification_emails = job_notification_emails or ""
+
+    @property
+    def base_url(self) -> str:
+        """The API base url."""
+        return self._base_url
+
+    @property
+    def application_ids(self) -> Dict[str, int]:
+        """Map of known application names to ids."""
+        return self._application_ids
+
+    @property
+    def job_notification_emails(self) -> str:
+        """Space-separated list of email addresses to notify when a job finishes."""
+        return self._job_notification_emails
 
     def with_overrides(
         self,
@@ -51,6 +69,11 @@ class BfabricConfig:
             else self.application_ids,
         )
 
+    def __repr__(self):
+        return (
+            f"BfabricConfig(base_url={repr(self.base_url)}, application_ids={repr(self.application_ids)}, "
+            f"job_notification_emails={repr(self.job_notification_emails)})"
+        )
 
 def _read_config_env_as_dict(config_path: str, config_env: str = None) -> Tuple[str, dict]:
     """

--- a/bfabric/tests/unit/test_bfabric_config.py
+++ b/bfabric/tests/unit/test_bfabric_config.py
@@ -24,6 +24,18 @@ class TestBfabricConfig(unittest.TestCase):
             application_ids={"app": 1},
         )
 
+    def test_default_params_when_omitted(self):
+        config = BfabricConfig()
+        self.assertEqual("https://fgcz-bfabric.uzh.ch/bfabric", config.base_url)
+        self.assertEqual({}, config.application_ids)
+        self.assertEqual("", config.job_notification_emails)
+
+    def test_default_params_when_specified(self):
+        config = BfabricConfig(base_url=None, application_ids=None, job_notification_emails=None)
+        self.assertEqual("https://fgcz-bfabric.uzh.ch/bfabric", config.base_url)
+        self.assertEqual({}, config.application_ids)
+        self.assertEqual("", config.job_notification_emails)
+
     def test_with_overrides(self):
         new_config = self.config.with_overrides(
             base_url="new_url",


### PR DESCRIPTION
This ensures that the BfabricConfig class takes the default value for fields specified as `None`. This makes more sense than the `dataclass` behavior here.