### PR TITLE
Create .env file on app run

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The workunit makefile now directly shows how to use the GitHub app runner version instead, which is sometimes required
     while debugging.
 - `CommandExec` allows prepending paths to `PATH` and setting environment variables and is less ambiguous than `shell`.
+- `.env` is created when executing the app with `bfabric-app-runner app run` command, which sets the
+    `BFABRICPY_CONFIG_OVERRIDE` environment variable to ensure the correct config is used for future use.
 
 ### Changed
 

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Silence interpolate_config_strings log messages.
-- Update `bfabric` dependency to 1.13.24.
+- Update `bfabric` dependency to 1.13.26.
 
 ### Fixed
 

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "bfabric==1.13.24",
+    "bfabric==1.13.26",
     "cyclopts>=3.13.0",
     "pydantic",
     "glom",

--- a/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
@@ -29,6 +29,7 @@ class Runner:
         command = [*self._app_version.commands.dispatch.to_shell(), str(workunit_ref), str(work_dir)]
         env = self._app_version.commands.dispatch.to_shell_env(environ=os.environ)
         logger.info(f"Running dispatch command: {shlex.join(command)}")
+        logger.debug(f"Split command: {command!r}")
         subprocess.run(command, check=True, env=env)
 
     def run_prepare_input(self, chunk_dir: Path) -> None:
@@ -45,6 +46,7 @@ class Runner:
             command = [*self._app_version.commands.collect.to_shell(), str(workunit_ref), str(chunk_dir)]
             env = self._app_version.commands.collect.to_shell_env(environ=os.environ)
             logger.info(f"Running collect command: {shlex.join(command)}")
+            logger.debug(f"Split command: {command!r}")
             subprocess.run(command, check=True, env=env)
         else:
             logger.info("App does not have a collect step.")
@@ -53,6 +55,7 @@ class Runner:
         command = [*self._app_version.commands.process.to_shell(), str(chunk_dir)]
         env = self._app_version.commands.process.to_shell_env(environ=os.environ)
         logger.info(f"Running process command: {shlex.join(command)}")
+        logger.debug(f"Split command: {command!r}")
         subprocess.run(command, check=True, env=env)
 
 

--- a/bfabric_app_runner/src/bfabric_app_runner/resources/workunit.mk
+++ b/bfabric_app_runner/src/bfabric_app_runner/resources/workunit.mk
@@ -19,6 +19,11 @@
 #
 # Use `make help` to see all available commands
 
+ifneq (,$(wildcard .env))
+    include .env
+    export BFABRICPY_CONFIG_OVERRIDE
+endif
+
 # Configuration
 RUNNER_CMD := uv run -p 3.13 --with "bfabric-app-runner==@RUNNER_VERSION@" bfabric-app-runner
 # To use GitHub main branch instead uncomment the following line (and adapt as needed):


### PR DESCRIPTION
`.env` is created when executing the app with `bfabric-app-runner app run` command, which sets the
    `BFABRICPY_CONFIG_OVERRIDE` environment variable to ensure the correct config is used for future use.

Originally developed for #126