### PR TITLE
Refactor list not available proteomics workunits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "suds >= 1.1.2",
     "PyYAML >= 6.0",
     "Flask == 2.2.5",
+    "rich >= 13.7.1",
     "zeep >= 4.2.1",
     "pandas >= 2.2.2"
 ]
@@ -35,7 +36,7 @@ Repository = "https://github.com/fgcz/bfabricPy"
 #bfabric_flask="bfabric.scripts.bfabric_flask:main"
 #bfabric_feeder_resource_autoQC="bfabric.scripts.bfabric_feeder_resource_autoQC:main"
 #bfabric_list_not_existing_storage_directories="bfabric.scripts.bfabric_list_not_existing_storage_directories:main"
-#bfabric_list_not_available_proteomics_workunits="bfabric.scripts.bfabric_list_not_available_proteomics_workunits:main"
+"bfabric_list_not_available_proteomics_workunits.py"="bfabric.scripts.bfabric_list_not_available_proteomics_workunits:main"
 #bfabric_upload_resource="bfabric.scripts.bfabric_upload_resource:main"
 #bfabric_logthis="bfabric.scripts.bfabric_logthis:main"
 #bfabric_setResourceStatus_available="bfabric.scripts.bfabric_setResourceStatus_available:main"


### PR DESCRIPTION
- Update the script to use the new Bfabric API
- Use rich for output formatting
  - If your terminal emulator does not support links etc then it will be formatted as text. (left in screenshot)
  - If you use a [modern terminal](https://github.com/Alhadis/OSC8-Adoption/) (on macOS e.g. iTerm - right in screenshot) you will get clickable links for app and workunit id:

<img width="768" alt="Pasted Graphic 2" src="https://github.com/fgcz/bfabricPy/assets/9108636/d04bd730-5eb1-449a-a3a9-5a8454d7542a">
