### PR TITLE
bfabric-scripts 1.13.21

### DIFF
--- a/bfabric_scripts/doc/changelog.md
+++ b/bfabric_scripts/doc/changelog.md
@@ -10,6 +10,10 @@ Versioning currently follows `X.Y.Z` where
 
 ## \[Unreleased\]
 
+### Fixed
+
+- Add missing default value for columns in `bfabric-cli api read`
+
 ## \[1.13.20\] - 2025-02-10
 
 ### Added

--- a/bfabric_scripts/doc/changelog.md
+++ b/bfabric_scripts/doc/changelog.md
@@ -10,6 +10,8 @@ Versioning currently follows `X.Y.Z` where
 
 ## \[Unreleased\]
 
+## \[1.13.21\] - 2025-02-11
+
 ### Fixed
 
 - Add missing default value for columns in `bfabric-cli api read`

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bfabric_scripts"
 description = "Python command line scripts for the B-Fabric API"
-version = "1.13.20"
+version = "1.13.21"
 
 dependencies = [
     "bfabric==1.13.20"

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/cli_api_read.py
@@ -36,7 +36,7 @@ class Params(BaseModel):
     """Output format."""
     limit: int = 100
     """Maximum number of results."""
-    columns: list[str]
+    columns: list[str] = []
     """Selection of columns to return, comma separated list."""
     cli_max_columns: int | None = 7
     """When showing the results as a table in the console (table-rich), the maximum number of columns to show."""

--- a/tests/bfabric_cli/test_cli_api_read.py
+++ b/tests/bfabric_cli/test_cli_api_read.py
@@ -39,14 +39,14 @@ def sample_results():
 class TestPerformQuery:
     def test_perform_query_basic(self, mock_client, mock_console):
         # Arrange
-        params = Params(endpoint="resource", query=[("status", "active")], columns=["id", "name"], limit=10)
+        params = Params(endpoint="resource", query=[("status", "active")])
         mock_client.read.return_value = ResultContainer([{"id": 1, "name": "Test"}])
 
         # Act
         results = perform_query(params, mock_client, mock_console)
 
         # Assert
-        mock_client.read.assert_called_once_with(endpoint="resource", obj={"status": "active"}, max_results=10)
+        mock_client.read.assert_called_once_with(endpoint="resource", obj={"status": "active"}, max_results=100)
         assert len(results) == 1
         assert results[0]["id"] == 1
 


### PR DESCRIPTION
### Fixed

- Add missing default value for columns in `bfabric-cli api read`
