### PR TITLE
1.13.12

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ Versioning currently follows `X.Y.Z` where
 
 ## \[Unreleased\]
 
+### Changed
+
+- The submitter ensures that workunits always get set to `processing`.
+
 ## \[1.13.11\] - 2024-12-13
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,8 @@ Versioning currently follows `X.Y.Z` where
 
 ## \[Unreleased\]
 
+## \[1.13.12\] - 2024-12-17
+
 ### Changed
 
 - The submitter ensures that workunits always get set to `processing`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,11 @@ Versioning currently follows `X.Y.Z` where
 
 - The submitter ensures that workunits always get set to `processing`.
 
+### Fixed
+
+- The script `bfabric_setResourceStatus_available.py` and other uses of `report_resource`, correctly search files which
+    have a relative path starting with `/` as in the case of the legacy wrapper creator.
+
 ## \[1.13.11\] - 2024-12-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "bfabric"
 description = "Python client for the B-Fabric WSDL API"
-version = "1.13.11"
+version = "1.13.12"
 license = { text = "GPL-3.0" }
 authors = [
     { name = "Christian Panse", email = "cp@fgcz.ethz.ch" },

--- a/src/bfabric/wrapper_creator/bfabric_submitter.py
+++ b/src/bfabric/wrapper_creator/bfabric_submitter.py
@@ -146,6 +146,9 @@ then
 fi
 # exit 0
 
+# Set the workunit status to processing
+bfabric_setWorkunitStatus_processing.py $WORKUNIT_ID
+
 # run the application
 test -f $TEMPDIR/config_WU$WORKUNIT_ID.yaml && {executable} $TEMPDIR/config_WU$WORKUNIT_ID.yaml
 
@@ -163,6 +166,7 @@ else
     echo "application failed"
      mutt -s "WORKUNIT_ID=$WORKUNIT_ID EXTERNALJOB_ID=$EXTERNALJOB_ID failed" $EMAIL < /dev/null
      bfabric_setResourceStatus_available.py $RESSOURCEID_STDOUT_STDERR $RESSOURCEID;
+     bfabric_setWorkunitStatus_failed.py $WORKUNIT_ID
     exit 1;
 fi
 

--- a/src/bfabric_scripts/feeder/report.py
+++ b/src/bfabric_scripts/feeder/report.py
@@ -20,6 +20,7 @@ def report_resource(client: Bfabric, resource_id: int) -> ResultContainer:
         return ResultContainer([])
 
     filename = Path(resource.storage["basepath"]) / resource["relativepath"]
+    logger.info("Testing file: {}", filename)
     if filename.is_file():
         checksum, _, filesize, _ = get_file_attributes(str(filename))
         return client.save(

--- a/src/bfabric_scripts/feeder/report.py
+++ b/src/bfabric_scripts/feeder/report.py
@@ -9,6 +9,14 @@ from bfabric.results.result_container import ResultContainer
 from bfabric_scripts.feeder.file_attributes import get_file_attributes
 
 
+def _make_relative(path: str) -> str:
+    # TODO this is a hack which is necessary due to behavior of the legacy wrapper_creator, hopefully no
+    #      other code uses leading slashes to indicate relative paths but this will be seen later when refactoring this
+    #      away.
+    # replaces any number of leading slashes with an empty string
+    return path.lstrip("/")
+
+
 def report_resource(client: Bfabric, resource_id: int) -> ResultContainer:
     """Saves the provided resource's checksum, file size and available state."""
     resource = Resource.find(id=resource_id, client=client)
@@ -19,7 +27,8 @@ def report_resource(client: Bfabric, resource_id: int) -> ResultContainer:
         logger.error("Resource does not have a storage")
         return ResultContainer([])
 
-    filename = Path(resource.storage["basepath"]) / resource["relativepath"]
+    relative_path = _make_relative(resource["relativepath"])
+    filename = Path(resource.storage["basepath"]) / relative_path
     logger.info("Testing file: {}", filename)
     if filename.is_file():
         checksum, _, filesize, _ = get_file_attributes(str(filename))


### PR DESCRIPTION
### Changed

- The submitter ensures that workunits always get set to `processing`.

### Fixed

- The script `bfabric_setResourceStatus_available.py` and other uses of `report_resource`, correctly search files which
    have a relative path starting with `/` as in the case of the legacy wrapper creator.