### PR TITLE
Extract multiquery

### DIFF
--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -208,6 +208,23 @@ class Bfabric:
             results.assert_success()
         return results
 
+    def exists(
+        self, endpoint: str, key: str, value: int | str, query: dict[str, Any] | None = None, check: bool = True
+    ) -> bool:
+        """Returns whether an object with the specified key-value pair exists in the specified endpoint.
+        Further conditions can be specified in the query.
+        :param endpoint: the endpoint to check, e.g. "sample"
+        :param key: the key to check, e.g. "id"
+        :param value: the value to check, e.g. 123
+        :param query: additional query conditions (optional)
+        :param check: whether to raise an error if the response is not successful
+        """
+        query = query or {}
+        results = self.read(
+            endpoint=endpoint, obj={**query, key: value}, max_results=1, check=check, return_id_only=True
+        )
+        return len(results) > 0
+
     def upload_resource(
         self, resource_name: str, content: bytes, workunit_id: int, check: bool = True
     ) -> ResultContainer:

--- a/bfabric/bfabric.py
+++ b/bfabric/bfabric.py
@@ -18,7 +18,6 @@ import importlib.metadata
 import logging
 import os
 from contextlib import contextmanager
-from copy import deepcopy
 from datetime import datetime
 from enum import Enum
 from pprint import pprint
@@ -32,7 +31,7 @@ from bfabric.cli_formatting import HostnameHighlighter, DEFAULT_THEME
 from bfabric.engine.engine_suds import EngineSUDS
 from bfabric.engine.engine_zeep import EngineZeep
 from bfabric.results.result_container import ResultContainer
-from bfabric.utils.paginator import compute_requested_pages, BFABRIC_QUERY_LIMIT, page_iter
+from bfabric.utils.paginator import compute_requested_pages, BFABRIC_QUERY_LIMIT
 
 
 class BfabricAPIEngineType(Enum):
@@ -230,113 +229,6 @@ class Bfabric:
             },
             check=check,
         )
-
-    ############################
-    # Multi-query functionality
-    ############################
-
-    # TODO: Is this scope sufficient? Is there ever more than one multi-query parameter, and/or not at the root of dict?
-    def read_multi(
-        self,
-        endpoint: str,
-        obj: dict,
-        multi_query_key: str,
-        multi_query_vals: list,
-        readid: bool = False,
-        idonly: bool = False,
-    ) -> ResultContainer:
-        """
-        Makes a 1-parameter multi-query (there is 1 parameter that takes a list of values)
-        Since the API only allows BFABRIC_QUERY_LIMIT queries per page, split the list into chunks before querying
-        :param endpoint: endpoint
-        :param obj: query dictionary
-        :param multi_query_key:  key for which the multi-query is performed
-        :param multi_query_vals: list of values for which the multi-query is performed
-        :param readid: whether to use reading by ID. Currently only available for engine=SUDS
-            TODO: Test the extent to which this method works. Add safeguards
-        :param idonly: whether to return only the ids of the objects
-        :return: List of responses, packaged in the results container
-
-        NOTE: It is assumed that there is only 1 response for each value.
-        """
-
-        response_tot = ResultContainer([], total_pages_api=0)
-        obj_extended = deepcopy(obj)  # Make a copy of the query, not to make edits to the argument
-
-        # Iterate over request chunks that fit into a single API page
-        for page_vals in page_iter(multi_query_vals):
-            obj_extended[multi_query_key] = page_vals
-
-            # TODO: Test what happens if there are multiple responses to each of the individual queries.
-            #     * What would happen?
-            #     * What would happen if total number of responses would exceed 100 now?
-            #     * What would happen if we naively made a multi-query with more than 100 values? Would API paginate
-            #       automatically? If yes, perhaps we don't need this method at all?
-            # TODO: It is assumed that a user requesting multi_query always wants all of the pages. Can anybody think of
-            #   exceptions to this?
-            response_this = self.read(endpoint, obj_extended, max_results=None, return_id_only=idonly)
-            response_tot.extend(response_this)
-
-        return response_tot
-
-    # NOTE: Save-multi method is likely useless. When saving multiple objects, they all have different fields.
-    #    One option would be to provide a dataframe, but it might struggle with nested dicts
-    #    Likely best solution is to not provide this method, and let users run a for-loop themselves.
-    # def save_multi(self, endpoint: str, obj_lst: list, **kwargs) -> ResultContainer:
-    #     response_tot = ResultContainer([], self.result_type, total_pages_api = 0)
-    #
-    #     # Iterate over request chunks that fit into a single API page
-    #     for page_objs in page_iter(obj_lst):
-    #         response_page = self.save(endpoint, page_objs, **kwargs)
-    #         response_tot.extend(response_page)
-    #
-    #     return response_tot
-
-    def delete_multi(self, endpoint: str, id_list: list) -> ResultContainer:
-        response_tot = ResultContainer([], total_pages_api=0)
-
-        if len(id_list) == 0:
-            print("Warning, empty list provided for deletion, ignoring")
-            return response_tot
-
-        # Iterate over request chunks that fit into a single API page
-        for page_ids in page_iter(id_list):
-            response_page = self.delete(endpoint, page_ids)
-            response_tot.extend(response_page)
-
-        return response_tot
-
-    def exists(self, endpoint: str, key: str, value: list[int | str] | int | str) -> bool | list[bool]:
-        """
-        :param endpoint:  endpoint
-        :param key:       A key for the query (e.g. id or name)
-        :param value:     A value or a list of values
-        :return:          Return a single bool or a list of bools for each value
-            For each value, test if a key with that value is found in the API.
-        """
-        is_scalar = isinstance(value, (int, str))
-
-        # 1. Read data for this id
-        if is_scalar:
-            results = self.read(endpoint, {key: value})
-        elif isinstance(value, list):
-            results = self.read_multi(endpoint, {}, key, value)
-        else:
-            raise ValueError("Unexpected data type", type(value))
-
-        # 2. Extract all the ids for which there was a response
-        result_vals = []
-        for r in results.results:
-            if key in r:
-                result_vals += [r[key]]
-            elif "_" + key in r:  # TODO: Remove this if SUDS bug is ever resolved
-                result_vals += [r["_" + key]]
-
-        # 3. For each of the requested ids, return true if there was a response and false if there was not
-        if is_scalar:
-            return value in result_vals
-        else:
-            return [val in result_vals for val in value]
 
     def get_version_message(self) -> str:
         """Returns the version message as a string."""

