### PR TITLE
Restore compatibility with cyclopts

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The workunit makefile now directly shows how to use the GitHub app runner version instead, which is sometimes required
     while debugging.
 
+### Fixed
+
+- Use most recent cyclopts version again, i.e. [issue 168](https://github.com/fgcz/bfabricPy/issues/168) is fixed.
+
 ## \[0.0.21\] - 2025-03-27
 
 ### Added

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "bfabric==1.13.24",
-    "cyclopts>=3.11.0",
+    "cyclopts>=3.13.0",
     "pydantic",
     "glom",
     "mako",

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "bfabric==1.13.23",
-    "cyclopts >= 3.8.0",
+    "cyclopts>=3.11.0",
     "pydantic",
     "glom",
     "mako",

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -13,8 +13,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "bfabric==1.13.23",
-    # TODO(leo): https://github.com/fgcz/bfabricPy/issues/168
-    "cyclopts >= 3.8.0,<3.11.0",
+    "cyclopts >= 3.8.0",
     "pydantic",
     "glom",
     "mako",

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -14,6 +14,10 @@ Versioning currently follows `X.Y.Z` where
 
 - Remove `bfabric-cli api save` -> use `bfabric-cli api create` and `bfabric-cli api update` instead.
 
+### Fixed
+
+- Use most recent cyclopts version again, i.e. [issue 168](https://github.com/fgcz/bfabricPy/issues/168) is fixed.
+
 ## \[1.13.25\] - 2025-03-27
 
 ### Fixed

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -9,8 +9,7 @@ version = "1.13.25"
 
 dependencies = [
     "bfabric==1.13.22",
-    # TODO(leo): https://github.com/fgcz/bfabricPy/issues/168
-    "cyclopts >= 3.8.0,<3.11.0",
+    "cyclopts >= 3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -9,7 +9,7 @@ version = "1.13.25"
 
 dependencies = [
     "bfabric==1.13.22",
-    "cyclopts >= 3.8.0",
+    "cyclopts>=3.11.0",
 ]
 
 [project.optional-dependencies]

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -9,7 +9,7 @@ version = "1.13.26"
 
 dependencies = [
     "bfabric==1.13.24",
-    "cyclopts>=3.11.0",
+    "cyclopts>=3.13.0",
 ]
 
 [project.optional-dependencies]

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
@@ -6,6 +6,7 @@ from rich.pretty import pprint
 
 from bfabric import Bfabric
 from bfabric.utils.cli_integration import use_client
+from bfabric_scripts.cli.api.query_repr import Query
 
 app = cyclopts.App()
 
@@ -14,7 +15,7 @@ app = cyclopts.App()
 class Params(BaseModel):
     endpoint: str
     """Endpoint to update, e.g. 'resource'."""
-    attributes: list[tuple[str, str]] | None = Field(min_length=1)
+    attributes: Query | None = Field(min_length=1)
     """List of attribute-value pairs to update the entity with."""
 
     @field_validator("attributes")
@@ -31,7 +32,7 @@ class Params(BaseModel):
 @logger.catch(reraise=True)
 def cmd_api_create(params: Params, *, client: Bfabric) -> None:
     """Creates a new entity in B-Fabric."""
-    attributes_dict = {attribute: value for attribute, value in params.attributes}
+    attributes_dict = params.attributes.to_dict(duplicates="error")
     result = client.save(params.endpoint, attributes_dict)
     logger.info(f"{params.endpoint} entity with ID {result[0]['id']} created successfully.")
     pprint(result)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
@@ -1,7 +1,7 @@
 import cyclopts
 from cyclopts import Parameter
 from loguru import logger
-from pydantic import BaseModel, field_validator, Field
+from pydantic import BaseModel, field_validator
 from rich.pretty import pprint
 
 from bfabric import Bfabric
@@ -15,7 +15,7 @@ app = cyclopts.App()
 class Params(BaseModel):
     endpoint: str
     """Endpoint to update, e.g. 'resource'."""
-    attributes: Query | None = Field(min_length=1)
+    attributes: Query
     """List of attribute-value pairs to update the entity with."""
 
     @field_validator("attributes")

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -39,16 +39,14 @@ class Query(RootModel):
 
     def to_dict(self, duplicates: Literal["drop", "error", "collect"]) -> dict[str, str] | dict[str, list[str]]:
         """Convert the query to a dictionary."""
-        if duplicates == "drop":
-            return dict(self.root)
-        collect: dict[str, list[str]] = defaultdict(list)
-        for key, value in self.root:
-            collect[key].append(value)
-        if duplicates == "collect":
-            return dict(collect)
-        # raise error on duplicates
-        if len(collect) != len(self.root):
-            duplicate_keys = [key for key, values in collect.items() if len(values) > 1]
-            msg = f"Duplicate keys found in query: {duplicate_keys}"
-            raise ValueError(msg)
+        if duplicates == "collect" or duplicates == "reject":
+            collect: dict[str, list[str]] = defaultdict(list)
+            for key, value in self.root:
+                collect[key].append(value)
+            if duplicates == "collect":
+                return dict(collect)
+            if duplicates == "reject" and len(collect) != len(self.root):
+                duplicate_keys = [key for key, values in collect.items() if len(values) > 1]
+                msg = f"Duplicate keys found in query: {duplicate_keys}"
+                raise ValueError(msg)
         return dict(self.root)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -1,36 +1,40 @@
+import copy
 from collections import defaultdict
 from typing import Any, Literal, overload
 
-from pydantic import RootModel, field_validator
+from pydantic import BaseModel, model_validator
 
 
-class Query(RootModel):
+class Query(BaseModel):
     """
     A model for handling key-value query parameters.
     Validates and converts flat lists to key-value pairs.
     """
 
-    root: list[tuple[str, str]]
+    pairs: list[tuple[str, str]] = []
 
-    @field_validator("root", mode="before")
+    @staticmethod
+    def _convert_flat_list_to_pairs(flat_list: list) -> list[tuple[str, str]]:
+        """Convert a flat list to key-value pairs."""
+        if flat_list and isinstance(flat_list[0], tuple):
+            return flat_list
+        if len(flat_list) % 2 != 0:
+            msg = f"Query must have an even number of elements (key/value pairs), got {len(flat_list)}"
+            raise ValueError(msg)
+        return [(flat_list[i], flat_list[i + 1]) for i in range(0, len(flat_list), 2)]
+
+    @model_validator(mode="before")
     @classmethod
-    def validate_query(cls, value: Any) -> list[tuple[str, str]]:
-        """Transform a flat list input into pairs."""
-        if isinstance(value, list):
-            # Check if it's already a list of tuples
-            if value and isinstance(value[0], tuple):
-                return value
-
-            # Handle flat list format
-            if len(value) % 2 != 0:
-                msg = f"Query must have an even number of elements (key/value pairs), got {len(value)}"
-                raise ValueError(msg)
-            return [(value[i], value[i + 1]) for i in range(0, len(value), 2)]
-        return value
+    def validate_query(cls, data: Any) -> Any:
+        if isinstance(data, list):
+            return {"pairs": cls._convert_flat_list_to_pairs(data)}
+        if isinstance(data, dict) and "pairs" in data:
+            return {"pairs": cls._convert_flat_list_to_pairs(data["pairs"])}
+        return data
 
     def drop_key_inplace(self, key: str) -> None:
         """Remove all instances of the specified key."""
-        self.root = [(k, v) for k, v in self.root if k != key]
+        self.pairs = [(k, v) for k, v in self.pairs if k != key]
 
     @overload
     def to_dict(self, duplicates: Literal["drop"]) -> dict[str, str]: ...
@@ -45,12 +49,12 @@ class Query(RootModel):
         """Convert the query to a dictionary."""
         if duplicates == "collect" or duplicates == "error":
             collect: dict[str, list[str]] = defaultdict(list)
-            for key, value in self.root:
+            for key, value in self.pairs:
                 collect[key].append(value)
             if duplicates == "collect":
                 return {key: (values[0] if len(values) == 1 else values) for key, values in collect.items()}
-            if duplicates == "error" and len(collect) != len(self.root):
+            if duplicates == "error" and len(collect) != len(self.pairs):
                 duplicate_keys = [key for key, values in collect.items() if len(values) > 1]
                 msg = f"Duplicate keys found in query: {duplicate_keys}"
                 raise ValueError(msg)
-        return dict(self.root)
+        return dict(self.pairs)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -28,6 +28,10 @@ class Query(RootModel):
             return [(value[i], value[i + 1]) for i in range(0, len(value), 2)]
         return value
 
+    def drop_key_inplace(self, key: str) -> None:
+        """Remove all instances of the specified key."""
+        self.root = [(k, v) for k, v in self.root if k != key]
+
     @overload
     def to_dict(self, duplicates: Literal["drop"]) -> dict[str, str]: ...
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -1,0 +1,32 @@
+from typing import Any, Dict, List, Tuple
+
+from pydantic import RootModel, field_validator
+
+
+class Query(RootModel):
+    """
+    A model for handling key-value query parameters.
+    Validates and converts flat lists to key-value pairs.
+    """
+
+    root: List[Tuple[str, str]]
+
+    @field_validator("root", mode="before")
+    @classmethod
+    def validate_query(cls, value: Any) -> List[Tuple[str, str]]:
+        """Transform a flat list input into pairs."""
+        if isinstance(value, list):
+            # Check if it's already a list of tuples
+            if value and isinstance(value[0], tuple):
+                return value
+
+            # Handle flat list format
+            if len(value) % 2 != 0:
+                msg = f"Query must have an even number of elements (key/value pairs), got {len(value)}"
+                raise ValueError(msg)
+            return [(value[i], value[i + 1]) for i in range(0, len(value), 2)]
+        return value
+
+    def to_dict(self) -> Dict[str, str]:
+        """Convert the query to a dictionary."""
+        return dict(self.root)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Tuple
+from collections import defaultdict
+from typing import Any, Literal, overload
 
 from pydantic import RootModel, field_validator
 
@@ -9,11 +10,11 @@ class Query(RootModel):
     Validates and converts flat lists to key-value pairs.
     """
 
-    root: List[Tuple[str, str]]
+    root: list[tuple[str, str]]
 
     @field_validator("root", mode="before")
     @classmethod
-    def validate_query(cls, value: Any) -> List[Tuple[str, str]]:
+    def validate_query(cls, value: Any) -> list[tuple[str, str]]:
         """Transform a flat list input into pairs."""
         if isinstance(value, list):
             # Check if it's already a list of tuples
@@ -27,6 +28,27 @@ class Query(RootModel):
             return [(value[i], value[i + 1]) for i in range(0, len(value), 2)]
         return value
 
-    def to_dict(self) -> Dict[str, str]:
+    @overload
+    def to_dict(self, duplicates: Literal["drop"]) -> dict[str, str]: ...
+
+    @overload
+    def to_dict(self, duplicates: Literal["collect"]) -> dict[str, list[str]]: ...
+
+    @overload
+    def to_dict(self, duplicates: Literal["error"]) -> dict[str, str]: ...
+
+    def to_dict(self, duplicates: Literal["drop", "error", "collect"]) -> dict[str, str] | dict[str, list[str]]:
         """Convert the query to a dictionary."""
+        if duplicates == "drop":
+            return dict(self.root)
+        collect: dict[str, list[str]] = defaultdict(list)
+        for key, value in self.root:
+            collect[key].append(value)
+        if duplicates == "collect":
+            return dict(collect)
+        # raise error on duplicates
+        if len(collect) != len(self.root):
+            duplicate_keys = [key for key, values in collect.items() if len(values) > 1]
+            msg = f"Duplicate keys found in query: {duplicate_keys}"
+            raise ValueError(msg)
         return dict(self.root)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -1,4 +1,3 @@
-import copy
 from collections import defaultdict
 from typing import Any, Literal, overload
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
@@ -51,7 +51,7 @@ class Params(BaseModel):
 
 def perform_query(params: Params, client: Bfabric, console_user: Console) -> list[dict[str, Any]]:
     """Performs the query and returns the results."""
-    query = params.query.to_dict()
+    query = params.query.to_dict(duplicates="collect")
     query_stmt = f"client.read(endpoint={params.endpoint!r}, obj={query!r}, max_results={params.limit!r})"
     results = eval(query_stmt)
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
@@ -29,7 +29,7 @@ class OutputFormat(Enum):
 class Params(BaseModel):
     endpoint: str
     """Endpoint to query, e.g. 'resource'."""
-    query: Query = []
+    query: Query = Query()
     """List of attribute-value pairs to filter the results by."""
     format: OutputFormat = OutputFormat.TABLE_RICH
     """Output format."""

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
@@ -1,5 +1,4 @@
 import json
-from collections import defaultdict
 from enum import Enum
 from pathlib import Path
 from typing import Any, Annotated

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
@@ -17,7 +17,7 @@ class Params(BaseModel):
     """Endpoint to update, e.g. 'resource'."""
     entity_id: int
     """ID of the entity to update."""
-    attributes: Query | None = None
+    attributes: Query
     """List of attribute-value pairs to update the entity with."""
     no_confirm: bool = False
     """If set, the update will be performed without asking for confirmation."""

--- a/tests/bfabric_cli/test_cli_api_read.py
+++ b/tests/bfabric_cli/test_cli_api_read.py
@@ -221,7 +221,7 @@ class TestReadFunction:
             endpoint="resource",
             columns=["id", "name"],
             format=OutputFormat.TABLE_RICH,
-            query=[("status", "active")],
+            query=["status", "active"],
             file=Path("test_output.txt"),
         )
 

--- a/tests/bfabric_cli/test_query_repr.py
+++ b/tests/bfabric_cli/test_query_repr.py
@@ -1,0 +1,36 @@
+import pytest
+
+from bfabric_scripts.cli.api.query_repr import Query
+
+
+@pytest.fixture
+def input_without_duplicates():
+    return ["a", "x", "b", "y", "c", "z"]
+
+
+@pytest.fixture
+def input_with_duplicates():
+    return ["a", "x", "b", "y", "a", "z"]
+
+
+@pytest.mark.parametrize("duplicates_method", ["drop", "collect", "error"])
+def test_to_dict_when_no_duplicates(input_without_duplicates, duplicates_method):
+    query = Query(input_without_duplicates)
+    assert query.to_dict(duplicates_method) == {"a": "x", "b": "y", "c": "z"}
+
+
+def test_to_dict_when_duplicates_drop(input_with_duplicates):
+    query = Query(input_with_duplicates)
+    assert query.to_dict("drop") == {"a": "z", "b": "y"}
+
+
+def test_to_dict_when_duplicates_collect(input_with_duplicates):
+    query = Query(input_with_duplicates)
+    assert query.to_dict("collect") == {"a": ["x", "z"], "b": "y"}
+
+
+def test_to_dict_when_duplicates_error(input_with_duplicates):
+    query = Query(input_with_duplicates)
+    with pytest.raises(ValueError) as error:
+        query.to_dict("error")
+    assert "Duplicate keys found in query: ['a']" in str(error.value)

--- a/tests/bfabric_cli/test_query_repr.py
+++ b/tests/bfabric_cli/test_query_repr.py
@@ -34,3 +34,9 @@ def test_to_dict_when_duplicates_error(input_with_duplicates):
     with pytest.raises(ValueError) as error:
         query.to_dict("error")
     assert "Duplicate keys found in query: ['a']" in str(error.value)
+
+
+def test_drop_key_inplace(input_without_duplicates):
+    query = Query(input_without_duplicates)
+    query.drop_key_inplace("b")
+    assert query.root == [("a", "x"), ("c", "z")]

--- a/tests/bfabric_cli/test_query_repr.py
+++ b/tests/bfabric_cli/test_query_repr.py
@@ -15,28 +15,28 @@ def input_with_duplicates():
 
 @pytest.mark.parametrize("duplicates_method", ["drop", "collect", "error"])
 def test_to_dict_when_no_duplicates(input_without_duplicates, duplicates_method):
-    query = Query(input_without_duplicates)
+    query = Query.model_validate(input_without_duplicates)
     assert query.to_dict(duplicates_method) == {"a": "x", "b": "y", "c": "z"}
 
 
 def test_to_dict_when_duplicates_drop(input_with_duplicates):
-    query = Query(input_with_duplicates)
+    query = Query.model_validate(input_with_duplicates)
     assert query.to_dict("drop") == {"a": "z", "b": "y"}
 
 
 def test_to_dict_when_duplicates_collect(input_with_duplicates):
-    query = Query(input_with_duplicates)
+    query = Query.model_validate(input_with_duplicates)
     assert query.to_dict("collect") == {"a": ["x", "z"], "b": "y"}
 
 
 def test_to_dict_when_duplicates_error(input_with_duplicates):
-    query = Query(input_with_duplicates)
+    query = Query.model_validate(input_with_duplicates)
     with pytest.raises(ValueError) as error:
         query.to_dict("error")
     assert "Duplicate keys found in query: ['a']" in str(error.value)
 
 
 def test_drop_key_inplace(input_without_duplicates):
-    query = Query(input_without_duplicates)
+    query = Query.model_validate(input_without_duplicates)
     query.drop_key_inplace("b")
-    assert query.root == [("a", "x"), ("c", "z")]
+    assert query.pairs == [("a", "x"), ("c", "z")]


### PR DESCRIPTION
Fixes #168 

This introduces proper validation for the query type parameters.
A benefit of this is that it becomes a lot more transparent what was actually passed.
And, it restores compatibility with upstream cyclopts.

Very basic integration tests have been added in in the integration test repository for the affected commands.