### PR TITLE
add `CommandExec`

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `static_file` input spec type has been integrated properly.
 - The workunit makefile now directly shows how to use the GitHub app runner version instead, which is sometimes required
     while debugging.
+- `CommandExec` allows prepending paths to `PATH` and setting environment variables and is less ambiguous than `shell`.
 
 ### Changed
 

--- a/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
@@ -26,8 +26,9 @@ class Runner:
 
     def run_dispatch(self, workunit_ref: int | Path, work_dir: Path) -> None:
         command = [*self._app_version.commands.dispatch.to_shell(), str(workunit_ref), str(work_dir)]
+        env = self._app_version.commands.dispatch.to_shell_env()
         logger.info(f"Running dispatch command: {shlex.join(command)}")
-        subprocess.run(command, check=True)
+        subprocess.run(command, check=True, env=env)
 
     def run_prepare_input(self, chunk_dir: Path) -> None:
         prepare_folder(
@@ -41,15 +42,17 @@ class Runner:
     def run_collect(self, workunit_ref: int | Path, chunk_dir: Path) -> None:
         if self._app_version.commands.collect is not None:
             command = [*self._app_version.commands.collect.to_shell(), str(workunit_ref), str(chunk_dir)]
+            env = self._app_version.commands.collect.to_shell_env()
             logger.info(f"Running collect command: {shlex.join(command)}")
-            subprocess.run(command, check=True)
+            subprocess.run(command, check=True, env=env)
         else:
             logger.info("App does not have a collect step.")
 
     def run_process(self, chunk_dir: Path) -> None:
         command = [*self._app_version.commands.process.to_shell(), str(chunk_dir)]
+        env = self._app_version.commands.process.to_shell_env()
         logger.info(f"Running process command: {shlex.join(command)}")
-        subprocess.run(command, check=True)
+        subprocess.run(command, check=True, env=env)
 
 
 class ChunksFile(BaseModel):

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
@@ -16,12 +16,6 @@ class CommandShell(BaseModel):
     command: str
     """The command to run, will be split by spaces and is not an actual shell script."""
 
-    env: dict[str, str] = {}
-    """Environment variables to set before executing the command."""
-
-    prepend_paths: list[Path] = []
-    """A list of paths to prepend to the PATH variable before executing the command."""
-
     def to_shell(self) -> list[str]:
         """Returns a shell command that can be used to run the specified command."""
         return shlex.split(self.command)

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
@@ -38,7 +38,10 @@ class CommandExec(BaseModel):
     """Environment variables to set before executing the command."""
 
     prepend_paths: list[Path] = []
-    """A list of paths to prepend to the PATH variable before executing the command."""
+    """A list of paths to prepend to the PATH variable before executing the command.
+
+    If multiple paths are specified, the first one will be the first in PATH, etc.
+    """
 
     def to_shell(self) -> list[str]:
         """Returns a shell command that can be used to run the specified command."""

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
@@ -9,16 +9,64 @@ from pydantic import BaseModel, Discriminator, ConfigDict
 class CommandShell(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    # TODO: proposal, this should be renamed, and then we could introduce e.g. "bash" to be less confusing.
+    # TODO: Now deprecated by exec type - we can add a "bash" type later, if needed
     type: Literal["shell"] = "shell"
     """Identifies the command type."""
 
     command: str
     """The command to run, will be split by spaces and is not an actual shell script."""
 
+    env: dict[str, str] = {}
+    """Environment variables to set before executing the command."""
+
+    prepend_paths: list[Path] = []
+    """A list of paths to prepend to the PATH variable before executing the command."""
+
     def to_shell(self) -> list[str]:
         """Returns a shell command that can be used to run the specified command."""
         return shlex.split(self.command)
+
+    def to_shell_env(self, environ: dict[str, str] | None) -> dict[str, str]:
+        """Returns the shell environment variables to set before executing the command."""
+        return environ if environ is not None else os.environ.copy()
+
+
+class CommandExec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["exec"] = "exec"
+    """Identifies the command type."""
+
+    command: str
+    """The command to run, will be split by `shlex.split` and is not an actual shell script."""
+
+    env: dict[str, str] = {}
+    """Environment variables to set before executing the command."""
+
+    prepend_paths: list[Path] = []
+    """A list of paths to prepend to the PATH variable before executing the command."""
+
+    def to_shell(self) -> list[str]:
+        """Returns a shell command that can be used to run the specified command."""
+        return shlex.split(self.command)
+
+    def to_shell_env(self, environ: dict[str, str] | None) -> dict[str, str]:
+        """Returns the shell environment variables to set before executing the command."""
+        if environ is None:
+            environ = os.environ.copy()
+
+        if self.prepend_paths:
+            # Ensure environ['PATH'] is set
+            environ["PATH"] = environ.get("PATH", "")
+            # Prepend paths
+            for path in reversed(self.prepend_paths):
+                resolved_path = path.expanduser().absolute()
+                environ["PATH"] = f"{resolved_path}:{environ['PATH']}"
+
+        for key, value in self.env.items():
+            environ[key] = value
+
+        return environ
 
 
 class MountOptions(BaseModel):
@@ -109,8 +157,12 @@ class CommandDocker(BaseModel):
             *shlex.split(self.command),
         ]
 
+    def to_shell_env(self, environ: dict[str, str] | None = None) -> dict[str, str]:
+        """Returns the shell environment variables to set before executing the command."""
+        return environ if environ is not None else os.environ.copy()
 
-Command = Annotated[CommandShell | CommandDocker, Discriminator("type")]
+
+Command = Annotated[CommandShell | CommandExec | CommandDocker, Discriminator("type")]
 
 
 class CommandsSpec(BaseModel):

--- a/tests/bfabric_app_runner/app_runner/test_runner.py
+++ b/tests/bfabric_app_runner/app_runner/test_runner.py
@@ -12,6 +12,9 @@ class MockCommand(BaseModel):
     def to_shell(self) -> list[str]:
         return ["mock-command"]
 
+    def to_shell_env(self, environ=None) -> dict[str, str]:
+        return {"MOCK_ENV_VAR": "mock_value"}
+
 
 class MockCommands(BaseModel):
     dispatch: MockCommand = MockCommand()
@@ -87,7 +90,9 @@ def test_runner_run_dispatch(mocker, mock_app_version, mock_bfabric, tmp_path):
 
     runner.run_dispatch(workunit_ref, work_dir)
 
-    mock_run.assert_called_once_with(["mock-command", str(workunit_ref), str(work_dir)], check=True)
+    mock_run.assert_called_once_with(
+        ["mock-command", str(workunit_ref), str(work_dir)], check=True, env={"MOCK_ENV_VAR": "mock_value"}
+    )
 
 
 def test_runner_run_prepare_input(mocker, mock_app_version, mock_bfabric, tmp_path):
@@ -117,7 +122,7 @@ def test_runner_run_process(mocker, mock_app_version, mock_bfabric, tmp_path):
 
     runner.run_process(chunk_dir)
 
-    mock_run.assert_called_once_with(["mock-command", str(chunk_dir)], check=True)
+    mock_run.assert_called_once_with(["mock-command", str(chunk_dir)], check=True, env={"MOCK_ENV_VAR": "mock_value"})
 
 
 def test_run_app_full_workflow(mocker, mock_app_version, mock_bfabric, mock_workunit_definition, setup_work_dir):

--- a/tests/bfabric_app_runner/specs/app/test_commands_spec.py
+++ b/tests/bfabric_app_runner/specs/app/test_commands_spec.py
@@ -4,185 +4,182 @@ from pathlib import Path
 from bfabric_app_runner.specs.app.commands_spec import MountOptions, CommandDocker, CommandShell
 
 
-def test_mount_options_default_behavior(tmp_path):
-    """Test collect method with default settings"""
-    options = MountOptions()
-    work_dir = tmp_path / "work"
-    work_dir.mkdir()
+class TestMountOptions:
+    def test_default_behavior(self, tmp_path):
+        """Test collect method with default settings"""
+        options = MountOptions()
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
 
-    mounts = options.collect(work_dir)
+        mounts = options.collect(work_dir)
 
-    # Should have 2 default mounts: bfabric config and work dir
-    assert len(mounts) == 2
-    assert mounts[0] == (
-        Path("~/.bfabricpy.yml").expanduser().absolute(),
-        Path("/home/user/.bfabricpy.yml"),
-        True,
-    )
-    assert mounts[1] == (work_dir.absolute(), work_dir, False)
+        # Should have 2 default mounts: bfabric config and work dir
+        assert len(mounts) == 2
+        assert mounts[0] == (
+            Path("~/.bfabricpy.yml").expanduser().absolute(),
+            Path("/home/user/.bfabricpy.yml"),
+            True,
+        )
+        assert mounts[1] == (work_dir.absolute(), work_dir, False)
 
+    def test_with_custom_mounts(self, tmp_path):
+        """Test collect method with both read-only and writeable mounts"""
+        source_ro = tmp_path / "data"
+        source_ro.mkdir()
+        target_ro = Path("/container/data")
 
-def test_mount_options_with_custom_mounts(tmp_path):
-    """Test collect method with both read-only and writeable mounts"""
-    source_ro = tmp_path / "data"
-    source_ro.mkdir()
-    target_ro = Path("/container/data")
+        source_rw = tmp_path / "shared"
+        source_rw.mkdir()
+        target_rw = Path("/container/shared")
 
-    source_rw = tmp_path / "shared"
-    source_rw.mkdir()
-    target_rw = Path("/container/shared")
+        options = MountOptions(
+            read_only=[(source_ro, target_ro)],
+            writeable=[(source_rw, target_rw)],
+            share_bfabric_config=False,  # Disable bfabric to simplify test
+        )
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
 
-    options = MountOptions(
-        read_only=[(source_ro, target_ro)],
-        writeable=[(source_rw, target_rw)],
-        share_bfabric_config=False,  # Disable bfabric to simplify test
-    )
-    work_dir = tmp_path / "work"
-    work_dir.mkdir()
+        mounts = options.collect(work_dir)
 
-    mounts = options.collect(work_dir)
+        # Should have 3 mounts: work_dir, read-only, and writeable
+        assert len(mounts) == 3
+        assert mounts[0] == (work_dir.absolute(), work_dir, False)
+        assert mounts[1] == (source_ro.absolute(), target_ro, True)
+        assert mounts[2] == (source_rw.absolute(), target_rw, False)
 
-    # Should have 3 mounts: work_dir, read-only, and writeable
-    assert len(mounts) == 3
-    assert mounts[0] == (work_dir.absolute(), work_dir, False)
-    assert mounts[1] == (source_ro.absolute(), target_ro, True)
-    assert mounts[2] == (source_rw.absolute(), target_rw, False)
+    def test_path_expansion(self):
+        """Test that paths are properly expanded"""
+        options = MountOptions(
+            read_only=[(Path("~/data"), Path("/container/data"))],
+            share_bfabric_config=False,
+        )
+        work_dir = Path("/work")
 
+        mounts = options.collect(work_dir)
 
-def test_mount_options_path_expansion():
-    """Test that paths are properly expanded"""
-    options = MountOptions(
-        read_only=[(Path("~/data"), Path("/container/data"))],
-        share_bfabric_config=False,
-    )
-    work_dir = Path("/work")
-
-    mounts = options.collect(work_dir)
-
-    assert len(mounts) == 2
-    assert mounts[1][0] == Path("~/data").expanduser().absolute()
-    assert mounts[1][1] == Path("/container/data")
-    assert mounts[1][2] is True
-
-
-def test_command_shell_basic():
-    """Test basic shell command parsing"""
-    cmd = CommandShell(command="echo hello")
-    result = cmd.to_shell()
-    assert result == ["echo", "hello"]
+        assert len(mounts) == 2
+        assert mounts[1][0] == Path("~/data").expanduser().absolute()
+        assert mounts[1][1] == Path("/container/data")
+        assert mounts[1][2] is True
 
 
-def test_command_shell_with_quotes():
-    """Test shell command with quoted arguments"""
-    cmd = CommandShell(command='echo "hello world"')
-    result = cmd.to_shell()
-    assert result == ["echo", "hello world"]
+class TestCommandShell:
+    def test_basic(self):
+        """Test basic shell command parsing"""
+        cmd = CommandShell(command="echo hello")
+        result = cmd.to_shell()
+        assert result == ["echo", "hello"]
+
+    def test_with_quotes(self):
+        """Test shell command with quoted arguments"""
+        cmd = CommandShell(command='echo "hello world"')
+        result = cmd.to_shell()
+        assert result == ["echo", "hello world"]
+
+    def test_complex_command(self):
+        """Test complex shell command with multiple arguments and quotes"""
+        cmd = CommandShell(command="python3 -c \"import sys; print('Hello from Python')\" --verbose")
+        result = cmd.to_shell()
+        assert result == [
+            "python3",
+            "-c",
+            "import sys; print('Hello from Python')",
+            "--verbose",
+        ]
 
 
-def test_command_shell_complex_command():
-    """Test complex shell command with multiple arguments and quotes"""
-    cmd = CommandShell(command="python3 -c \"import sys; print('Hello from Python')\" --verbose")
-    result = cmd.to_shell()
-    assert result == [
-        "python3",
-        "-c",
-        "import sys; print('Hello from Python')",
-        "--verbose",
-    ]
+class TestCommandDocker:
+    def test_basic(self):
+        """Test basic docker command generation"""
+        cmd = CommandDocker(image="python:3.9", command="python script.py")
 
+        result = cmd.to_shell(Path("/work"))
 
-def test_command_docker_basic():
-    """Test basic docker command generation"""
-    cmd = CommandDocker(image="python:3.9", command="python script.py")
+        expected = [
+            "docker",
+            "run",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--rm",
+            "--mount",
+            "type=bind,source=/home/user/.bfabricpy.yml,target=/home/user/.bfabricpy.yml,readonly",
+            "--mount",
+            "type=bind,source=/work,target=/work",
+            "python:3.9",
+            "python",
+            "script.py",
+        ]
 
-    result = cmd.to_shell(Path("/work"))
+        # Replace actual home directory path with /home/user for test stability
+        result = [s.replace(str(Path.home()), "/home/user") for s in result]
+        assert result == expected
 
-    expected = [
-        "docker",
-        "run",
-        "--user",
-        f"{os.getuid()}:{os.getgid()}",
-        "--rm",
-        "--mount",
-        "type=bind,source=/home/user/.bfabricpy.yml,target=/home/user/.bfabricpy.yml,readonly",
-        "--mount",
-        "type=bind,source=/work,target=/work",
-        "python:3.9",
-        "python",
-        "script.py",
-    ]
+    def test_with_options(self, tmp_path):
+        """Test docker command generation with entrypoint, env vars, and custom args"""
+        cmd = CommandDocker(
+            image="ubuntu:latest",
+            command="echo 'hello'",
+            entrypoint="/bin/bash",
+            env={"DEBUG": "1", "PATH": "/usr/local/bin"},
+            mac_address="00:00:00:00:00:00",
+            custom_args=["--network=host"],
+            hostname="myhost",
+            mounts=MountOptions(share_bfabric_config=False),  # Disable bfabric mount for simpler testing
+        )
 
-    # Replace actual home directory path with /home/user for test stability
-    result = [s.replace(str(Path.home()), "/home/user") for s in result]
-    assert result == expected
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        result = cmd.to_shell(work_dir)
 
+        expected = [
+            "docker",
+            "run",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--rm",
+            "--mount",
+            f"type=bind,source={work_dir.absolute()},target={work_dir.absolute()}",
+            "--entrypoint",
+            "/bin/bash",
+            "--env",
+            "DEBUG=1",
+            "--env",
+            "PATH=/usr/local/bin",
+            "--mac-address",
+            "00:00:00:00:00:00",
+            "--network=host",
+            "--hostname",
+            "myhost",
+            "ubuntu:latest",
+            "echo",
+            "hello",
+        ]
 
-def test_command_docker_with_options(tmp_path):
-    """Test docker command generation with entrypoint, env vars, and custom args"""
-    cmd = CommandDocker(
-        image="ubuntu:latest",
-        command="echo 'hello'",
-        entrypoint="/bin/bash",
-        env={"DEBUG": "1", "PATH": "/usr/local/bin"},
-        mac_address="00:00:00:00:00:00",
-        custom_args=["--network=host"],
-        hostname="myhost",
-        mounts=MountOptions(share_bfabric_config=False),  # Disable bfabric mount for simpler testing
-    )
+        assert result == expected
 
-    work_dir = tmp_path / "work"
-    work_dir.mkdir()
-    result = cmd.to_shell(work_dir)
+    def test_with_complex_command(self):
+        """Test docker command generation with a complex command containing spaces and quotes"""
+        cmd = CommandDocker(
+            image="alpine:latest",
+            command="sh -c \"echo 'test with spaces' && ls -la\"",
+            mounts=MountOptions(share_bfabric_config=False),
+        )
 
-    expected = [
-        "docker",
-        "run",
-        "--user",
-        f"{os.getuid()}:{os.getgid()}",
-        "--rm",
-        "--mount",
-        f"type=bind,source={work_dir.absolute()},target={work_dir.absolute()}",
-        "--entrypoint",
-        "/bin/bash",
-        "--env",
-        "DEBUG=1",
-        "--env",
-        "PATH=/usr/local/bin",
-        "--mac-address",
-        "00:00:00:00:00:00",
-        "--network=host",
-        "--hostname",
-        "myhost",
-        "ubuntu:latest",
-        "echo",
-        "hello",
-    ]
+        result = cmd.to_shell(Path("/work"))
 
-    assert result == expected
+        expected = [
+            "docker",
+            "run",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--rm",
+            "--mount",
+            "type=bind,source=/work,target=/work",
+            "alpine:latest",
+            "sh",
+            "-c",
+            "echo 'test with spaces' && ls -la",
+        ]
 
-
-def test_command_docker_with_complex_command():
-    """Test docker command generation with a complex command containing spaces and quotes"""
-    cmd = CommandDocker(
-        image="alpine:latest",
-        command="sh -c \"echo 'test with spaces' && ls -la\"",
-        mounts=MountOptions(share_bfabric_config=False),
-    )
-
-    result = cmd.to_shell(Path("/work"))
-
-    expected = [
-        "docker",
-        "run",
-        "--user",
-        f"{os.getuid()}:{os.getgid()}",
-        "--rm",
-        "--mount",
-        "type=bind,source=/work,target=/work",
-        "alpine:latest",
-        "sh",
-        "-c",
-        "echo 'test with spaces' && ls -la",
-    ]
-
-    assert result == expected
+        assert result == expected


### PR DESCRIPTION
This will greatly simplify some things to adopt wheel-based deployment also it sets us up to remove the ill-named "shell" command type in the future.

I kind of want to add a wheel-based command, but if we can manage with a generic solution here then it is probably better to do it this way especially since it is so easy to integrate `uv` for this purpose.