### PR TITLE
Improve CommandPythonEnv for "refresh=True"

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## \[Unreleased\]
 
+- `CommandPythonEnv` with `refresh=True` now will create a separate environment to avoid breaking apps which are already using a particular
+    Python environment without locking it.
+
 ## \[0.1.1\] - 2025-07-07
 
 ### Changed

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
@@ -4,8 +4,8 @@ import os
 import shlex
 import socket
 import tempfile
-from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Protocol
 
 from loguru import logger
 
@@ -74,16 +74,15 @@ class PythonEnvironment:
         return self.env_path / ".provisioned"
 
 
-class EnvironmentStrategy(ABC):
-    """Abstract strategy for obtaining Python environments."""
+class EnvironmentStrategy(Protocol):
+    """Protocol for obtaining Python environments."""
 
-    @abstractmethod
     def get_environment(self, command: CommandPythonEnv) -> PythonEnvironment:
         """Get a Python environment for the given command."""
-        pass
+        ...
 
 
-class CachedEnvironmentStrategy(EnvironmentStrategy):
+class CachedEnvironmentStrategy:
     """Strategy for cached environments with file locking."""
 
     def get_environment(self, command: CommandPythonEnv) -> PythonEnvironment:
@@ -123,7 +122,7 @@ class CachedEnvironmentStrategy(EnvironmentStrategy):
         return env_hash
 
 
-class EphemeralEnvironmentStrategy(EnvironmentStrategy):
+class EphemeralEnvironmentStrategy:
     """Strategy for ephemeral (temporary) environments."""
 
     def get_environment(self, command: CommandPythonEnv) -> PythonEnvironment:

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
@@ -29,9 +29,10 @@ class PythonEnvironment:
         self._install_local_deps()
         self._mark_provisioned()
 
+    @property
     def is_provisioned(self) -> bool:
-        """Check if the environment is already provisioned."""
-        return self._provisioned_marker().exists()
+        """True if the environment is already provisioned."""
+        return self._provisioned_marker.exists()
 
     def _create_virtual_environment(self) -> None:
         """Create a virtual environment using uv venv."""
@@ -67,10 +68,11 @@ class PythonEnvironment:
 
     def _mark_provisioned(self) -> None:
         """Mark environment as successfully provisioned."""
-        self._provisioned_marker().touch()
+        self._provisioned_marker.touch()
 
+    @property
     def _provisioned_marker(self) -> Path:
-        """Returns the path to the provisioned marker file."""
+        """Path to the provisioned marker file."""
         return self.env_path / ".provisioned"
 
 
@@ -97,7 +99,7 @@ class CachedEnvironmentStrategy:
             fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
 
             # Check if environment is properly provisioned (under lock)