--- a/bfabric/examples/exists_multi.py
+++ b/bfabric/examples/exists_multi.py
@@ -27,8 +27,8 @@ b2 = MultiQuery(Bfabric(config, auth, engine=BfabricAPIEngineType.ZEEP))
 
 target_workunit_names = ["tomcat", "tomcat2"]
 
-response1 = b1.exists("workunit", "name", target_workunit_names)
-response2 = b2.exists("workunit", "name", target_workunit_names)
+response1 = b1.exists_multi("workunit", "name", target_workunit_names)
+response2 = b2.exists_multi("workunit", "name", target_workunit_names)
 
 print(response1)
 print(response2)

--- a/bfabric/examples/exists_multi.py
+++ b/bfabric/examples/exists_multi.py
@@ -1,10 +1,12 @@
 from bfabric import BfabricAPIEngineType, Bfabric
 from bfabric.bfabric import get_system_auth
+from bfabric.experimental.multi_query import MultiQuery
+
 
 config, auth = get_system_auth(config_env="TEST")
 
-b1 = Bfabric(config, auth, engine=BfabricAPIEngineType.SUDS)
-b2 = Bfabric(config, auth, engine=BfabricAPIEngineType.ZEEP)
+b1 = MultiQuery(Bfabric(config, auth, engine=BfabricAPIEngineType.SUDS))
+b2 = MultiQuery(Bfabric(config, auth, engine=BfabricAPIEngineType.ZEEP))
 
 
 ###################

