### PR TITLE
Better bfabric-cli api read command

### DIFF
--- a/bfabric_scripts/doc/changelog.md
+++ b/bfabric_scripts/doc/changelog.md
@@ -16,6 +16,16 @@ Versioning currently follows `X.Y.Z` where
     - allows sorting by arbitrary fields, e.g. application id
     - allows filtering inclusive or exclusive by user
 
+### Changed
+
+- `bfabric-cli api read`
+    - Removes the automatic output type logic
+    - Multiple values can be submitted for the same key (just specify it multiple times)
+    - The actual query will be printed as a line of bfabricPy code
+    - `--file` parameter to write the output to a specific file
+    - Argument parsing is handled with pydantic now
+    - Added tsv support
+
 ## \[1.13.19\] - 2025-01-29
 
 Initial release of standalone bfabric_scripts package.

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
@@ -67,7 +67,7 @@ def perform_query(params: Params, client: Bfabric, console_user: Console) -> lis
     return results
 
 
-def render_output(results: list[dict[str, Any]], params: Params, client: Bfabric, console: Console) -> str:
+def render_output(results: list[dict[str, Any]], params: Params, client: Bfabric, console: Console) -> str | None:
     """Renders the results in the specified output format."""
     if params.format == OutputFormat.JSON:
         return json.dumps(results, indent=2)
@@ -81,6 +81,7 @@ def render_output(results: list[dict[str, Any]], params: Params, client: Bfabric
             output_format=params.format,
         )
         _print_table_rich(client.config, console, params.endpoint, results, output_columns=output_columns)
+        return None
     else:
         raise ValueError(f"output format {params.format} not supported")
 
