### PR TITLE
More changes for legacy wrapper creator

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -21,6 +21,10 @@ Versioning currently follows `X.Y.Z` where
 - `TokenData` will include the `caller` url now.
 - Entity `User` has been added.
 
+### Fixed
+
+- Legacy wrapper creator creates `""` rather than `None` for empty parameter values.
+
 ## \[1.13.30\] - 2025-08-19
 
 ### Fixed

--- a/bfabric/src/bfabric/wrapper_creator/bfabric_wrapper_creator.py
+++ b/bfabric/src/bfabric/wrapper_creator/bfabric_wrapper_creator.py
@@ -94,7 +94,7 @@ class BfabricWrapperCreator:
                 f"bfabric@{resource.storage.scp_prefix}{resource.data_dict['relativepath']}"
             )
         return {
-            "parameters": self.workunit_definition.execution.raw_parameters,
+            "parameters": {k: v or "" for k, v in self.workunit_definition.execution.raw_parameters.items()},
             "protocol": "scp",
             "input": dict(inputs),
             "output": [output_url],


### PR DESCRIPTION
The previous fix was not sufficient unfortunately.

- Convert `None` to `""` in workunit parameters.