--- a/bfabric/experimental/multi_query.py
+++ b/bfabric/experimental/multi_query.py
@@ -31,7 +31,7 @@ class MultiQuery:
 
         NOTE: It is assumed that there is only 1 response for each value.
         """
-
+        # TODO add `check` parameter
         response_tot = ResultContainer([], total_pages_api=0)
         obj_extended = deepcopy(obj)  # Make a copy of the query, not to make edits to the argument
 
@@ -64,10 +64,13 @@ class MultiQuery:
     #
     #     return response_tot
 
-    def delete_multi(self, endpoint: str, id_list: list) -> ResultContainer:
+    def delete_multi(self, endpoint: str, id_list: list[int]) -> ResultContainer:
+        """Deletes multiple objects from `endpoint` by their ids."""
+        # TODO document and test error handling
+        # TODO add `check` parameter
         response_tot = ResultContainer([], total_pages_api=0)
 
-        if len(id_list) == 0:
+        if not id_list:
             print("Warning, empty list provided for deletion, ignoring")
             return response_tot
 
@@ -78,7 +81,7 @@ class MultiQuery:
 
         return response_tot
 
-    def exists(self, endpoint: str, key: str, value: list[int | str] | int | str) -> bool | list[bool]:
+    def exists_multi(self, endpoint: str, key: str, value: list[int | str] | int | str) -> bool | list[bool]:
         """
         :param endpoint:  endpoint
         :param key:       A key for the query (e.g. id or name)

--- a/bfabric/experimental/multi_query.py
+++ b/bfabric/experimental/multi_query.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from copy import deepcopy
 
-from bfabric.bfabric import Bfabric
 from bfabric.results.result_container import ResultContainer
 from bfabric.utils.paginator import page_iter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bfabric.bfabric import Bfabric
 
 
 class MultiQuery:

--- a/bfabric/experimental/multi_query.py
+++ b/bfabric/experimental/multi_query.py
@@ -8,6 +8,11 @@ from bfabric.utils.paginator import page_iter
 
 
 class MultiQuery:
+    """Some advanced functionality that supports paginating over a list of conditions that is larger than the 100
+    conditions limit of the API.
+    This functionality might eventually be merged into the main Bfabric class but will probably be subject to some
+    breaking changes and is not as thoroughly tested as the main classes functionality.
+    """
     def __init__(self, client: Bfabric) -> None:
         self._client = client
 

--- a/bfabric/experimental/multi_query.py
+++ b/bfabric/experimental/multi_query.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from bfabric.bfabric import Bfabric
+from bfabric.results.result_container import ResultContainer
+from bfabric.utils.paginator import page_iter
+
+
+class MultiQuery:
+    def __init__(self, client: Bfabric) -> None:
+        self._client = client
+
+    # TODO: Is this scope sufficient? Is there ever more than one multi-query parameter, and/or not at the root of dict?
+    def read_multi(
+        self,
+        endpoint: str,
+        obj: dict,
+        multi_query_key: str,
+        multi_query_vals: list,
+        return_id_only: bool = False,
+    ) -> ResultContainer:
+        """Performs a 1-parameter multi-query (there is 1 parameter that takes a list of values)
+        Since the API only allows BFABRIC_QUERY_LIMIT queries per page, split the list into chunks before querying
+        :param endpoint: endpoint
+        :param obj: query dictionary
+        :param multi_query_key:  key for which the multi-query is performed
+        :param multi_query_vals: list of values for which the multi-query is performed
+        :param return_id_only: whether to return only the ids of the objects
+        :return: List of responses, packaged in the results container
+
+        NOTE: It is assumed that there is only 1 response for each value.
+        """
+
+        response_tot = ResultContainer([], total_pages_api=0)
+        obj_extended = deepcopy(obj)  # Make a copy of the query, not to make edits to the argument
+
+        # Iterate over request chunks that fit into a single API page
+        for page_vals in page_iter(multi_query_vals):
+            obj_extended[multi_query_key] = page_vals
+
+            # TODO: Test what happens if there are multiple responses to each of the individual queries.
+            #     * What would happen?
+            #     * What would happen if total number of responses would exceed 100 now?
+            #     * What would happen if we naively made a multi-query with more than 100 values? Would API paginate
+            #       automatically? If yes, perhaps we don't need this method at all?
+            # TODO: It is assumed that a user requesting multi_query always wants all of the pages. Can anybody think of
+            #   exceptions to this?
+            response_this = self._client.read(endpoint, obj_extended, max_results=None, return_id_only=return_id_only)
+            response_tot.extend(response_this)
+
+        return response_tot
+
+    # NOTE: Save-multi method is likely useless. When saving multiple objects, they all have different fields.
+    #    One option would be to provide a dataframe, but it might struggle with nested dicts
+    #    Likely best solution is to not provide this method, and let users run a for-loop themselves.
+    # def save_multi(self, endpoint: str, obj_lst: list, **kwargs) -> ResultContainer:
+    #     response_tot = ResultContainer([], self.result_type, total_pages_api = 0)
+    #
+    #     # Iterate over request chunks that fit into a single API page
+    #     for page_objs in page_iter(obj_lst):
+    #         response_page = self.save(endpoint, page_objs, **kwargs)
+    #         response_tot.extend(response_page)
+    #
+    #     return response_tot
+
+    def delete_multi(self, endpoint: str, id_list: list) -> ResultContainer:
+        response_tot = ResultContainer([], total_pages_api=0)
+
+        if len(id_list) == 0:
+            print("Warning, empty list provided for deletion, ignoring")
+            return response_tot
+
+        # Iterate over request chunks that fit into a single API page
+        for page_ids in page_iter(id_list):
+            response_page = self._client.delete(endpoint, page_ids)
+            response_tot.extend(response_page)
+
+        return response_tot
+
+    def exists(self, endpoint: str, key: str, value: list[int | str] | int | str) -> bool | list[bool]:
+        """
+        :param endpoint:  endpoint
+        :param key:       A key for the query (e.g. id or name)
+        :param value:     A value or a list of values
+        :return:          Return a single bool or a list of bools for each value
+            For each value, test if a key with that value is found in the API.
+        """
+        is_scalar = isinstance(value, (int, str))
+
+        # 1. Read data for this id
+        if is_scalar:
+            results = self._client.read(endpoint, {key: value})
+        elif isinstance(value, list):
+            results = self.read_multi(endpoint, {}, key, value)
+        else:
+            raise ValueError("Unexpected data type", type(value))
+
+        # 2. Extract all the ids for which there was a response
+        result_vals = []
+        for r in results.results:
+            if key in r:
+                result_vals += [r[key]]
+            elif "_" + key in r:  # TODO: Remove this if SUDS bug is ever resolved
+                result_vals += [r["_" + key]]
+
+        # 3. For each of the requested ids, return true if there was a response and false if there was not
+        if is_scalar:
+            return value in result_vals
+        else:
+            return [val in result_vals for val in value]

