### PR TITLE
new pagination interface, more stable reads, Bfabric.from_config

### DIFF
--- a/bfabric/src/paginator.py
+++ b/bfabric/src/paginator.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+import math
+
 # Single page query limit for BFabric API (as of time of writing, adapt if it changes)
 BFABRIC_QUERY_LIMIT = 100
+
 
 def page_iter(objs: list, page_size: int = BFABRIC_QUERY_LIMIT) -> list:
     """
@@ -9,4 +14,37 @@ def page_iter(objs: list, page_size: int = BFABRIC_QUERY_LIMIT) -> list:
     """
 
     for i in range(0, len(objs), page_size):
-        yield objs[i:i + page_size]
+        yield objs[i : i + page_size]
+
+
+def compute_requested_pages(
+    n_page_total: int,
+    n_item_per_page: int,
+    n_item_offset: int,
+    n_item_return_max: int | None,
+) -> tuple[list[int], int]:
+    """Returns the page indices that need to be requested to get all requested items.
+    :param n_page_total: Total number of pages available
+    :param n_item_per_page: Number of items per page
+    :param n_item_offset: Number of items to skip from the beginning
+    :param n_item_return_max: Maximum number of items to return
+    :return:
+        - list of page indices that need to be requested
+        - initial page offset (0-based), i.e. the i-th item from which onwards to retain results
+    """
+    # B-Fabric API uses 1-based indexing for pages
+    index_start = 1
+
+    # Determine the page indices to request
+    # If n_item_return_max is not provided, we will return all items
+    if n_item_return_max is None:
+        n_item_return_max = n_page_total * n_item_per_page
+
+    # Determine the page indices to request
+    idx_max_return = math.ceil((n_item_return_max + n_item_offset) / n_item_per_page)
+    idx_arr = [idx + index_start for idx in range(n_item_offset // n_item_per_page, min(n_page_total, idx_max_return))]
+
+    # Determine the initial offset on the first page
+    initial_offset = min(n_item_offset, n_item_return_max) % n_item_per_page
+
+    return idx_arr, initial_offset

--- a/bfabric/tests/unit/test_bfabric.py
+++ b/bfabric/tests/unit/test_bfabric.py
@@ -1,6 +1,9 @@
+import datetime
+import logging
 import unittest
 from functools import cached_property
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, ANY
+from zoneinfo import ZoneInfo
 
 from bfabric import BfabricConfig
 from bfabric.bfabric2 import BfabricAPIEngineType, Bfabric
@@ -10,6 +13,7 @@ from bfabric.src.engine_suds import EngineSUDS
 class TestBfabric(unittest.TestCase):
     def setUp(self):
         self.mock_config = MagicMock(name="mock_config", spec=BfabricConfig)
+        self.mock_config.server_timezone = "Pacific/Kiritimati"
         self.mock_auth = None
         self.mock_engine_type = BfabricAPIEngineType.SUDS
         self.mock_engine = MagicMock(name="mock_engine", spec=EngineSUDS)
@@ -17,6 +21,42 @@ class TestBfabric(unittest.TestCase):
     @cached_property
     def mock_bfabric(self) -> Bfabric:
         return Bfabric(config=self.mock_config, auth=self.mock_auth, engine=self.mock_engine_type)
+
+    @patch("bfabric.bfabric2.get_system_auth")
+    def test_from_config_when_no_args(self, mock_get_system_auth):
+        mock_config = MagicMock(name="mock_config", server_timezone="Pacific/Kiritimati")
+        mock_auth = MagicMock(name="mock_auth")
+        mock_get_system_auth.return_value = (mock_config, mock_auth)
+        client = Bfabric.from_config()
+        self.assertIsInstance(client, Bfabric)
+        self.assertEqual(mock_config, client.config)
+        self.assertEqual(mock_auth, client.auth)
+        mock_get_system_auth.assert_called_once_with(config_env=None)
+
+    @patch("bfabric.bfabric2.get_system_auth")
+    def test_from_config_when_explicit_auth(self, mock_get_system_auth):
+        mock_config = MagicMock(name="mock_config", server_timezone="Pacific/Kiritimati")
+        mock_auth = MagicMock(name="mock_auth")
+        mock_config_auth = MagicMock(name="mock_config_auth")
+        mock_get_system_auth.return_value = (mock_config, mock_config_auth)
+        client = Bfabric.from_config(config_env="TestingEnv", auth=mock_auth)
+        self.assertIsInstance(client, Bfabric)
+        self.assertEqual(mock_config, client.config)
+        self.assertEqual(mock_auth, client.auth)
+        mock_get_system_auth.assert_called_once_with(config_env="TestingEnv")
+
+    @patch("bfabric.bfabric2.get_system_auth")
+    def test_from_config_when_none_auth(self, mock_get_system_auth):
+        mock_config = MagicMock(name="mock_config", server_timezone="Pacific/Kiritimati")
+        mock_auth = MagicMock(name="mock_auth")
+        mock_get_system_auth.return_value = (mock_config, mock_auth)
+        client = Bfabric.from_config(config_env="TestingEnv", auth=None)
+        self.assertIsInstance(client, Bfabric)
+        self.assertEqual(mock_config, client.config)
+        with self.assertRaises(ValueError) as error:
+            _ = client.auth
+        self.assertIn("Authentication not available", str(error.exception))
+        mock_get_system_auth.assert_called_once_with(config_env="TestingEnv")
 
     def test_query_counter(self):
         self.assertEqual(0, self.mock_bfabric.query_counter)
@@ -52,7 +92,62 @@ class TestBfabric(unittest.TestCase):
             pass
         self.assertEqual(mock_old_auth, self.mock_bfabric.auth)
 
-    # TODO further unit tests
+    @patch("bfabric.bfabric2.datetime")
+    def test_add_query_timestamp_when_not_present(self, module_datetime):
+        module_datetime.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5)
+        query = self.mock_bfabric._add_query_timestamp( {"a": "b", "c": 1})
+        self.assertDictEqual(
+            {"a": "b", "c": 1, 'createdbefore': '2020-01-02T03:04:05'},
+            query,
+        )
+        module_datetime.now.assert_called_once_with(ZoneInfo('Pacific/Kiritimati'))
+
+    @patch("bfabric.bfabric2.datetime")
+    def test_add_query_timestamp_when_set_and_past(self, module_datetime):
+        module_datetime.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5)
+        module_datetime.fromisoformat = datetime.datetime.fromisoformat
+        query_before = {"a": "b", "createdbefore": "2019-12-31T23:59:59"}
+        # TODO once py3.10 is available, use assertNoLogs
+        query = self.mock_bfabric._add_query_timestamp(query_before)
+        self.assertDictEqual(
+            {"a": "b", "createdbefore": "2019-12-31T23:59:59"},
+            query,
+        )
+        module_datetime.now.assert_called_once_with(ZoneInfo('Pacific/Kiritimati'))
+
+    @patch("bfabric.bfabric2.datetime")
+    def test_add_query_timestamp_when_set_and_future(self, module_datetime):
+        module_datetime.now.return_value = datetime.datetime(2020, 1, 2, 3, 4, 5)
+        module_datetime.fromisoformat = datetime.datetime.fromisoformat
+        query_before = {"a": "b", "createdbefore": "2020-01-02T03:04:06"}
+        with self.assertLogs(level=logging.WARNING) as logs:
+            query = self.mock_bfabric._add_query_timestamp(query_before)
+        self.assertDictEqual(
+            {"a": "b", "createdbefore": "2020-01-02T03:04:06"},
+            query,
+        )
+        self.assertEqual(1, len(logs.output))
+        self.assertIn("Query timestamp is in the future: 2020-01-02 03:04:06", logs.output[0])
+
+    def test_get_version_message(self):
+        self.mock_config.base_url = "dummy_url"
+        message = self.mock_bfabric.get_version_message()
+        lines = message.split("\n")
+        self.assertEqual(2, len(lines))
+        # first line
+        pattern = r"--- bfabricPy v\d+\.\d+\.\d+ \(EngineSUDS, dummy_url, U=None\) ---"
+        self.assertRegex(lines[0], pattern)
+        # second line
+        year = datetime.datetime.now().year
+        self.assertEqual(f"--- Copyright (C) 2014-{year} Functional Genomics Center Zurich ---", lines[1])
+
+    @patch("bfabric.bfabric2.Console")
+    @patch.object(Bfabric, "get_version_message")
+    def test_print_version_message(self, method_get_version_message, mock_console):
+        mock_stderr = MagicMock(name="mock_stderr")
+        self.mock_bfabric.print_version_message(stderr=mock_stderr)
+        mock_console.assert_called_once_with(stderr=mock_stderr, highlighter=ANY, theme=ANY)
+        mock_console.return_value.print.assert_called_once_with(method_get_version_message.return_value, style="bright_yellow")
 
 
 if __name__ == "__main__":