@@ -101,6 +102,8 @@ def read(command: Annotated[Params, cyclopts.Parameter(name="*")], *, client: Bf
     console_out = Console()
     output = render_output(results, params=command, client=client, console=console_out)
     if command.file:
+        if output is None:
+            raise ValueError("File output is not supported for the specified output format.")
         command.file.write_text(output)
 
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
@@ -93,29 +93,29 @@ def render_output(results: list[dict[str, Any]], params: Params, client: Bfabric
 @app.default
 @use_client
 @logger.catch()
-def read(command: Annotated[Params, cyclopts.Parameter(name="*")], *, client: Bfabric) -> None | int:
+def read(params: Annotated[Params, cyclopts.Parameter(name="*")], *, client: Bfabric) -> None | int:
     """Reads one type of entity from B-Fabric."""
     console_user = Console(stderr=True)
-    console_user.print(command)
+    console_user.print(params)
 
     # Perform the query
-    results = perform_query(params=command, client=client, console_user=console_user)
+    results = perform_query(params=params, client=client, console_user=console_user)
 
     # Print/export output
     results = sorted(results, key=lambda x: x["id"])
     console_out = Console()
-    output = render_output(results, params=command, client=client, console=console_out)
+    output = render_output(results, params=params, client=client, console=console_out)
     if output is not None:
-        if command.format == OutputFormat.TSV:
+        if params.format == OutputFormat.TSV:
             print(output)
         else:
             console_out.print(output)
-    if command.file:
+    if params.file:
         if output is None:
             logger.error("File output is not supported for the specified output format.")
             return 1
-        command.file.write_text(output)
-        logger.info(f"Results written to {command.file} (size: {command.file.stat().st_size} bytes)")
+        params.file.write_text(output)
+        logger.info(f"Results written to {params.file} (size: {params.file.stat().st_size} bytes)")
 
 
 def _determine_output_columns(

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,17 +8,14 @@ import nox
 nox.options.default_venv_backend = "uv"
 
 
-@nox.session(python=["3.9", "3.13"])
+@nox.session(python=["3.9", "3.11", "3.13"])
 def tests(session):
     session.install("./bfabric[test]", "-e", "./bfabric_scripts")
     session.run("uv", "pip", "list")
-    session.run(
-        "pytest",
-        "--durations=50",
-        "tests/bfabric",
-        "tests/bfabric_scripts",
-        "tests/bfabric_cli",
-    )
+    packages = ["tests/bfabric", "tests/bfabric_scripts"]
+    if session.python.split(".")[0] == "3" and int(session.python.split(".")[1]) >= 11:
+        packages.append("tests/bfabric_cli")
+    session.run("pytest", "--durations=50", *packages)
 
 
 @nox.session(python=["3.13"])

--- a/tests/bfabric_cli/test_cli_api_read.py
+++ b/tests/bfabric_cli/test_cli_api_read.py
@@ -1,0 +1,230 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from bfabric import Bfabric
+from bfabric.results.result_container import ResultContainer
+from bfabric_scripts.cli.api.cli_api_read import (
+    Params,
+    OutputFormat,
+    perform_query,
+    read,
+    render_output,
+    _determine_output_columns,
+)
+from rich.console import Console
+
+
+@pytest.fixture
+def mock_client(mocker):
+    client = mocker.Mock(spec=Bfabric)
+    client.config.base_url = "http://test-bfabric.com"
+    return client
+
+
+@pytest.fixture
+def mock_console(mocker):
+    return mocker.Mock(spec=Console)
+
+
+@pytest.fixture
+def sample_results():
+    return [
+        {"id": 1, "name": "Sample 1", "status": "active", "groupingvar": {"name": "Group A"}},
+        {"id": 2, "name": "Sample 2", "status": "inactive", "groupingvar": {"name": "Group B"}},
+    ]
+
+
+class TestPerformQuery:
+    def test_perform_query_basic(self, mock_client, mock_console):
+        # Arrange
+        params = Params(endpoint="resource", query=[("status", "active")], columns=["id", "name"], limit=10)
+        mock_client.read.return_value = ResultContainer([{"id": 1, "name": "Test"}])
+
+        # Act
+        results = perform_query(params, mock_client, mock_console)
+
+        # Assert
+        mock_client.read.assert_called_once_with(endpoint="resource", obj={"status": "active"}, max_results=10)
+        assert len(results) == 1
+        assert results[0]["id"] == 1
+
+    def test_perform_query_multiple_values(self, mock_client, mock_console):
+        # Arrange
+        params = Params(
+            endpoint="resource", query=[("status", "active"), ("status", "pending")], columns=["id"], limit=10
+        )
+        mock_client.read.return_value = ResultContainer([{"id": 1, "status": "active"}, {"id": 2, "status": "pending"}])
+
+        # Act
+        results = perform_query(params, mock_client, mock_console)
+
+        # Assert
+        mock_client.read.assert_called_once_with(
+            endpoint="resource", obj={"status": ["active", "pending"]}, max_results=10
+        )
+        assert len(results) == 2
+
+
+class TestRenderOutput:
+    def test_render_json_output(self, mocker, sample_results):
+        # Arrange
+        params = Params(endpoint="resource", columns=["id", "name"], format=OutputFormat.JSON)
+
+        # Act
+        output = render_output(sample_results, params, mocker.Mock(), mocker.Mock())
+
+        # Assert
+        parsed = json.loads(output)
+        assert len(parsed) == 2
+        assert all(set(item.keys()) == {"id", "name"} for item in parsed)
+
+    def test_render_yaml_output(self, mocker, sample_results):
+        # Arrange
+        params = Params(endpoint="resource", columns=["id", "name"], format=OutputFormat.YAML)
+
+        # Act
+        output = render_output(sample_results, params, mocker.Mock(), mocker.Mock())
+
+        # Assert
+        parsed = yaml.safe_load(output)
+        assert len(parsed) == 2
+        assert all(set(item.keys()) == {"id", "name"} for item in parsed)
+
+    def test_render_tsv_output(self, sample_results, mocker):
+        # Arrange
+        params = Params(endpoint="resource", columns=["id", "name"], format=OutputFormat.TSV)
+        mock_flatten = mocker.patch("bfabric_scripts.cli.api.cli_api_read.flatten_relations")
+        mock_df = mocker.Mock()
+        mock_flatten.return_value = mock_df
+
+        # Act
+        render_output(sample_results, params, mocker.Mock(), mocker.Mock())
+
+        # Assert
+        mock_flatten.assert_called_once()
+        mock_df.write_csv.assert_called_once_with(separator="\t")
+
+
+class TestDetermineOutputColumns:
+    def test_determine_output_columns_with_specified_columns(self):
+        # Arrange
+        results = [{"id": 1, "name": "Test", "status": "active"}]
+        specified_columns = ["id", "name"]
+
+        # Act
+        columns = _determine_output_columns(
+            results=results, columns=specified_columns, max_columns=7, output_format=OutputFormat.TABLE_RICH
+        )
+
+        # Assert
+        assert columns == ["id", "name"]
+
+    def test_determine_output_columns_with_max_columns(self):
+        # Arrange
+        results = [{"id": 1, "name": "Test", "status": "active", "type": "sample"}]
+
+        # Act
+        columns = _determine_output_columns(
+            results=results, columns=None, max_columns=2, output_format=OutputFormat.TABLE_RICH
+        )
+
+        # Assert
+        assert len(columns) == 3  # id + 2 more columns
+        assert "id" in columns
+
+    def test_determine_output_columns_invalid_max_columns(self):
+        # Arrange
+        results = [{"id": 1, "name": "Test"}]
+
+        # Act/Assert
+        with pytest.raises(ValueError, match="max_columns must be at least 1"):
+            _determine_output_columns(
+                results=results, columns=None, max_columns=0, output_format=OutputFormat.TABLE_RICH
+            )
+
+
+class TestReadFunction:
+    def test_read_json_output(self, mock_client, mock_console, sample_results, mocker):
+        # Arrange
+        mock_perform_query = mocker.patch("bfabric_scripts.cli.api.cli_api_read.perform_query")
+        mock_perform_query.return_value = sample_results
+
+        params = Params(
+            endpoint="resource", columns=["id", "name"], format=OutputFormat.JSON, query=[("status", "active")]
+        )
+
+        # Act
+        result = read(params, client=mock_client)
+
+        # Assert
+        mock_perform_query.assert_called_once_with(params=params, client=mock_client, console_user=mocker.ANY)
+        assert result is None  # Function should return None on success
+
+    def test_read_with_file_output(self, mock_client, mock_console, sample_results, mocker, tmp_path):
+        # Arrange
+        output_file = tmp_path / "test_output.json"
+        mock_perform_query = mocker.patch("bfabric_scripts.cli.api.cli_api_read.perform_query")
+        mock_perform_query.return_value = sample_results
+
+        params = Params(
+            endpoint="resource",
+            columns=["id", "name"],
+            format=OutputFormat.JSON,
+            query=[("status", "active")],
+            file=output_file,
+        )
+
+        # Act
+        result = read(params, client=mock_client)
+
+        # Assert
+        assert result is None
+        assert output_file.exists()
+        content = output_file.read_text()
+        parsed_content = json.loads(content)
+        assert len(parsed_content) == len(sample_results)
+        assert all(set(item.keys()) == {"id", "name"} for item in parsed_content)
+
+    def test_read_with_tsv_format(self, mock_client, mock_console, sample_results, mocker):
+        # Arrange
+        mock_perform_query = mocker.patch("bfabric_scripts.cli.api.cli_api_read.perform_query")
+        mock_perform_query.return_value = sample_results
+        mock_flatten = mocker.patch("bfabric_scripts.cli.api.cli_api_read.flatten_relations")
+        mock_df = mocker.Mock()
+        mock_df.write_csv.return_value = "mocked,csv,content"
+        mock_flatten.return_value = mock_df
+
+        params = Params(
+            endpoint="resource", columns=["id", "name"], format=OutputFormat.TSV, query=[("status", "active")]
+        )
+
+        # Act
+        result = read(params, client=mock_client)
+
+        # Assert
+        mock_perform_query.assert_called_once()
+        mock_flatten.assert_called_once()
+        mock_df.write_csv.assert_called_once_with(separator="\t")
+        assert result is None
+
+    def test_read_with_invalid_file_output(self, mock_client, mock_console, sample_results, mocker):
+        # Arrange
+        mock_perform_query = mocker.patch("bfabric_scripts.cli.api.cli_api_read.perform_query")
+        mock_perform_query.return_value = sample_results
+
+        # Using TABLE_RICH format which doesn't support file output
+        params = Params(
+            endpoint="resource",
+            columns=["id", "name"],
+            format=OutputFormat.TABLE_RICH,
+            query=[("status", "active")],
+            file=Path("test_output.txt"),
+        )
+
+        # Act
+        result = read(params, client=mock_client)
+
+        # Assert
+        assert result == 1  # Should return error code 1


### PR DESCRIPTION
This improves the command in several ways:

- Removes the automatic output type
- Multiple values can be submitted for the same key
- The query will be printed as a line of bfabricPy code
- `--file` parameter to write the output to a specific file
- Argument parsing is handled with pydantic now
- Added tsv support