--- a/bfabric/experimental/multi_query.py
+++ b/bfabric/experimental/multi_query.py
@@ -95,14 +95,13 @@ class MultiQuery:
             For each value, test if a key with that value is found in the API.
         """
         is_scalar = isinstance(value, (int, str))
+        if is_scalar:
+            return self._client.exists(endpoint=endpoint, key=key, value=value, check=True)
+        elif not isinstance(value, list):
+            raise ValueError("Unexpected data type", type(value))
 
         # 1. Read data for this id
-        if is_scalar:
-            results = self._client.read(endpoint, {key: value})
-        elif isinstance(value, list):
-            results = self.read_multi(endpoint, {}, key, value)
-        else:
-            raise ValueError("Unexpected data type", type(value))
+        results = self.read_multi(endpoint, {}, key, value)
 
         # 2. Extract all the ids for which there was a response
         result_vals = []
@@ -113,7 +112,4 @@ class MultiQuery:
                 result_vals += [r["_" + key]]
 
         # 3. For each of the requested ids, return true if there was a response and false if there was not
-        if is_scalar:
-            return value in result_vals
-        else:
-            return [val in result_vals for val in value]
+        return [val in result_vals for val in value]

--- a/bfabric/tests/integration/test_bfabric2_exists.py
+++ b/bfabric/tests/integration/test_bfabric2_exists.py
@@ -1,5 +1,5 @@
 import unittest
-
+from bfabric.experimental.multi_query import  MultiQuery
 from bfabric import BfabricAPIEngineType, Bfabric
 from bfabric.bfabric import get_system_auth
 
@@ -10,7 +10,8 @@ class BfabricTestExists(unittest.TestCase):
 
     def _test_single_exists(self, engine: BfabricAPIEngineType):
         bf = Bfabric(self.config, self.auth, engine=engine)
-        res = bf.exists("dataset", "id", 30721)  # Take ID which is the same as in production
+        multiquery = MultiQuery(bf)
+        res = multiquery.exists("dataset", "id", 30721)  # Take ID which is the same as in production
         self.assertEqual(res, True)
 
     def test_zeep(self):

--- a/bfabric/tests/integration/test_bfabric2_exists.py
+++ b/bfabric/tests/integration/test_bfabric2_exists.py
@@ -1,17 +1,12 @@
 import unittest
-from bfabric.experimental.multi_query import  MultiQuery
+
 from bfabric import BfabricAPIEngineType, Bfabric
-from bfabric.bfabric import get_system_auth
 
 
 class BfabricTestExists(unittest.TestCase):
-    def setUp(self):
-        self.config, self.auth = get_system_auth(config_env="TEST")
-
     def _test_single_exists(self, engine: BfabricAPIEngineType):
-        bf = Bfabric(self.config, self.auth, engine=engine)
-        multiquery = MultiQuery(bf)
-        res = multiquery.exists_multi("dataset", "id", 30721)  # Take ID which is the same as in production
+        client = Bfabric.from_config("TEST", engine=engine)
+        res = client.exists("dataset", "id", 30721)
         self.assertEqual(res, True)
 
     def test_zeep(self):
@@ -19,3 +14,7 @@ class BfabricTestExists(unittest.TestCase):
 
     def test_suds(self):
         self._test_single_exists(engine=BfabricAPIEngineType.SUDS)
+
+
+if __name__ == "__main__":
+    pass

--- a/bfabric/tests/integration/test_bfabric2_exists.py
+++ b/bfabric/tests/integration/test_bfabric2_exists.py
@@ -11,7 +11,7 @@ class BfabricTestExists(unittest.TestCase):
     def _test_single_exists(self, engine: BfabricAPIEngineType):
         bf = Bfabric(self.config, self.auth, engine=engine)
         multiquery = MultiQuery(bf)
-        res = multiquery.exists("dataset", "id", 30721)  # Take ID which is the same as in production
+        res = multiquery.exists_multi("dataset", "id", 30721)  # Take ID which is the same as in production
         self.assertEqual(res, True)
 
     def test_zeep(self):

--- a/bfabric/tests/integration/test_bfabric2_save_delete.py
+++ b/bfabric/tests/integration/test_bfabric2_save_delete.py
@@ -17,7 +17,7 @@ def _find_delete_existing_objects_by_name(b: Bfabric, endpoint: str, name_list: 
     """
 
     # 1. Check which objects exist
