### PR TITLE
Clean commands spec

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## \[Unreleased\]
 
+### Changed
+
+- Command implementation is separated from command definition for cleaner implementation.
+
 ## \[0.0.23\] - 2025-06-02
 
 ### Added

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "mypy",
     "types-PyYAML",
 ]
-test = ["pytest", "pytest-mock", "logot", "pyfakefs"]
+test = ["pytest", "pytest-mock", "logot", "pyfakefs", "inline-snapshot"]
 
 [tool.uv]
 reinstall-package = ["bfabric", "bfabric_scripts", "bfabric_app_runner"]

--- a/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
+
+from bfabric_app_runner.commands.execute import execute_command
 from bfabric_app_runner.inputs.prepare.prepare_folder import prepare_folder
 from bfabric_app_runner.output_registration import register_outputs
 from loguru import logger
@@ -24,7 +26,7 @@ class Runner:
 
     def run_dispatch(self, workunit_ref: int | Path, work_dir: Path) -> None:
         logger.info(f"Calling dispatch for workunit {workunit_ref} in {work_dir}")
-        self._app_version.commands.dispatch.execute(str(workunit_ref), str(work_dir))
+        execute_command(self._app_version.commands.dispatch, str(workunit_ref), str(work_dir))
 
     def run_inputs(self, chunk_dir: Path) -> None:
         prepare_folder(
@@ -37,12 +39,12 @@ class Runner:
 
     def run_process(self, chunk_dir: Path) -> None:
         logger.info(f"Calling process for chunk directory {chunk_dir}")
-        self._app_version.commands.process.execute(str(chunk_dir))
+        execute_command(self._app_version.commands.process, str(chunk_dir))
 
     def run_collect(self, workunit_ref: int | Path, chunk_dir: Path) -> None:
         if self._app_version.commands.collect is not None:
             logger.info(f"Calling collect for workunit {workunit_ref} in {chunk_dir}")
-            self._app_version.commands.collect.execute(str(workunit_ref), str(chunk_dir))
+            execute_command(self._app_version.commands.collect, str(workunit_ref), str(chunk_dir))
         else:
             logger.info("App does not have a collect step.")
 

--- a/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/app_runner/runner.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import os
-import shlex
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -26,13 +23,10 @@ class Runner:
         self._ssh_user = ssh_user
 
     def run_dispatch(self, workunit_ref: int | Path, work_dir: Path) -> None:
-        command = [*self._app_version.commands.dispatch.to_shell(), str(workunit_ref), str(work_dir)]
-        env = self._app_version.commands.dispatch.to_shell_env(environ=os.environ)
-        logger.info(f"Running dispatch command: {shlex.join(command)}")
-        logger.debug(f"Split command: {command!r}")
-        subprocess.run(command, check=True, env=env)
+        logger.info(f"Calling dispatch for workunit {workunit_ref} in {work_dir}")
+        self._app_version.commands.dispatch.execute(str(workunit_ref), str(work_dir))
 
-    def run_prepare_input(self, chunk_dir: Path) -> None:
+    def run_inputs(self, chunk_dir: Path) -> None:
         prepare_folder(
             inputs_yaml=chunk_dir / "inputs.yml",
             target_folder=chunk_dir,
@@ -41,22 +35,16 @@ class Runner:
             filter=None,
         )
 
+    def run_process(self, chunk_dir: Path) -> None:
+        logger.info(f"Calling process for chunk directory {chunk_dir}")
+        self._app_version.commands.process.execute(str(chunk_dir))
+
     def run_collect(self, workunit_ref: int | Path, chunk_dir: Path) -> None:
         if self._app_version.commands.collect is not None:
-            command = [*self._app_version.commands.collect.to_shell(), str(workunit_ref), str(chunk_dir)]
-            env = self._app_version.commands.collect.to_shell_env(environ=os.environ)
-            logger.info(f"Running collect command: {shlex.join(command)}")
-            logger.debug(f"Split command: {command!r}")
-            subprocess.run(command, check=True, env=env)
+            logger.info(f"Calling collect for workunit {workunit_ref} in {chunk_dir}")
+            self._app_version.commands.collect.execute(str(workunit_ref), str(chunk_dir))
         else:
             logger.info("App does not have a collect step.")
-
-    def run_process(self, chunk_dir: Path) -> None:
-        command = [*self._app_version.commands.process.to_shell(), str(chunk_dir)]
-        env = self._app_version.commands.process.to_shell_env(environ=os.environ)
-        logger.info(f"Running process command: {shlex.join(command)}")
-        logger.debug(f"Split command: {command!r}")
-        subprocess.run(command, check=True, env=env)
 
 
 class ChunksFile(BaseModel):
@@ -98,7 +86,7 @@ def run_app(
     chunks_file = ChunksFile.read(work_dir=work_dir)
     for chunk in chunks_file.chunks:
         logger.info(f"Processing chunk {chunk}")
-        runner.run_prepare_input(chunk_dir=chunk)
+        runner.run_inputs(chunk_dir=chunk)
         runner.run_process(chunk_dir=chunk)
         runner.run_collect(workunit_ref=workunit_definition_file, chunk_dir=chunk)
         if not read_only:

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_docker.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_docker.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import shlex
+import os
+from bfabric_app_runner.commands.command_exec import execute_command_exec
+from bfabric_app_runner.specs.app.commands_spec import CommandExec, CommandDocker, MountOptions
+
+
+def _collect_mount_options(options: MountOptions, work_dir: Path) -> list[tuple[Path, Path, bool]]:
+    """Collects all mounts that are required to run the command.
+
+    These are returned as triplets of (source, target, read_only).
+    """
+    mounts = []
+    if options.share_bfabric_config:
+        mounts.append((Path("~/.bfabricpy.yml"), Path("/home/user/.bfabricpy.yml"), True))
+    # TODO reconsider if we ever want work_dir_target to be customizable to be different from host path
+    #      (currently things will break down if this is configured)
+    work_dir_target = work_dir if options.work_dir_target is None else options.work_dir_target
+    mounts.append((work_dir, work_dir_target, False))
+    for source, target in options.read_only:
+        mounts.append((source, target, True))
+    for source, target in options.writeable:
+        mounts.append((source, target, False))
+    return [(source.expanduser().absolute(), target, read_only) for source, target, read_only in mounts]
+
+
+def _to_shell(command: CommandDocker, work_dir: Path | None = None) -> list[str]:
+    """Returns a shell command that can be used to run the specified command."""
+    work_dir = (work_dir or Path()).expanduser().absolute()
+    mounts = _collect_mount_options(command.options, work_dir)
+    mount_args = []
+    for host, container, read_only in mounts:
+        source = shlex.quote(str(host))
+        target = shlex.quote(str(container))
+        mount_args.append("--mount")
+        mount_args.append(f"type=bind,source={source},target={target}" + (",readonly" if read_only else ""))
+    entrypoint_arg = ["--entrypoint", command.entrypoint] if command.entrypoint else []
+    env_args = []
+    for key, value in command.env.items():
+        env_args.append("--env")
+        env_args.append(f"{key}={shlex.quote(value)}")
+    mac_address_arg = ["--mac-address", command.mac_address] if command.mac_address else []
+    hostname_arg = ["--hostname", command.hostname] if command.hostname else []
+
+    return [
+        command.engine,
+        "run",
+        "--user",
+        f"{os.getuid()}:{os.getgid()}",
+        "--rm",
+        *mount_args,
+        *entrypoint_arg,
+        *env_args,
+        *mac_address_arg,
+        *command.custom_args,
+        *hostname_arg,
+        command.image,
+        *shlex.split(command.command),
+    ]
+
+
+def execute_command_docker(command: CommandDocker, *args: str) -> None:
+    """Executes the command with the provided arguments."""
+    shell_command = _to_shell(command)
+    execute_command_exec(CommandExec(command=shlex.join(shell_command)), *args)

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_docker.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_docker.py
@@ -27,7 +27,7 @@ def _collect_mount_options(options: MountOptions, work_dir: Path) -> list[tuple[
 def _to_shell(command: CommandDocker, work_dir: Path | None = None) -> list[str]:
     """Returns a shell command that can be used to run the specified command."""
     work_dir = (work_dir or Path()).expanduser().absolute()
-    mounts = _collect_mount_options(command.options, work_dir)
+    mounts = _collect_mount_options(command.mounts, work_dir)
     mount_args = []
     for host, container, read_only in mounts:
         source = shlex.quote(str(host))

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_exec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_exec.py
@@ -1,0 +1,37 @@
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+from loguru import logger
+
+from bfabric_app_runner.specs.app.commands_spec import CommandExec
+
+
+def _get_shell_env(
+    environ: dict[str, str] | None, config_env: dict[str, str], config_prepend_paths: list[Path]
+) -> dict[str, str]:
+    if environ is None:
+        environ = os.environ.copy()
+
+    if config_prepend_paths:
+        # Ensure environ['PATH'] is set
+        environ["PATH"] = environ.get("PATH", "")
+        # Prepend paths
+        for path in reversed(config_prepend_paths):
+            resolved_path = path.expanduser().absolute()
+            environ["PATH"] = f"{resolved_path}:{environ['PATH']}"
+
+    for key, value in config_env.items():
+        environ[key] = value
+
+    return environ
+
+
+def execute_command_exec(command: CommandExec, *args: str, environ: dict[str, str] | None = None) -> None:
+    """Executes the command with the provided arguments."""
+    command_args = shlex.split(command.command) + list(args)
+    shell_env = _get_shell_env(environ, command.env, command.prepend_paths)
+    logger.info("Executing command:", command_args, "with environment:", shell_env)
+    logger.debug(f"{command_args=}, {shell_env=}")
+    subprocess.run(command_args, check=True, env=shell_env)

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_exec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_exec.py
@@ -32,6 +32,7 @@ def execute_command_exec(command: CommandExec, *args: str, environ: dict[str, st
     """Executes the command with the provided arguments."""
     command_args = shlex.split(command.command) + list(args)
     shell_env = _get_shell_env(environ, command.env, command.prepend_paths)
-    logger.info("Executing command:", command_args, "with environment:", shell_env)
-    logger.debug(f"{command_args=}, {shell_env=}")
+    logger.info("Executing command:", command_args)
+    logger.debug(f"{command_args=}")
+    logger.trace(f"{shell_env=}")
     subprocess.run(command_args, check=True, env=shell_env)

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
@@ -1,6 +1,0 @@
-from bfabric_app_runner.specs.app.commands_spec import CommandPythonEnv
-
-
-def execute_command_python_env(command: CommandPythonEnv, *args: str) -> None:
-    """Executes the command with the provided arguments."""
-    raise NotImplementedError

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
@@ -1,0 +1,6 @@
+from bfabric_app_runner.specs.app.commands_spec import CommandPythonEnv
+
+
+def execute_command_python_env(command: CommandPythonEnv, *args: str) -> None:
+    """Executes the command with the provided arguments."""
+    raise NotImplementedError

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_shell.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_shell.py
@@ -1,0 +1,7 @@
+from bfabric_app_runner.commands.command_exec import execute_command_exec
+from bfabric_app_runner.specs.app.commands_spec import CommandShell, CommandExec
+
+
+def execute_command_shell(command: CommandShell, *args: str) -> None:
+    """Executes the command with the provided arguments."""
+    execute_command_exec(CommandExec(command=command.command), *args)

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/execute.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/execute.py
@@ -1,0 +1,28 @@
+from typing import assert_never
+
+from bfabric_app_runner.commands.command_docker import execute_command_docker
+from bfabric_app_runner.commands.command_exec import execute_command_exec
+from bfabric_app_runner.commands.command_python_env import execute_command_python_env
+from bfabric_app_runner.commands.command_shell import execute_command_shell
+from bfabric_app_runner.specs.app.commands_spec import (
+    Command,
+    CommandShell,
+    CommandExec,
+    CommandDocker,
+    CommandPythonEnv,
+)
+
+
+def execute_command(command: Command, *args: str) -> None:
+    """Executes the given command with the provided arguments."""
+    command_type = type(command)
+    if issubclass(command_type, CommandShell):
+        execute_command_shell(command, *args)
+    elif issubclass(command_type, CommandExec):
+        execute_command_exec(command, *args)
+    elif issubclass(command_type, CommandDocker):
+        execute_command_docker(command, *args)
+    elif issubclass(command_type, CommandPythonEnv):
+        execute_command_python_env(command, *args)
+    else:
+        assert_never(command_type)

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/execute.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/execute.py
@@ -2,14 +2,12 @@ from typing import assert_never
 
 from bfabric_app_runner.commands.command_docker import execute_command_docker
 from bfabric_app_runner.commands.command_exec import execute_command_exec
-from bfabric_app_runner.commands.command_python_env import execute_command_python_env
 from bfabric_app_runner.commands.command_shell import execute_command_shell
 from bfabric_app_runner.specs.app.commands_spec import (
     Command,
     CommandShell,
     CommandExec,
     CommandDocker,
-    CommandPythonEnv,
 )
 
 
@@ -22,7 +20,5 @@ def execute_command(command: Command, *args: str) -> None:
         execute_command_exec(command, *args)
     elif issubclass(command_type, CommandDocker):
         execute_command_docker(command, *args)
-    elif issubclass(command_type, CommandPythonEnv):
-        execute_command_python_env(command, *args)
     else:
         assert_never(command_type)

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
@@ -1,38 +1,10 @@
-import os
-import shlex
-import subprocess
 from pathlib import Path
-from typing import Literal, Annotated, Protocol, runtime_checkable
-from loguru import logger
+from typing import Literal, Annotated
+
 from pydantic import BaseModel, Discriminator, ConfigDict
 
 
-@runtime_checkable
-class Execute(Protocol):
-    def execute(self, *args: str) -> None:
-        """Executes the command with the given arguments."""
-        raise NotImplementedError()
-
-
-class ExecuteInSubprocess:
-    def to_shell(self) -> list[str]:
-        """Returns a shell command that can be used to run the specified command."""
-        raise NotImplementedError()
-
-    def to_shell_env(self, environ: dict[str, str] | None) -> dict[str, str]:
-        """Returns the shell environment variables to set before executing the command."""
-        raise NotImplementedError()
-
-    def execute(self, *args: str) -> None:
-        """Executes the command in a subprocess with the given arguments."""
-        command = [*self.to_shell(), *args]
-        env = self.to_shell_env(environ=os.environ)
-        logger.info(f"Running dispatch command: {shlex.join(command)}")
-        logger.debug(f"Split command: {command!r}")
-        subprocess.run(command, check=True, env=env)
-
-
-class CommandShell(BaseModel, ExecuteInSubprocess):
+class CommandShell(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     # TODO: Now deprecated by exec type - we can add a "bash" type later, if needed
@@ -42,36 +14,8 @@ class CommandShell(BaseModel, ExecuteInSubprocess):
     command: str
     """The command to run, will be split by spaces and is not an actual shell script."""
 
-    def to_shell(self) -> list[str]:
-        """Returns a shell command that can be used to run the specified command."""
-        return shlex.split(self.command)
 
-    def to_shell_env(self, environ: dict[str, str] | None) -> dict[str, str]:
-        """Returns the shell environment variables to set before executing the command."""
-        return environ if environ is not None else os.environ.copy()
-
-
-def _get_shell_env(
-    environ: dict[str, str] | None, config_env: dict[str, str], config_prepend_paths: list[Path]
-) -> dict[str, str]:
-    if environ is None:
-        environ = os.environ.copy()
-
-    if config_prepend_paths:
-        # Ensure environ['PATH'] is set
-        environ["PATH"] = environ.get("PATH", "")
-        # Prepend paths
-        for path in reversed(config_prepend_paths):
-            resolved_path = path.expanduser().absolute()
-            environ["PATH"] = f"{resolved_path}:{environ['PATH']}"
-
-    for key, value in config_env.items():
-        environ[key] = value
-
-    return environ
-
-
-class CommandExec(BaseModel, ExecuteInSubprocess):
+class CommandExec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["exec"] = "exec"
@@ -89,48 +33,17 @@ class CommandExec(BaseModel, ExecuteInSubprocess):
     If multiple paths are specified, the first one will be the first in PATH, etc.
     """
 
-    def to_shell(self) -> list[str]:
-        """Returns a shell command that can be used to run the specified command."""
-        return shlex.split(self.command)
-
-    def to_shell_env(self, environ: dict[str, str] | None) -> dict[str, str]:
-        """Returns the shell environment variables to set before executing the command."""
-        return _get_shell_env(environ=environ, config_env=self.env, config_prepend_paths=self.prepend_paths)
-
 
 class MountOptions(BaseModel):
     model_config = ConfigDict(extra="forbid")
-
-    # TODO this will have to be reworked later it is not flexible enough as it does not allow to specify the
-    #      flags for shared etc.
     work_dir_target: Path | None = None
     read_only: list[tuple[Path, Path]] = []
     writeable: list[tuple[Path, Path]] = []
     share_bfabric_config: bool = True
 
-    def collect(self, work_dir: Path) -> list[tuple[Path, Path, bool]]:
-        """Collects all mounts that are required to run the command.
 
-        These are returned as triplets of (source, target, read_only).
-        """
-        mounts = []
-        if self.share_bfabric_config:
-            mounts.append((Path("~/.bfabricpy.yml"), Path("/home/user/.bfabricpy.yml"), True))
-        # TODO reconsider if we ever want work_dir_target to be customizable to be different from host path
-        #      (currently things will break down if this is configured)
-        work_dir_target = work_dir if self.work_dir_target is None else self.work_dir_target
-        mounts.append((work_dir, work_dir_target, False))
-        for source, target in self.read_only:
-            mounts.append((source, target, True))
-        for source, target in self.writeable:
-            mounts.append((source, target, False))
-        return [(source.expanduser().absolute(), target, read_only) for source, target, read_only in mounts]
-
-
-class CommandDocker(BaseModel, ExecuteInSubprocess):
+class CommandDocker(BaseModel):
     model_config = ConfigDict(extra="forbid")
-
-    # TODO not sure if to call this "docker", since "docker-compatible" would be appropriate
     type: Literal["docker"] = "docker"
     """Identifies the command type."""
     image: str
@@ -151,44 +64,6 @@ class CommandDocker(BaseModel, ExecuteInSubprocess):
     """The hostname to use for the container (instead of Docker's default assignment)."""
     custom_args: list[str] = []
     """Any custom CLI arguments to pass to the container engine."""
-
-    def to_shell(self, work_dir: Path | None = None) -> list[str]:
-        """Returns a shell command that can be used to run the specified command."""
-        work_dir = (work_dir or Path()).expanduser().absolute()
-        mounts = self.mounts.collect(work_dir=work_dir)
-        mount_args = []
-        for host, container, read_only in mounts:
-            source = shlex.quote(str(host))
-            target = shlex.quote(str(container))
-            mount_args.append("--mount")
-            mount_args.append(f"type=bind,source={source},target={target}" + (",readonly" if read_only else ""))
-        entrypoint_arg = ["--entrypoint", self.entrypoint] if self.entrypoint else []
-        env_args = []
-        for key, value in self.env.items():
-            env_args.append("--env")
-            env_args.append(f"{key}={shlex.quote(value)}")
-        mac_address_arg = ["--mac-address", self.mac_address] if self.mac_address else []
-        hostname_arg = ["--hostname", self.hostname] if self.hostname else []
-
-        return [
-            self.engine,
-            "run",
-            "--user",
-            f"{os.getuid()}:{os.getgid()}",
-            "--rm",
-            *mount_args,
-            *entrypoint_arg,
-            *env_args,
-            *mac_address_arg,
-            *self.custom_args,
-            *hostname_arg,
-            self.image,
-            *shlex.split(self.command),
-        ]
-
-    def to_shell_env(self, environ: dict[str, str] | None = None) -> dict[str, str]:
-        """Returns the shell environment variables to set before executing the command."""
-        return environ if environ is not None else os.environ.copy()
 
 
 class CommandPythonEnv(BaseModel):
@@ -220,25 +95,6 @@ class CommandPythonEnv(BaseModel):
 
     If multiple paths are specified, the first one will be the first in PATH, etc.
     """
-
-    def _get_venv_command(self) -> list[str]:
-        # TODO
-        [
-            "bfabric-app-runner",
-            "utils",
-            "run-in-venv",
-        ]
-        raise NotImplementedError
-
-    def to_shell(self) -> list[str]:
-        """Returns a shell command that can be used to run the specified command."""
-        venv_command = self._get_venv_command()
-        main_command = shlex.split(self.command)
-        return venv_command + main_command
-
-    def to_shell_env(self, environ: dict[str, str] | None) -> dict[str, str]:
-        """Returns the shell environment variables to set before executing the command."""
-        return _get_shell_env(environ=environ, config_env=self.env, config_prepend_paths=self.prepend_paths)
 
 
 Command = Annotated[CommandShell | CommandExec | CommandDocker | CommandPythonEnv, Discriminator("type")]

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
@@ -66,38 +66,7 @@ class CommandDocker(BaseModel):
     """Any custom CLI arguments to pass to the container engine."""
 
 
-class CommandPythonEnv(BaseModel):
-    type: Literal["python_env"]
-
-    pylock: Path
-    """Path to the Pylock file that specifies the environment to use."""
-
-    command: str
-    """The command to run, will be split by `shlex.split` and is not an actual shell script."""
-
-    python_version: str | None = None
-    """The Python version to use."""
-
-    local_extra_deps: list[str] = []
-    """Additional dependencies, e.g. wheels or local packages, to install into the environment.
-
-    For these, no additional dependencies will be installed, so their dependencies should already be in the pylock file.
-    """
-
-    cache_env_path: Path | None = None
-    """Path to the cached environment."""
-
-    env: dict[str, str] = {}
-    """Environment variables to set before executing the command."""
-
-    prepend_paths: list[Path] = []
-    """A list of paths to prepend to the PATH variable before executing the command.
-
-    If multiple paths are specified, the first one will be the first in PATH, etc.
-    """
-
-
-Command = Annotated[CommandShell | CommandExec | CommandDocker | CommandPythonEnv, Discriminator("type")]
+Command = Annotated[CommandShell | CommandExec | CommandDocker, Discriminator("type")]
 
 
 class CommandsSpec(BaseModel):

--- a/tests/bfabric_app_runner/app_runner/test_runner.py
+++ b/tests/bfabric_app_runner/app_runner/test_runner.py
@@ -7,19 +7,14 @@ from pydantic import BaseModel
 from bfabric_app_runner.app_runner.runner import Runner, run_app
 
 
-# Mock classes to represent dependencies
 class MockCommand(BaseModel):
-    def to_shell(self) -> list[str]:
-        return ["mock-command"]
-
-    def to_shell_env(self, environ) -> dict[str, str]:
-        return {"MOCK_ENV_VAR": "mock_value"}
+    name: str
 
 
 class MockCommands(BaseModel):
-    dispatch: MockCommand = MockCommand()
-    process: MockCommand = MockCommand()
-    collect: MockCommand = MockCommand()
+    dispatch: MockCommand = MockCommand(name="dispatch")
+    process: MockCommand = MockCommand(name="process")
+    collect: MockCommand = MockCommand(name="collect")
 
 
 class MockAppVersion(BaseModel):
@@ -37,6 +32,11 @@ def mock_app_version():
 def mock_bfabric(mocker):
     """Fixture providing a mock bfabric client"""
     return mocker.Mock(save=mocker.Mock())
+
+
+@pytest.fixture
+def mock_execute_command(mocker):
+    return mocker.patch("bfabric_app_runner.app_runner.runner.execute_command", autospec=True)
 
 
 @pytest.fixture
@@ -81,21 +81,17 @@ def test_runner_initialization(mock_app_version, mock_bfabric):
     assert runner._ssh_user == "test_user"
 
 
-def test_runner_run_dispatch(mocker, mock_app_version, mock_bfabric, tmp_path):
+def test_runner_run_dispatch(mock_app_version, mock_bfabric, tmp_path, mock_execute_command):
     """Test Runner.run_dispatch method"""
-    mock_run = mocker.patch("subprocess.run")
     runner = Runner(spec=mock_app_version, client=mock_bfabric)
     workunit_ref = 123
     work_dir = tmp_path / "work"
 
     runner.run_dispatch(workunit_ref, work_dir)
-
-    mock_run.assert_called_once_with(
-        ["mock-command", str(workunit_ref), str(work_dir)], check=True, env={"MOCK_ENV_VAR": "mock_value"}
-    )
+    mock_execute_command.assert_called_once_with(MockCommand(name="dispatch"), str(workunit_ref), str(work_dir))
 
 
-def test_runner_run_prepare_input(mocker, mock_app_version, mock_bfabric, tmp_path):
+def test_runner_run_inputs(mocker, mock_app_version, mock_bfabric, tmp_path):
     """Test Runner.run_prepare_input method"""
     mock_prepare = mocker.patch("bfabric_app_runner.app_runner.runner.prepare_folder")
     runner = Runner(spec=mock_app_version, client=mock_bfabric, ssh_user="test_user")
@@ -114,25 +110,25 @@ def test_runner_run_prepare_input(mocker, mock_app_version, mock_bfabric, tmp_pa
     )
 
 
-def test_runner_run_process(mocker, mock_app_version, mock_bfabric, tmp_path):
+def test_runner_run_process(mocker, mock_app_version, mock_bfabric, tmp_path, mock_execute_command):
     """Test Runner.run_process method"""
-    mock_run = mocker.patch("subprocess.run")
     runner = Runner(spec=mock_app_version, client=mock_bfabric)
     chunk_dir = tmp_path / "chunk"
 
     runner.run_process(chunk_dir)
 
-    mock_run.assert_called_once_with(["mock-command", str(chunk_dir)], check=True, env={"MOCK_ENV_VAR": "mock_value"})
+    mock_execute_command.assert_called_once_with(MockCommand(name="process"), str(chunk_dir))
 
 
-def test_run_app_full_workflow(mocker, mock_app_version, mock_bfabric, mock_workunit_definition, setup_work_dir):
+def test_run_app_full_workflow(
+    mocker, mock_app_version, mock_bfabric, mock_workunit_definition, setup_work_dir, mock_execute_command
+):
     """Test complete run_app workflow"""
     # Setup mocks
     mocker.patch(
         "bfabric.experimental.workunit_definition.WorkunitDefinition.from_ref",
         return_value=mock_workunit_definition,
     )
-    mock_run = mocker.patch("subprocess.run")
     mock_prepare = mocker.patch("bfabric_app_runner.app_runner.runner.prepare_folder")
     mock_register = mocker.patch("bfabric_app_runner.app_runner.runner.register_outputs")
 
@@ -148,7 +144,7 @@ def test_run_app_full_workflow(mocker, mock_app_version, mock_bfabric, mock_work
 
     # Verify workflow steps
     assert mock_bfabric.save.call_count == 2  # Status updates at start and end
-    assert mock_run.call_count == 3  # dispatch, process, collect
+    assert mock_execute_command.call_count == 3  # dispatch, process, collect
     assert mock_prepare.call_count == 1
     assert mock_register.call_count == 1
 
@@ -161,13 +157,13 @@ def test_run_app_read_only_mode(
     mock_bfabric,
     mock_workunit_definition,
     setup_work_dir,
+    mock_execute_command,
 ):
     """Test run_app behavior in read-only mode"""
     mocker.patch(
         "bfabric.experimental.workunit_definition.WorkunitDefinition.from_ref",
         return_value=mock_workunit_definition,
     )
-    mocker.patch("subprocess.run")
     mocker.patch("bfabric_app_runner.app_runner.runner.prepare_folder")
     mocker.patch("bfabric_app_runner.app_runner.runner.register_outputs")
 
@@ -183,10 +179,11 @@ def test_run_app_read_only_mode(
     # Verify status updates based on read_only mode
     expected_calls = 0 if read_only else 2
     assert mock_bfabric.save.call_count == expected_calls
+    assert mock_execute_command.call_count == 3
 
 
 def test_run_app_with_path_workunit_ref(
-    mocker, mock_app_version, mock_bfabric, mock_workunit_definition, setup_work_dir
+    mocker, mock_app_version, mock_bfabric, mock_workunit_definition, setup_work_dir, mock_execute_command
 ):
     """Test run_app with Path workunit_ref instead of int"""
     workunit_path = setup_work_dir / "workunit.yml"
@@ -196,7 +193,6 @@ def test_run_app_with_path_workunit_ref(
         "bfabric.experimental.workunit_definition.WorkunitDefinition.from_ref",
         return_value=mock_workunit_definition,
     )
-    mocker.patch("subprocess.run")
     mocker.patch("bfabric_app_runner.app_runner.runner.prepare_folder")
     mocker.patch("bfabric_app_runner.app_runner.runner.register_outputs")
 
@@ -212,3 +208,4 @@ def test_run_app_with_path_workunit_ref(
     mock_from_ref.assert_called_once()
     assert isinstance(mock_from_ref.call_args[1]["workunit"], Path)
     assert mock_from_ref.call_args[1]["workunit"].is_absolute()
+    assert mock_execute_command.call_count == 3

--- a/tests/bfabric_app_runner/app_runner/test_runner.py
+++ b/tests/bfabric_app_runner/app_runner/test_runner.py
@@ -103,7 +103,7 @@ def test_runner_run_prepare_input(mocker, mock_app_version, mock_bfabric, tmp_pa
     chunk_dir.mkdir()
     (chunk_dir / "inputs.yml").touch()
 
-    runner.run_prepare_input(chunk_dir)
+    runner.run_inputs(chunk_dir)
 
     mock_prepare.assert_called_once_with(
         inputs_yaml=chunk_dir / "inputs.yml",

--- a/tests/bfabric_app_runner/commands/test_command_docker.py
+++ b/tests/bfabric_app_runner/commands/test_command_docker.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+from bfabric_app_runner.commands.command_docker import _collect_mount_options
+from bfabric_app_runner.specs.app.commands_spec import (
+    MountOptions,
+)
+
+
+class TestCollectMountOptions:
+    def test_default_behavior(self, tmp_path):
+        """Test collect method with default settings"""
+        options = MountOptions()
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+
+        mounts = _collect_mount_options(options, work_dir)
+
+        # Should have 2 default mounts: bfabric config and work dir
+        assert len(mounts) == 2
+        assert mounts[0] == (
+            Path("~/.bfabricpy.yml").expanduser().absolute(),
+            Path("/home/user/.bfabricpy.yml"),
+            True,
+        )
+        assert mounts[1] == (work_dir.absolute(), work_dir, False)
+
+    def test_with_custom_mounts(self, tmp_path):
+        """Test collect method with both read-only and writeable mounts"""
+        source_ro = tmp_path / "data"
+        source_ro.mkdir()
+        target_ro = Path("/container/data")
+
+        source_rw = tmp_path / "shared"
+        source_rw.mkdir()
+        target_rw = Path("/container/shared")
+
+        options = MountOptions(
+            read_only=[(source_ro, target_ro)],
+            writeable=[(source_rw, target_rw)],
+            share_bfabric_config=False,  # Disable bfabric to simplify test
+        )
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+
+        mounts = _collect_mount_options(options, work_dir)
+
+        # Should have 3 mounts: work_dir, read-only, and writeable
+        assert len(mounts) == 3
+        assert mounts[0] == (work_dir.absolute(), work_dir, False)
+        assert mounts[1] == (source_ro.absolute(), target_ro, True)
+        assert mounts[2] == (source_rw.absolute(), target_rw, False)
+
+    def test_path_expansion(self):
+        """Test that paths are properly expanded"""
+        options = MountOptions(
+            read_only=[(Path("~/data"), Path("/container/data"))],
+            share_bfabric_config=False,
+        )
+        work_dir = Path("/work")
+
+        mounts = _collect_mount_options(options, work_dir)
+
+        assert len(mounts) == 2
+        assert mounts[1][0] == Path("~/data").expanduser().absolute()
+        assert mounts[1][1] == Path("/container/data")
+        assert mounts[1][2] is True

--- a/tests/bfabric_app_runner/commands/test_command_docker.py
+++ b/tests/bfabric_app_runner/commands/test_command_docker.py
@@ -1,6 +1,13 @@
+import os
 from pathlib import Path
 
-from bfabric_app_runner.commands.command_docker import _collect_mount_options
+import pytest
+
+from bfabric_app_runner.commands.command_docker import _collect_mount_options, execute_command_docker, _to_shell
+from bfabric_app_runner.specs.app.commands_spec import (
+    CommandDocker,
+    CommandExec,
+)
 from bfabric_app_runner.specs.app.commands_spec import (
     MountOptions,
 )
@@ -64,3 +71,111 @@ class TestCollectMountOptions:
         assert mounts[1][0] == Path("~/data").expanduser().absolute()
         assert mounts[1][1] == Path("/container/data")
         assert mounts[1][2] is True
+
+
+class TestExecuteCommandDocker:
+    @pytest.fixture
+    def execute_command_exec(self, mocker):
+        return mocker.patch("bfabric_app_runner.commands.command_docker.execute_command_exec")
+
+    def test_basic(self, execute_command_exec):
+        """Test basic docker command generation"""
+        cmd = CommandDocker(image="python:3.9", command="python script.py")
+
+        result = _to_shell(cmd, Path("/work"))
+
+        expected = [
+            "docker",
+            "run",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--rm",
+            "--mount",
+            "type=bind,source=/home/user/.bfabricpy.yml,target=/home/user/.bfabricpy.yml,readonly",
+            "--mount",
+            "type=bind,source=/work,target=/work",
+            "python:3.9",
+            "python",
+            "script.py",
+        ]
+
+        # Replace actual home directory path with /home/user for test stability
+        result = [s.replace(str(Path.home()), "/home/user") for s in result]
+        assert result == expected
+
+    def test_with_options(self, tmp_path):
+        """Test docker command generation with entrypoint, env vars, and custom args"""
+        cmd = CommandDocker(
+            image="ubuntu:latest",
+            command="echo 'hello'",
+            entrypoint="/bin/bash",
+            env={"DEBUG": "1", "PATH": "/usr/local/bin"},
+            mac_address="00:00:00:00:00:00",
+            custom_args=["--network=host"],
+            hostname="myhost",
+            mounts=MountOptions(share_bfabric_config=False),  # Disable bfabric mount for simpler testing
+        )
+
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        result = _to_shell(cmd, work_dir)
+
+        expected = [
+            "docker",
+            "run",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--rm",
+            "--mount",
+            f"type=bind,source={work_dir.absolute()},target={work_dir.absolute()}",
+            "--entrypoint",
+            "/bin/bash",
+            "--env",
+            "DEBUG=1",
+            "--env",
+            "PATH=/usr/local/bin",
+            "--mac-address",
+            "00:00:00:00:00:00",
+            "--network=host",
+            "--hostname",
+            "myhost",
+            "ubuntu:latest",
+            "echo",
+            "hello",
+        ]
+
+        assert result == expected
+
+    def test_with_complex_command(self):
+        """Test docker command generation with a complex command containing spaces and quotes"""
+        cmd = CommandDocker(
+            image="alpine:latest",
+            command="sh -c \"echo 'test with spaces' && ls -la\"",
+            mounts=MountOptions(share_bfabric_config=False),
+        )
+
+        result = _to_shell(cmd, Path("/work"))
+
+        expected = [
+            "docker",
+            "run",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "--rm",
+            "--mount",
+            "type=bind,source=/work,target=/work",
+            "alpine:latest",
+            "sh",
+            "-c",
+            "echo 'test with spaces' && ls -la",
+        ]
+
+        assert result == expected
+
+    def test_execute(self, mocker, execute_command_exec):
+        """Test execution of a docker command"""
+        to_shell = mocker.patch("bfabric_app_runner.commands.command_docker._to_shell")
+        to_shell.return_value = ["dummy", "command"]
+        cmd = CommandDocker(image="alpine:latest", command="echo 'hello world'")
+        execute_command_docker(cmd)
+        execute_command_exec.assert_called_once_with(CommandExec(command="dummy command"))

--- a/tests/bfabric_app_runner/commands/test_command_exec.py
+++ b/tests/bfabric_app_runner/commands/test_command_exec.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pytest
+
+from bfabric_app_runner.commands.command_exec import execute_command_exec
+from bfabric_app_runner.specs.app.commands_spec import CommandExec
+
+
+@pytest.fixture
+def command_minimal():
+    return CommandExec(command="echo 'hello world'")
+
+
+@pytest.fixture
+def command_full():
+    return CommandExec(
+        command='bash -c \'echo "hello $NAME" && echo "$PATH"\'',
+        env={"NAME": "sun"},
+        prepend_paths=[Path("/usr/local/bin"), Path("~/bin")],
+    )
+
+
+@pytest.fixture
+def subprocess_run(mocker):
+    return mocker.patch("subprocess.run")
+
+
+def test_execute_minimal(command_minimal, subprocess_run):
+    execute_command_exec(command_minimal, "hello", "world", environ={"NAME": "testing"})
+    subprocess_run.assert_called_once_with(
+        ["echo", "hello world", "hello", "world"],
+        env={"NAME": "testing"},
+        check=True,
+    )
+
+
+def test_execute_full(mocker, command_full, subprocess_run):
+    mocker.patch.dict("os.environ", {"HOME": "/home/user"})
+    execute_command_exec(command_full, "hello", "world", environ={"NAME": "testing"})
+    subprocess_run.assert_called_once_with(
+        [
+            "bash",
+            "-c",
+            'echo "hello $NAME" && echo "$PATH"',
+            "hello",
+            "world",
+        ],
+        check=True,
+        env={"NAME": "sun", "PATH": "/usr/local/bin:/home/user/bin:"},
+    )

--- a/tests/bfabric_app_runner/specs/app/test_commands_spec.py
+++ b/tests/bfabric_app_runner/specs/app/test_commands_spec.py
@@ -1,35 +1,9 @@
 import pytest
 
 from bfabric_app_runner.specs.app.commands_spec import (
-    CommandShell,
     CommandExec,
     CommandsSpec,
 )
-
-
-class TestCommandShell:
-    def test_basic(self):
-        """Test basic shell command parsing"""
-        cmd = CommandShell(command="echo hello")
-        result = cmd.to_shell()
-        assert result == ["echo", "hello"]
-
-    def test_with_quotes(self):
-        """Test shell command with quoted arguments"""
-        cmd = CommandShell(command='echo "hello world"')
-        result = cmd.to_shell()
-        assert result == ["echo", "hello world"]
-
-    def test_complex_command(self):
-        """Test complex shell command with multiple arguments and quotes"""
-        cmd = CommandShell(command="python3 -c \"import sys; print('Hello from Python')\" --verbose")
-        result = cmd.to_shell()
-        assert result == [
-            "python3",
-            "-c",
-            "import sys; print('Hello from Python')",
-            "--verbose",
-        ]
 
 
 class TestCommandsSpec:

--- a/tests/bfabric_app_runner/specs/app/test_commands_spec.py
+++ b/tests/bfabric_app_runner/specs/app/test_commands_spec.py
@@ -12,66 +12,6 @@ from bfabric_app_runner.specs.app.commands_spec import (
 )
 
 
-class TestMountOptions:
-    def test_default_behavior(self, tmp_path):
-        """Test collect method with default settings"""
-        options = MountOptions()
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-
-        mounts = options.collect(work_dir)
-
-        # Should have 2 default mounts: bfabric config and work dir
-        assert len(mounts) == 2
-        assert mounts[0] == (
-            Path("~/.bfabricpy.yml").expanduser().absolute(),
-            Path("/home/user/.bfabricpy.yml"),
-            True,
-        )
-        assert mounts[1] == (work_dir.absolute(), work_dir, False)
-
-    def test_with_custom_mounts(self, tmp_path):
-        """Test collect method with both read-only and writeable mounts"""
-        source_ro = tmp_path / "data"
-        source_ro.mkdir()
-        target_ro = Path("/container/data")
-
-        source_rw = tmp_path / "shared"
-        source_rw.mkdir()
-        target_rw = Path("/container/shared")
-
-        options = MountOptions(
-            read_only=[(source_ro, target_ro)],
-            writeable=[(source_rw, target_rw)],
-            share_bfabric_config=False,  # Disable bfabric to simplify test
-        )
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-
-        mounts = options.collect(work_dir)
-
-        # Should have 3 mounts: work_dir, read-only, and writeable
-        assert len(mounts) == 3
-        assert mounts[0] == (work_dir.absolute(), work_dir, False)
-        assert mounts[1] == (source_ro.absolute(), target_ro, True)
-        assert mounts[2] == (source_rw.absolute(), target_rw, False)
-
-    def test_path_expansion(self):
-        """Test that paths are properly expanded"""
-        options = MountOptions(
-            read_only=[(Path("~/data"), Path("/container/data"))],
-            share_bfabric_config=False,
-        )
-        work_dir = Path("/work")
-
-        mounts = options.collect(work_dir)
-
-        assert len(mounts) == 2
-        assert mounts[1][0] == Path("~/data").expanduser().absolute()
-        assert mounts[1][1] == Path("/container/data")
-        assert mounts[1][2] is True
-
-
 class TestCommandShell:
     def test_basic(self):
         """Test basic shell command parsing"""

--- a/tests/bfabric_app_runner/specs/app/test_commands_spec.py
+++ b/tests/bfabric_app_runner/specs/app/test_commands_spec.py
@@ -97,37 +97,6 @@ class TestCommandShell:
         ]
 
 
-class TestCommandExec:
-    @pytest.fixture
-    def command_minimal(self):
-        return CommandExec(command="echo 'hello world'")
-
-    @pytest.fixture
-    def command_full(self):
-        return CommandExec(
-            command='bash -c \'echo "hello $NAME" && echo "$PATH"\'',
-            env={"NAME": "sun"},
-            prepend_paths=[Path("/usr/local/bin"), Path("~/bin")],
-        )
-
-    def test_minimal(self, command_minimal):
-        assert command_minimal.to_shell() == ["echo", "hello world"]
-        assert command_minimal.to_shell_env({}) == {}
-        assert command_minimal.to_shell_env({"NAME": "world"}) == {"NAME": "world"}
-
-    def test_full(self, mocker, command_full):
-        mocker.patch.dict("os.environ", {"HOME": "/home/user"})
-        assert command_full.to_shell() == ["bash", "-c", 'echo "hello $NAME" && echo "$PATH"']
-        assert command_full.to_shell_env({}) == {
-            "NAME": "sun",
-            "PATH": "/usr/local/bin:/home/user/bin:",
-        }
-        assert command_full.to_shell_env({"NAME": "world"}) == {
-            "NAME": "sun",
-            "PATH": "/usr/local/bin:/home/user/bin:",
-        }
-
-
 class TestCommandDocker:
     def test_basic(self):
         """Test basic docker command generation"""

--- a/tests/bfabric_app_runner/specs/app/test_commands_spec.py
+++ b/tests/bfabric_app_runner/specs/app/test_commands_spec.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 import pytest
-from pydantic import ValidationError
 
 from bfabric_app_runner.specs.app.commands_spec import (
     MountOptions,
@@ -10,7 +9,6 @@ from bfabric_app_runner.specs.app.commands_spec import (
     CommandShell,
     CommandExec,
     CommandsSpec,
-    CommandAppZip,
 )
 
 
@@ -233,16 +231,6 @@ class TestCommandsSpec:
         return {"type": "exec", "command": "bash -c 'echo hello world'"}
 
     @staticmethod
-    @pytest.fixture
-    def data_command_app_zip_without_purpose(app_zip_path):
-        return {"type": "app.zip", "app_zip": str(app_zip_path), "app_name": "my_app"}
-
-    @staticmethod
-    @pytest.fixture
-    def app_zip_path():
-        return Path("/test/app.zip")
-
-    @staticmethod
     def test_parse_exec(data_command_exec):
         data = {"dispatch": data_command_exec, "process": data_command_exec}
         parsed = CommandsSpec.model_validate(data)
@@ -250,33 +238,3 @@ class TestCommandsSpec:
         assert parsed.dispatch == expected_command
         assert parsed.process == expected_command
         assert parsed.collect is None
-
-    @staticmethod
-    def test_populate_app_zip_purpose_when_dict(data_command_app_zip_without_purpose, app_zip_path):
-        data = {"dispatch": data_command_app_zip_without_purpose, "process": data_command_app_zip_without_purpose}
-        parsed = CommandsSpec.model_validate(data)
-        assert parsed.dispatch.purpose == "dispatch"
-        assert parsed.dispatch.app_zip == app_zip_path
-        assert parsed.process.purpose == "process"
-        assert parsed.process.app_zip == app_zip_path
-        assert parsed.collect is None
-
-    @staticmethod
-    def test_populate_app_zip_purpose_when_model_valid(data_command_app_zip_without_purpose):
-        command_dispatch = CommandAppZip(**data_command_app_zip_without_purpose, purpose="dispatch")
-        command_process = CommandAppZip(**data_command_app_zip_without_purpose, purpose="process")
-        data = {"dispatch": command_dispatch, "process": command_process}
-        commands = CommandsSpec.model_validate(data)
-        assert commands.dispatch == command_dispatch
-        assert commands.process == command_process
-        assert commands.collect is None
-
-    @staticmethod
-    def test_populate_app_zip_purpose_when_model_invalid(data_command_app_zip_without_purpose):
-        command_dispatch = CommandAppZip(**data_command_app_zip_without_purpose, purpose="dispatch")
-        command_process = CommandAppZip(**data_command_app_zip_without_purpose, purpose="dispatch")
-        data = {"dispatch": command_dispatch, "process": command_process}
-        with pytest.raises(ValidationError) as error:
-            CommandsSpec.model_validate(data)
-        assert error.value.error_count() == 1
-        assert error.value.errors()[0]["msg"] == "Value error, Inconsistent purpose 'dispatch' expected 'process'"


### PR DESCRIPTION
The command imlementation is moved from `bfabric_app_runner.specs` to `bfabric_app_runner.commands` and tests are refactored. Overall the runner code has been simplified as well.