### PR TITLE
Use configured url

### DIFF
--- a/bfabric/src/cli_formatting.py
+++ b/bfabric/src/cli_formatting.py
@@ -1,0 +1,11 @@
+from rich.highlighter import RegexHighlighter
+from rich.theme import Theme
+
+
+class HostnameHighlighter(RegexHighlighter):
+    """Highlights hostnames in URLs."""
+    base_style = "bfabric."
+    highlights = [r"https://(?P<hostname>[^.]+)"]
+
+
+DEFAULT_THEME = Theme({"bfabric.hostname": "bold red"})


### PR DESCRIPTION
Fixes #81

- Use the correct URL. 
- Better version message, either by calling `Bfabric.print_version_message` or `verbose=True` when constructing `Bfabric`