-    objs_exist = MultiQuery(b).exists(endpoint, "name", name_list)
+    objs_exist = MultiQuery(b).exists_multi(endpoint, "name", name_list)
     objs_exist_names = [name for i, name in enumerate(name_list) if objs_exist[i]]
 
     if len(objs_exist_names) == 0:

--- a/bfabric/tests/integration/test_bfabric2_save_delete.py
+++ b/bfabric/tests/integration/test_bfabric2_save_delete.py
@@ -3,6 +3,7 @@ import unittest
 
 from bfabric import BfabricAPIEngineType, Bfabric
 from bfabric.bfabric import get_system_auth
+from bfabric.experimental.multi_query import MultiQuery
 
 
 def _find_delete_existing_objects_by_name(b: Bfabric, endpoint: str, name_list: list) -> Tuple[list, list]:
@@ -16,7 +17,7 @@ def _find_delete_existing_objects_by_name(b: Bfabric, endpoint: str, name_list: 
     """
 
     # 1. Check which objects exist
-    objs_exist = b.exists(endpoint, "name", name_list)
+    objs_exist = MultiQuery(b).exists(endpoint, "name", name_list)
     objs_exist_names = [name for i, name in enumerate(name_list) if objs_exist[i]]
 
     if len(objs_exist_names) == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ indent-width = 4
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["ANN", "BLE", "D103", "E", "F", "PLW", "PTH", "SIM", "UP"]
+select = ["ANN", "BLE", "D103", "E", "F", "PLW", "PTH", "SIM", "UP", "TCH"]
 ignore = ["ANN101"]
 
 [tool.licensecheck]


### PR DESCRIPTION
As there remain several important questions to be answered about some MultiQuery functionality, this PR will move these methods into a separate module to prevent too much of the code getting entangled again until we have something that will be maintained long term.

```python
client.read_multi(...)
```

becomes

```python
from bfabric.experimental.multi_query import MultiQuery
MultiQuery(client).read_multi(...)
```

In principle it's not even clear right now, if `upload_resource` should be part of the `Bfabric` API or rather a separate module too.