### PR TITLE
Require base_url in config

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -10,6 +10,10 @@ Versioning currently follows `X.Y.Z` where
 
 ## \[Unreleased\]
 
+### Breaking
+
+- `base_url` is now a mandatory parameter in the configuration.
+
 ### Added
 
 - It is now possible to configure `~/.bfabricpy.yml` without a default environment. In that case it will always be

--- a/bfabric/src/bfabric/config/bfabric_client_config.py
+++ b/bfabric/src/bfabric/config/bfabric_client_config.py
@@ -27,11 +27,10 @@ class BfabricClientConfig(BaseModel):
         job_notification_emails (optional): Space-separated list of email addresses to notify when a job finishes.
     """
 
-    # TODO consider using AnyHttpUrl in the future directly and make mandatory
+    # TODO consider using AnyHttpUrl in the future directly
     base_url: Annotated[
         str,
         BeforeValidator(lambda value: str(http_url_adapter.validate_python(value))),
-        Field(default="https://fgcz-bfabric.uzh.ch/bfabric"),
     ]
     application_ids: Annotated[dict[str, int], Field(default_factory=dict)]
     job_notification_emails: Annotated[str, Field(default="")]

--- a/bfabric/src/bfabric/config/bfabric_client_config.py
+++ b/bfabric/src/bfabric/config/bfabric_client_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Annotated, Any
 
-from pydantic import BaseModel, BeforeValidator, Field, TypeAdapter, AnyHttpUrl
+from pydantic import BaseModel, Field, TypeAdapter, AnyHttpUrl, BeforeValidator
 
 http_url_adapter = TypeAdapter(AnyHttpUrl)
 


### PR DESCRIPTION
Fixes #101 

This is a breaking change that I think shouldn't affect too many users, since I have been encouraging the use of `base_url` for a while, but, we will see about that.