### PR TITLE
Add `api update` command

### DIFF
--- a/bfabric_scripts/doc/changelog.md
+++ b/bfabric_scripts/doc/changelog.md
@@ -14,6 +14,10 @@ Versioning currently follows `X.Y.Z` where
 
 - Add missing default value for columns in `bfabric-cli api read`
 
+### Added
+
+- `bfabric-cli api update` command to update an existing entity
+
 ## \[1.13.20\] - 2025-02-10
 
 ### Added

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
@@ -101,7 +101,7 @@ def render_output(results: list[dict[str, Any]], params: Params, client: Bfabric
 
 @app.default
 @use_client
-@logger.catch()
+@logger.catch(reraise=True)
 def read(params: Annotated[Params, cyclopts.Parameter(name="*")], *, client: Bfabric) -> None | int:
     """Reads one type of entity from B-Fabric."""
     console_user = Console(stderr=True)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_update.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_update.py
@@ -1,0 +1,70 @@
+import cyclopts
+import rich
+import rich.prompt
+from cyclopts import Parameter
+from loguru import logger
+from pydantic import BaseModel
+from rich.panel import Panel
+from rich.pretty import Pretty, pprint
+
+from bfabric import Bfabric
+from bfabric.utils.cli_integration import use_client
+
+app = cyclopts.App()
+
+
+@Parameter(name="*")
+class Params(BaseModel):
+    endpoint: str
+    """Endpoint to update, e.g. 'resource'."""
+    entity_id: int
+    """ID of the entity to update."""
+    attributes: list[tuple[str, str]] | None = None
+    """List of attribute-value pairs to update the entity with."""
+    no_confirm: bool = False
+    """If set, the update will be performed without asking for confirmation."""
+
+
+@app.default
+@use_client
+@logger.catch(reraise=True)
+def update(params: Params, *, client: Bfabric) -> None:
+    """Updates an existing entity in B-Fabric."""
+    attributes_dict = _sanitize_attributes(params.attributes, params.entity_id)
+    if not attributes_dict:
+        return
+
+    if not params.no_confirm:
+        if not _confirm_action(attributes_dict, client, params.endpoint, params.entity_id):
+            return
+
+    result = client.save(params.endpoint, {"id": params.entity_id, **attributes_dict})
+    pprint(result)
+
+
+def _confirm_action(attributes_dict: dict[str, str], client: Bfabric, endpoint: str, entity_id: int) -> bool:
+    logger.info(f"Updating {endpoint} entity with ID {entity_id} with attributes {attributes_dict}")
+    result_read = client.read(endpoint, {"id": entity_id}, max_results=1)
+    if not result_read:
+        raise ValueError(f"No entity found with ID {entity_id}")
+    rich.print(Panel.fit(Pretty(result_read[0], expand_all=False), title="Existing entity"))
+    rich.print(Panel.fit(Pretty(attributes_dict, expand_all=False), title="Updates"))
+    if not rich.prompt.Confirm.ask("Do you want to proceed with the update?"):
+        logger.info("Update cancelled by user.")
+        return False
+    return True
+
+
+def _sanitize_attributes(attributes: list[tuple[str, str]] | None, entity_id: int) -> dict[str, str] | None:
+    if not attributes:
+        logger.warning("No attributes provided, doing nothing.")
+        return None
+
+    attributes_dict = {attribute: value for attribute, value in attributes}
+    if "id" in attributes_dict:
+        if int(attributes_dict["id"]) == entity_id:
+            logger.warning("Attribute 'id' is not allowed in the attributes, removing it.")
+            del attributes_dict["id"]
+        else:
+            raise ValueError("Attribute 'id' must match the entity_id")
+    return attributes_dict

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_update.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_update.py
@@ -39,6 +39,7 @@ def update(params: Params, *, client: Bfabric) -> None:
             return
 
     result = client.save(params.endpoint, {"id": params.entity_id, **attributes_dict})
+    logger.info(f"Entity with ID {params.entity_id} updated successfully.")
     pprint(result)
 
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/cli_api.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/cli_api.py
@@ -3,8 +3,10 @@ import cyclopts
 from bfabric_scripts.cli.api.cli_api_log import cmd as _cmd_log
 from bfabric_scripts.cli.api.cli_api_read import app as _cmd_read
 from bfabric_scripts.cli.api.cli_api_save import app as _cmd_save
+from bfabric_scripts.cli.api.cli_api_update import app as _cmd_update
 
 app = cyclopts.App()
 app.command(_cmd_log, name="log")
 app.command(_cmd_read, name="read")
+app.command(_cmd_update, name="update")
 app.command(_cmd_save, name="save")


### PR DESCRIPTION
This will supersede the `api save` command which always directly wrote. It will also be more clear that if we add a `create` later. I think for the command line tools it's better to be more explicit about create vs update, to prevent user errors when the `id` is present or absent accidentally.

When using in scripts `--no-confirm` can be specified whereas it should prevent some more obvious problems when someone less experienced uses these scripts.