-            if not environment.is_provisioned():
+            if not environment.is_provisioned:
                 logger.info(f"Provisioning Python environment at {env_path} with command: {command.command}")
                 environment.provision()
 

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
@@ -99,7 +99,12 @@ class CommandPythonEnv(BaseModel):
     """
 
     refresh: bool = False
-    """When True, forces re-download and cache refresh of the environment, ignoring any existing cache."""
+    """When True, forces provisioning of an ephemeral environment that doesn't affect the cache.
+
+    This creates a temporary environment for the single execution and doesn't modify or reuse
+    the cached environment. This ensures that refresh operations always start from a clean state
+    and don't leave broken environments in the cache if provisioning fails.
+    """
 
 
 Command = Annotated[CommandShell | CommandExec | CommandDocker | CommandPythonEnv, Discriminator("type")]

--- a/tests/bfabric_app_runner/commands/test_command_python_env.py
+++ b/tests/bfabric_app_runner/commands/test_command_python_env.py
@@ -14,56 +14,79 @@ def mock_python_env_setup(mocker):
     mock_env_path = Path("/cache/env/test_hash")
     mock_ephemeral_path = Path("/tmp/bfabric_app_runner_refresh_12345")
 
-    # Mock the _ensure_environment function to return appropriate paths
-    def mock_ensure_environment(command):
-        if command.refresh:
-            return mock_ephemeral_path
-        return mock_env_path
+    # Mock the strategy classes and their methods
+    mock_cached_strategy = mocker.MagicMock()
+    mock_ephemeral_strategy = mocker.MagicMock()
 
-    mock_ensure_env = mocker.patch(
-        "bfabric_app_runner.commands.command_python_env._ensure_environment", side_effect=mock_ensure_environment
+    # Mock PythonEnvironment
+    mock_environment = mocker.MagicMock()
+    mock_environment.env_path = mock_env_path
+    mock_environment.is_provisioned.return_value = True
+
+    mock_cached_strategy.get_environment.return_value = mock_environment
+    mock_ephemeral_strategy.get_environment.return_value = mock_environment
+
+    # Mock strategy constructors
+    mock_cached_strategy_class = mocker.patch(
+        "bfabric_app_runner.commands.command_python_env.CachedEnvironmentStrategy", return_value=mock_cached_strategy
+    )
+    mock_ephemeral_strategy_class = mocker.patch(
+        "bfabric_app_runner.commands.command_python_env.EphemeralEnvironmentStrategy",
+        return_value=mock_ephemeral_strategy,
     )
 
     # Mock execute_command_exec
     mock_execute = mocker.patch("bfabric_app_runner.commands.command_python_env.execute_command_exec")
 
-    # Add missing mocks
-    mock_exists = mocker.patch("pathlib.Path.exists", return_value=True)
-    mock_flock = mocker.patch("fcntl.flock")
-
     yield {
         "env_path": mock_env_path,
         "ephemeral_path": mock_ephemeral_path,
-        "mock_ensure_env": mock_ensure_env,
+        "mock_cached_strategy": mock_cached_strategy,
+        "mock_ephemeral_strategy": mock_ephemeral_strategy,
+        "mock_cached_strategy_class": mock_cached_strategy_class,
+        "mock_ephemeral_strategy_class": mock_ephemeral_strategy_class,
+        "mock_environment": mock_environment,
         "mock_execute": mock_execute,
-        "mock_exists": mock_exists,
-        "mock_flock": mock_flock,
     }
 
 
 def test_execute_with_existing_environment(mock_python_env_setup):
     """Test execution when environment already exists."""
     mock_execute = mock_python_env_setup["mock_execute"]
-    mock_env_path = mock_python_env_setup["env_path"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
+
+    # Environment is already provisioned
+    mock_environment.is_provisioned.return_value = True
 
     cmd = CommandPythonEnv(pylock=Path("/test/pylock"), command="script.py", python_version="3.13")
     execute_command_python_env(cmd, "hello", "world")
+
+    # Should use cached strategy
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd)
 
     # Should call execute_command_exec once for execution
     mock_execute.assert_called_once()
     called_command = mock_execute.call_args[0][0]
     assert isinstance(called_command, CommandExec)
-    assert str(mock_env_path / "bin" / "python") in called_command.command
+    assert str(mock_python_env_setup["env_path"] / "bin" / "python") in called_command.command
     assert "script.py hello world" in called_command.command
 
 
 def test_execute_with_refresh_flag(mock_python_env_setup):
     """Test execution with refresh flag uses ephemeral environment."""
     mock_execute = mock_python_env_setup["mock_execute"]
-    mock_ephemeral_path = mock_python_env_setup["ephemeral_path"]
+    mock_ephemeral_strategy = mock_python_env_setup["mock_ephemeral_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
+
+    # Set up ephemeral environment path
+    mock_environment.env_path = mock_python_env_setup["ephemeral_path"]
 
     cmd = CommandPythonEnv(pylock=Path("/test/pylock"), command="script.py", python_version="3.13", refresh=True)
     execute_command_python_env(cmd)
+
+    # Should use ephemeral strategy
+    mock_ephemeral_strategy.get_environment.assert_called_once_with(cmd)
 
     # Should call execute_command_exec once for execution
     mock_execute.assert_called_once()
@@ -71,50 +94,57 @@ def test_execute_with_refresh_flag(mock_python_env_setup):
     # Verify that the ephemeral path is used in the command
     called_command = mock_execute.call_args[0][0]
     assert isinstance(called_command, CommandExec)
-    assert str(mock_ephemeral_path / "bin" / "python") in called_command.command
+    assert str(mock_python_env_setup["ephemeral_path"] / "bin" / "python") in called_command.command
     assert "script.py" in called_command.command
 
 
 def test_refresh_does_not_affect_cache(mock_python_env_setup):
     """Test that refresh operations don't affect the cached environment."""
     mock_execute = mock_python_env_setup["mock_execute"]
