### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/bfabric/src/result_container.py
+++ b/bfabric/src/result_container.py
@@ -94,26 +94,32 @@ class ResultContainer:
 
     def to_list_dict(self, drop_empty: bool = True, drop_underscores_suds: bool = True,
                      have_sort_responses: bool = False):
-        match self.result_type:
-            case BfabricResultType.LISTDICT:
-                return self.results
-            case BfabricResultType.LISTSUDS:
-                results = []
-                for rez in self.results:
-                    rez_parsed = suds_asdict_recursive(rez, convert_types=True)
-                    rez_parsed = _clean_result(rez_parsed, drop_empty=drop_empty,
-                                               drop_underscores_suds=drop_underscores_suds,
-                                               sort_responses=have_sort_responses)
-                    results += [rez_parsed]
-                return results
-            case BfabricResultType.LISTZEEP:
-                results = []
-                for rez in self.results:
-                    rez_parsed = dict(serialize_object(rez, target_cls=dict))
-                    rez_parsed = _clean_result(rez_parsed, drop_empty=drop_empty,
-                                               drop_underscores_suds=False,  # NOTE: Underscore problem specific to SUDS
-                                               sort_responses=have_sort_responses)
-                    results += [rez_parsed]
-                return results
-            case _:
-                raise ValueError("Unexpected results type", self.result_type)
+        """
+        Converts the results to a list of dictionaries.
+        :param drop_empty: If True, empty attributes will be removed from the results
+        :param drop_underscores_suds: If True, leading underscores will be removed from the keys of the results
+        :param have_sort_responses: If True, keys of dictionaries in the response will be sorted.
+        TODO what about the order of items in the list?
+        """
+        if self.result_type == BfabricResultType.LISTDICT:
+            return self.results
+        elif self.result_type == BfabricResultType.LISTSUDS:
+            results = []
+            for rez in self.results:
+                rez_parsed = suds_asdict_recursive(rez, convert_types=True)
+                rez_parsed = _clean_result(rez_parsed, drop_empty=drop_empty,
+                                           drop_underscores_suds=drop_underscores_suds,
+                                           sort_responses=have_sort_responses)
+                results += [rez_parsed]
+            return results
+        elif self.result_type == BfabricResultType.LISTZEEP:
+            results = []
+            for rez in self.results:
+                rez_parsed = dict(serialize_object(rez, target_cls=dict))
+                rez_parsed = _clean_result(rez_parsed, drop_empty=drop_empty,
+                                           drop_underscores_suds=False,  # NOTE: Underscore problem specific to SUDS
+                                           sort_responses=have_sort_responses)
+                results += [rez_parsed]
+            return results
+        else:
+            raise ValueError("Unexpected results type", self.result_type)


### PR DESCRIPTION
This is a tiny change that I don't really like to make, but for now we can't drop Python 3.9 support yet. (If the CI wasn't broken we might have been able to detect the problem.)