--- a/bfabric/tests/unit/test_paginator.py
+++ b/bfabric/tests/unit/test_paginator.py
@@ -13,6 +13,70 @@ class BfabricTestBasicPagination(unittest.TestCase):
         self.assertEqual(rez[0], list(range(100)))
         self.assertEqual(rez[1], list(range(100, 123)))
 
+    def test_compute_requested_pages_when_no_offset(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=0, n_item_return_max=None
+        )
+        self.assertListEqual([1, 2, 3, 4, 5], pages)
+        self.assertEqual(0, init_offset)
+
+    def test_compute_requested_pages_when_offset_2(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=2, n_item_return_max=None
+        )
+        self.assertListEqual([1, 2, 3, 4, 5], pages)
+        self.assertEqual(2, init_offset)
+
+    def test_compute_requested_pages_when_offset_3(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=3, n_item_return_max=None
+        )
+        self.assertListEqual([2, 3, 4, 5], pages)
+        self.assertEqual(0, init_offset)
+
+    def test_compute_requested_pages_when_offset_4(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=4, n_item_return_max=None
+        )
+        self.assertListEqual([2, 3, 4, 5], pages)
+        self.assertEqual(1, init_offset)
+
+    def test_compute_requested_pages_when_offset_6(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=6, n_item_return_max=None
+        )
+        self.assertListEqual([3, 4, 5], pages)
+        self.assertEqual(0, init_offset)
+
+    def test_compute_requested_pages_when_offset_out_of_bounds(self):
+        # TODO maybe it should yield an error?
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=100, n_item_return_max=None
+        )
+        self.assertListEqual([], pages)
+        self.assertEqual(0, init_offset)
+
+    def test_compute_requested_pages_when_max(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=0, n_item_return_max=10
+        )
+        self.assertListEqual([1, 2, 3, 4], pages)
+        self.assertEqual(0, init_offset)
+
+    def test_compute_requested_pages_when_max_9(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=0, n_item_return_max=9
+        )
+        self.assertListEqual([1, 2, 3], pages)
+        self.assertEqual(0, init_offset)
+
+    def test_compute_requested_pages_when_max_6(self):
+        pages, init_offset = paginator.compute_requested_pages(
+            n_page_total=5, n_item_per_page=3, n_item_offset=0, n_item_return_max=6
+        )
+        self.assertListEqual([1, 2], pages)
+        self.assertEqual(0, init_offset)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
This mixes 3 different concerns, but it will make it much quicker for me to bundle these changes than separate them out from the branch where they are integrated already:

- New pagination logic:
  - Specify max number of items
  - Specify offset of items to skip
- Stable reading
  - Reading passes a `createdbefore` query field (if it's not part of the query) to ensure consistent reads/pagination in the presence of insertions into the database. Deletions are not handled and might require an API feature.
  - It will need to be tested further before releasing, but my idea is that this is a lot more flexible moving forward
- New `Bfabric.from_config` arguably it is a bit redundant with the `get_system_auth` method, however I do feel like 99% of use cases will be handled with this method now and it will be easier to do so. I'm not changing the usage in this PR yet.