-    mock_exists = mock_python_env_setup["mock_exists"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+    mock_ephemeral_strategy = mock_python_env_setup["mock_ephemeral_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
 
-    # First, run with refresh=True (should use ephemeral path)
+    # First, run with refresh=True (should use ephemeral strategy)
+    mock_environment.env_path = mock_python_env_setup["ephemeral_path"]
     cmd_refresh = CommandPythonEnv(
         pylock=Path("/test/pylock"), command="script.py", python_version="3.13", refresh=True
     )
     execute_command_python_env(cmd_refresh)
 
-    # Reset mock for second call
+    # Verify ephemeral strategy was used
+    mock_ephemeral_strategy.get_environment.assert_called_once_with(cmd_refresh)
+    mock_cached_strategy.get_environment.assert_not_called()
+
+    # Reset mocks for second call
     mock_execute.reset_mock()
+    mock_cached_strategy.reset_mock()
+    mock_ephemeral_strategy.reset_mock()
 
-    # Mock that cache doesn't exist (to trigger provisioning)
-    mock_exists.return_value = False
-
-    # Now run without refresh (should use cached path and provision normally)
+    # Now run without refresh (should use cached strategy)
+    mock_environment.env_path = mock_python_env_setup["env_path"]
     cmd_normal = CommandPythonEnv(
         pylock=Path("/test/pylock"), command="script.py", python_version="3.13", refresh=False
     )
     execute_command_python_env(cmd_normal)
 
-    # Should still provision normally in cache path
-    assert mock_execute.call_count == 1  # Only execution call since using strategy pattern
+    # Verify cached strategy was used
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd_normal)
+    mock_ephemeral_strategy.get_environment.assert_not_called()
 
-    # Verify cache path is used, not ephemeral path
-    cache_path = mock_python_env_setup["env_path"]
-    ephemeral_path = mock_python_env_setup["ephemeral_path"]
-
-    calls = mock_execute.call_args_list
-    exec_call = calls[0][0][0]
-    assert str(cache_path / "bin" / "python") in exec_call.command
-    assert str(ephemeral_path) not in exec_call.command
+    # Verify cache path is used in the command
+    called_command = mock_execute.call_args[0][0]
+    assert str(mock_python_env_setup["env_path"] / "bin" / "python") in called_command.command
 
 
 def test_refresh_with_local_extra_deps(mock_python_env_setup):
     """Test refresh with local extra dependencies uses ephemeral environment."""
     mock_execute = mock_python_env_setup["mock_execute"]
-    mock_ephemeral_path = mock_python_env_setup["ephemeral_path"]
+    mock_ephemeral_strategy = mock_python_env_setup["mock_ephemeral_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
+
+    # Set up ephemeral environment path
+    mock_environment.env_path = mock_python_env_setup["ephemeral_path"]
 
     cmd = CommandPythonEnv(
         pylock=Path("/test/pylock"),
@@ -125,37 +155,45 @@ def test_refresh_with_local_extra_deps(mock_python_env_setup):
     )
     execute_command_python_env(cmd, "arg1")
 
-    # Should call execute_command_exec once for execution (strategy handles provisioning)
+    # Should use ephemeral strategy
+    mock_ephemeral_strategy.get_environment.assert_called_once_with(cmd)
+
+    # Should call execute_command_exec once for execution
     mock_execute.assert_called_once()
 
-    # Check final execution
+    # Check final execution uses ephemeral path
     exec_call = mock_execute.call_args[0][0]
-    assert str(mock_ephemeral_path / "bin" / "python") in exec_call.command
+    assert str(mock_python_env_setup["ephemeral_path"] / "bin" / "python") in exec_call.command
     assert "script.py arg1" in exec_call.command
 
 
 def test_execute_with_missing_environment(mock_python_env_setup):
     """Test execution when environment doesn't exist yet."""
     mock_execute = mock_python_env_setup["mock_execute"]
-    mock_exists = mock_python_env_setup["mock_exists"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
 
-    # Mock provisioned marker doesn't exist
-    mock_exists.return_value = False
+    # Environment is not provisioned initially
+    mock_environment.is_provisioned.return_value = False
 
     cmd = CommandPythonEnv(pylock=Path("/test/pylock"), command="script.py", python_version="3.13")
     execute_command_python_env(cmd)
 
-    # Should call execute_command_exec once for execution (strategy handles provisioning)
+    # Should use cached strategy
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd)
+
+    # Should call execute_command_exec once for execution
     mock_execute.assert_called_once()
 
 
 def test_execute_with_local_extra_deps(mock_python_env_setup, mocker):
     """Test execution with local extra dependencies."""
     mock_execute = mock_python_env_setup["mock_execute"]
-    mock_exists = mock_python_env_setup["mock_exists"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
 
-    # Mock provisioned marker doesn't exist (to trigger provisioning)
-    mock_exists.return_value = False
+    # Environment is not provisioned initially
+    mock_environment.is_provisioned.return_value = False
 
     cmd = CommandPythonEnv(
         pylock=Path("/test/pylock"),
@@ -165,7 +203,10 @@ def test_execute_with_local_extra_deps(mock_python_env_setup, mocker):
     )
     execute_command_python_env(cmd, "arg1")
 
-    # Should call execute_command_exec once for execution (strategy handles provisioning)
+    # Should use cached strategy
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd)
+
+    # Should call execute_command_exec once for execution
     mock_execute.assert_called_once()
 
     # Last call should be the execution
@@ -177,6 +218,7 @@ def test_execute_with_local_extra_deps(mock_python_env_setup, mocker):
 def test_execute_with_env_and_prepend_paths(mock_python_env_setup):
     """Test execution with custom environment and prepend paths."""
     mock_execute = mock_python_env_setup["mock_execute"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
 
     cmd = CommandPythonEnv(
         pylock=Path("/test/pylock"),
@@ -186,6 +228,9 @@ def test_execute_with_env_and_prepend_paths(mock_python_env_setup):
         prepend_paths=[Path("/custom/bin")],
     )
     execute_command_python_env(cmd)
+
+    # Should use cached strategy
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd)
 
     # Should call execute_command_exec once for execution
     mock_execute.assert_called_once()
@@ -203,42 +248,64 @@ def test_hash(mocker):
 
 def test_file_locking_during_provisioning(mock_python_env_setup):
     """Test that file locking is used during environment provisioning."""
-    mock_execute = mock_python_env_setup["mock_execute"]
-    mock_exists = mock_python_env_setup["mock_exists"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
 
-    # Mock provisioned marker doesn't exist (to trigger provisioning)
-    mock_exists.return_value = False
+    # Environment is not provisioned initially
+    mock_environment.is_provisioned.return_value = False
 
     cmd = CommandPythonEnv(pylock=Path("/test/pylock"), command="script.py", python_version="3.13")
     execute_command_python_env(cmd)
 
-    # Should call execute_command_exec once for execution (strategy handles provisioning and locking)
-    mock_execute.assert_called_once()
+    # Should use cached strategy (which handles locking internally)
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd)
 
 
 def test_double_check_after_lock_acquisition(mock_python_env_setup):
     """Test that environment existence is checked again after acquiring lock."""
-    mock_execute = mock_python_env_setup["mock_execute"]
-    mock_exists = mock_python_env_setup["mock_exists"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
 
-    # Mock provisioned marker exists (environment exists after lock acquired)
-    # This simulates the case where another process created the environment
-    # between when we might have checked initially and when we acquired the lock
-    mock_exists.return_value = True
+    # Environment exists (simulating another process created it)
+    mock_environment.is_provisioned.return_value = True
 
     cmd = CommandPythonEnv(pylock=Path("/test/pylock"), command="script.py", python_version="3.13")
     execute_command_python_env(cmd)
 
-    # Should only call execute_command_exec once for the final execution (no provisioning)
-    mock_execute.assert_called_once()
+    # Should use cached strategy
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd)
 
 
 def test_refresh_does_not_use_locking(mock_python_env_setup):
     """Test that refresh operations don't use file locking since they use ephemeral environments."""
-    mock_execute = mock_python_env_setup["mock_execute"]
+    mock_ephemeral_strategy = mock_python_env_setup["mock_ephemeral_strategy"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+    mock_environment = mock_python_env_setup["mock_environment"]
+
+    # Set up ephemeral environment path
+    mock_environment.env_path = mock_python_env_setup["ephemeral_path"]
 
     cmd = CommandPythonEnv(pylock=Path("/test/pylock"), command="script.py", python_version="3.13", refresh=True)
     execute_command_python_env(cmd)
 
-    # Should call execute_command_exec once for execution (ephemeral strategy handles provisioning)
+    # Should use ephemeral strategy (no locking)
+    mock_ephemeral_strategy.get_environment.assert_called_once_with(cmd)
+    mock_cached_strategy.get_environment.assert_not_called()
+
+
+def test_execute_with_changed_args(mock_python_env_setup):
+    """Test execution with changed arguments."""
+    mock_execute = mock_python_env_setup["mock_execute"]
+    mock_cached_strategy = mock_python_env_setup["mock_cached_strategy"]
+
+    cmd = CommandPythonEnv(pylock=Path("/test/pylock"), command="script.py", python_version="3.13")
+    execute_command_python_env(cmd, "hi", "world")
+
+    # Should use cached strategy
+    mock_cached_strategy.get_environment.assert_called_once_with(cmd)
+
+    # Should call execute_command_exec once for execution
     mock_execute.assert_called_once()
+    called_command = mock_execute.call_args[0][0]
+    assert isinstance(called_command, CommandExec)
+    assert "script.py hi world" in called_command.command

--- a/tests/bfabric_app_runner/commands/test_command_python_env.py
+++ b/tests/bfabric_app_runner/commands/test_command_python_env.py
@@ -12,7 +12,7 @@ def mock_python_env_setup(mocker):
     """Common mocking setup for python environment tests."""
     # Create mock environment paths
     mock_env_path = Path("/cache/env/test_hash")
-    mock_ephemeral_path = Path("/tmp/bfabric_app_runner_refresh_12345")
+    mock_ephemeral_path = Path("/cache/ephemeral/env_12345")
 
     # Mock the strategy classes and their methods
     mock_cached_strategy = mocker.MagicMock()
@@ -38,6 +38,9 @@ def mock_python_env_setup(mocker):
     # Mock execute_command_exec
     mock_execute = mocker.patch("bfabric_app_runner.commands.command_python_env.execute_command_exec")
 
+    # Mock cleanup function
+    mock_cleanup = mocker.patch("bfabric_app_runner.commands.command_python_env._cleanup_ephemeral_environment")
+
     yield {
         "env_path": mock_env_path,
         "ephemeral_path": mock_ephemeral_path,
@@ -47,6 +50,7 @@ def mock_python_env_setup(mocker):
         "mock_ephemeral_strategy_class": mock_ephemeral_strategy_class,
         "mock_environment": mock_environment,
         "mock_execute": mock_execute,
+        "mock_cleanup": mock_cleanup,
     }
 
 


### PR DESCRIPTION
Fixes #228 


* **Refactor to `PythonEnvironment` class**: The environment provisioning logic has been encapsulated into a new `PythonEnvironment` class, streamlining environment creation, dependency installation, and provisioning checks.
* **Strategy pattern for environment management**: Introduced `EnvironmentStrategy` with implementations for `CachedEnvironmentStrategy` and `EphemeralEnvironmentStrategy`. This allows for dynamic selection between cached and temporary environments based on the `refresh` flag.
* **Ephemeral environment for `refresh=True`**: Modified the `refresh` flag behavior to create a temporary environment that avoids impacting cached environments, ensuring clean state provisioning. [[1]](diffhunk://#diff-5033b2aa14ab064914bac8f3cdd30b2bbde9011fa0311d605b71c0df1f49cc01R7-R9) [[2]](diffhunk://#diff-c936a453b8b51ba0ee723b351ab43eaff5d07ef1cf4bd8ce2d56cb5cfe78461fL102-R107)
