### PR TITLE
Better workunit params

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -15,6 +15,7 @@ Versioning currently follows `X.Y.Z` where
 - Attribute `Bfabric.config_data` to obtain a `ConfigData` object directly.
 - `TokenData.load_entity` convenience method to load an entity from the token data.
 - Entities `Instrument`, `Plate`, `Run` were added (but with no extra functionality).
+- `Workunit.{application_parameters, submitter_parameters}` which will replace `Workunit.parameters` in the future.
 
 ### Fixed
 

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -17,6 +17,10 @@ Versioning currently follows `X.Y.Z` where
 - Entities `Instrument`, `Plate`, `Run` were added (but with no extra functionality).
 - `Workunit.{application_parameters, submitter_parameters}` to access parameter values.
 
+### Changed
+
+- Submitter parameters will not be written any longer to `WorkunitExecution` parameters.
+
 ### Fixed
 
 - Compatibility with upcoming change that `Application` can have multiple `technology` values.

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -15,12 +15,16 @@ Versioning currently follows `X.Y.Z` where
 - Attribute `Bfabric.config_data` to obtain a `ConfigData` object directly.
 - `TokenData.load_entity` convenience method to load an entity from the token data.
 - Entities `Instrument`, `Plate`, `Run` were added (but with no extra functionality).
-- `Workunit.{application_parameters, submitter_parameters}` which will replace `Workunit.parameters` in the future.
+- `Workunit.{application_parameters, submitter_parameters}` to access parameter values.
 
 ### Fixed
 
 - Compatibility with upcoming change that `Application` can have multiple `technology` values.
 - Compatibility with pandera 0.24.0 was restored.
+
+### Deprecated
+
+- `Workunit.parameter_values` will be removed in favor of `Workunit.application_parameters` and `Workunit.submitter_parameters` in a future version.
 
 ## \[1.13.26\] - 2025-04-26
 

--- a/bfabric/src/bfabric/entities/workunit.py
+++ b/bfabric/src/bfabric/entities/workunit.py
@@ -39,6 +39,16 @@ class Workunit(Entity, HasContainerMixin):
     external_jobs: HasMany[ExternalJob] = HasMany(entity="ExternalJob", bfabric_field="externaljob", optional=True)
 
     @cached_property
+    def application_parameters(self) -> dict[str, str]:
+        """Dictionary of application context parameters."""
+        return {p.key: p.value for p in self.parameters if p["context"] == "APPLICATION"}
+
+    @cached_property
+    def submitter_parameters(self) -> dict[str, str]:
+        """Dictionary of submitter context parameters."""
+        return {p.key: p.value for p in self.parameters if p["context"] == "SUBMITTER"}
+
+    @cached_property
     def parameter_values(self) -> dict[str, Any]:
         return {p.key: p.value for p in self.parameters.list}
 

--- a/bfabric/src/bfabric/entities/workunit.py
+++ b/bfabric/src/bfabric/entities/workunit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from functools import cached_property
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
@@ -50,6 +51,12 @@ class Workunit(Entity, HasContainerMixin):
 
     @cached_property
     def parameter_values(self) -> dict[str, Any]:
+        # Deprecated
+        warnings.warn(
+            "The parameter_values property is deprecated and will be removed in a future version. "
+            "Use application_parameters or submitter_parameters instead.",
+            DeprecationWarning,
+        )
         return {p.key: p.value for p in self.parameters.list}
 
     @cached_property

--- a/bfabric/src/bfabric/experimental/workunit_definition.py
+++ b/bfabric/src/bfabric/experimental/workunit_definition.py
@@ -50,7 +50,7 @@ class WorkunitExecutionDefinition(BaseModel):
         if workunit.application is None:
             raise ValueError("Workunit does not have an application")
         data = {
-            "raw_parameters": workunit.parameter_values,
+            "raw_parameters": workunit.application_parameters,
             "dataset": workunit.input_dataset.id if workunit.input_dataset else None,
             "resources": [r.id for r in workunit.input_resources],
         }

--- a/tests/bfabric/entities/test_workunit.py
+++ b/tests/bfabric/entities/test_workunit.py
@@ -71,14 +71,14 @@ def test_parameter_values(mocker, mock_workunit: Workunit) -> None:
     mocker.patch.object(
         mock_workunit,
         "parameters",
-        mocker.Mock(
-            list=[
-                mocker.Mock(key="key1", value="value1"),
-                mocker.Mock(key="key2", value="value2"),
-            ]
-        ),
+        [
+            mocker.MagicMock(key="key1", value="value1", __getitem__=lambda _self, x: {"context": "APPLICATION"}[x]),
+            mocker.MagicMock(key="key2", value="value2", __getitem__=lambda _self, x: {"context": "APPLICATION"}[x]),
+            mocker.MagicMock(key="key3", value="value3", __getitem__=lambda _self, x: {"context": "SUBMITTER"}[x]),
+        ],
     )
-    assert mock_workunit.parameter_values == {"key1": "value1", "key2": "value2"}
+    assert mock_workunit.application_parameters == {"key1": "value1", "key2": "value2"}
+    assert mock_workunit.submitter_parameters == {"key3": "value3"}
 
 
 def test_container_when_project(mocker, mock_workunit) -> None:

--- a/tests/bfabric/experimental/test_workunit_definition.py
+++ b/tests/bfabric/experimental/test_workunit_definition.py
@@ -10,7 +10,7 @@ def test_workunit_definition_from_workunit(mocker):
         __getitem__=lambda self, k: {"name": "workunit (mocked)"}[k],
         input_dataset=None,
         input_resources=[mocker.Mock(id=3), mocker.Mock(id=4)],
-        parameter_values={"param1": "value1", "param2": "value2"},
+        application_parameters={"param1": "value1", "param2": "value2"},
         container=mocker.Mock(id=5, ENDPOINT="project"),
         store_output_folder="output_folder",
     )


### PR DESCRIPTION
Add `Workunit.{application_parameters, submitter_parameters}` to access parameter values.

This makes it easier to cleanly implement the parsing. It is potentially breaking due to the change in WorkunitDefinition, but I think the risk is low and we will see the impact when updating individual apps.