### PR TITLE
More robust bfabric_list_not_existing_storage_directories.py

### DIFF
--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,6 +10,12 @@ Versioning currently follows `X.Y.Z` where
 
 ## \[Unreleased\]
 
+## \[1.13.35\] - 2025-09-25
+
+### Changed
+
+- `bfabric_list_not_existing_storage_directories.py` is made more robust. Instead of the file based cache, it will check all containers modified within a sliding time window (default 14 days).
+
 ## \[1.13.34\] - 2025-09-22
 
 ### Fixed

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -25,7 +25,7 @@ excel = ["fastexcel"]
 
 # TODO Legacy CLI interfaces
 #bfabric_feeder_resource_autoQC="bfabric_scripts.bfabric_feeder_resource_autoQC:main"
-"bfabric_list_not_existing_storage_directories.py" = "bfabric_scripts.bfabric_list_not_existing_storage_directories:main"
+"bfabric_list_not_existing_storage_directories.py" = "bfabric_scripts.bfabric_list_not_existing_storage_directories:app"
 "bfabric_list_workunit_parameters.py" = "bfabric_scripts.bfabric_list_workunit_parameters:main"
 "bfabric_upload_resource.py" = "bfabric_scripts.bfabric_upload_resource:main"
 "bfabric_logthis.py" = "bfabric_scripts.bfabric_logthis:main"

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 python_requires = ">=3.10"
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-mock", "logot[pytest,loguru]", "pyfakefs"]
+test = ["pytest", "pytest-mock", "logot[pytest,loguru]", "pyfakefs", "inline-snapshot", "freezegun"]
 excel = ["fastexcel"]
 
 [project.scripts]

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_list_not_existing_storage_directories.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_list_not_existing_storage_directories.py
@@ -28,7 +28,7 @@ def list_not_existing_storage_dirs(
 
     # list containers with technology id 2 or 4 modified after cutoff date
     result = client.read(
-        "container", obj={"technologyid": [2, 4], "modifiedafter": date}, return_id_only=True, max_results=None
+        endpoint="container", obj={"technologyid": [2, 4], "modifiedafter": date}, return_id_only=True, max_results=None
     )
     container_ids = sorted(r["id"] for r in result)
     count = 0

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_list_not_existing_storage_directories.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_list_not_existing_storage_directories.py
@@ -1,104 +1,43 @@
-#!/usr/bin/env python3
-"""
-Copyright (C) 2020 Functional Genomics Center Zurich ETHZ|UZH. All rights reserved.
-
-Author:
- Maria d'Errico <maria.derrico@fgcz.ethz.ch>
- Christian Panse <cp@fgcz.ethz.ch>
-
-Licensed under  GPL version 3
-"""
-
 from __future__ import annotations
 
 import datetime
-import json
-import os
 from pathlib import Path
 
+import cyclopts
 from loguru import logger
-from pydantic import BaseModel
 
 from bfabric import Bfabric
+from bfabric.utils.cli_integration import use_client
+
+app = cyclopts.App()
 
 
-class CacheData(BaseModel):
-    """Content of the cache file."""
+@app.default
+@use_client
+def list_not_existing_storage_dirs(
+    root_dir: Path = Path("/srv/www/htdocs"), cutoff_days: int = 14, *, client: Bfabric
+) -> None:
+    """Lists not existing storage directories for a given technology id.
 
-    container_ids: set[int] = set()
-    checked_at: datetime.datetime = datetime.datetime(2024, 1, 1)
-    query: dict[str, int | str | list[str | int]] = {
-        "technologyid": [2, 4],
-        "createdafter": "2024-01-01",
-    }
+    :param root_dir: Root directory where storage directories are located.
+    :param cutoff_days: Number of days to look back for modified containers.
+    """
+    # determine cutoff date
+    date = (datetime.date.today() - datetime.timedelta(days=cutoff_days)).isoformat()
+    logger.info(f"Checking containers modified after cutoff date: {date}")
 
-
-class Cache:
-    """Caches retrieval of the list of all container ids."""
-
-    def __init__(self, path: Path, data: CacheData) -> None:
-        self._path = path
-        self._data = data
-
-    @property
-    def container_ids(self) -> list[int]:
-        """Returns the container ids sorted."""
-        return sorted(self._data.container_ids)
-
-    @classmethod
-    def load(cls, path: Path) -> Cache:
-        """Returns the cache from the cache file if it exists, otherwise returns a new instance."""
-        if path.exists():
-            logger.info(f"Loading cache from {path}")
-            data = CacheData.model_validate_json(path.read_text())
-        else:
-            logger.info(f"Cache file {path} does not exist. Using default values.")
-            data = CacheData()
-        return cls(path=path, data=data)
-
-    def save(self) -> None:
-        """Saves the cache to the cache file."""
-        logger.info(f"Saving cache to {self._path}")
-        with self._path.open("w") as f:
-            json.dump(self._data.model_dump(mode="json"), f)
-
-    def update(self, client: Bfabric) -> None:
-        """Updates the cache with the container ids from B-Fabric."""
-        now = datetime.datetime.now()
-        # add some buffer to deal e.g. with miss-configured clocks
-        timestamp = (self._data.checked_at - datetime.timedelta(days=1)).isoformat()
-        max_results = 300 if "BFABRICPY_DEBUG" in os.environ else None
-        logger.debug(f"Checking for new container ids since {timestamp} with limit {max_results}")
-        result = client.read(
-            endpoint="container",
-            obj={**self._data.query, "createdafter": timestamp},
-            return_id_only=True,
-            max_results=max_results,
-        )
-        if len(result):
-            ids = result.to_polars()["id"].unique().to_list()
-            self._data.container_ids.update(ids)
-        self._data.checked_at = now
-
-
-def list_not_existing_storage_dirs(client: Bfabric, root_dir: Path, cache_path: Path) -> None:
-    """Lists not existing storage directories for a given technology id."""
-    cache = Cache.load(path=cache_path)
-    cache.update(client=client)
-    cache.save()
-
-    for container_id in cache.container_ids:
+    # list containers with technology id 2 or 4 modified after cutoff date
+    result = client.read(
+        "container", obj={"technologyid": [2, 4], "modifiedafter": date}, return_id_only=True, max_results=None
+    )
+    container_ids = sorted(r["id"] for r in result)
+    count = 0
+    for container_id in container_ids:
         if not (root_dir / f"p{container_id}").is_dir():
             print(container_id)
-
-
-def main() -> None:
-    """Calls `list_not_existing_storage_dirs`."""
-    client = Bfabric.connect()
-    root_dir = Path("/srv/www/htdocs/")
-    cache_path = Path("cache.json")
-    list_not_existing_storage_dirs(client=client, root_dir=root_dir, cache_path=cache_path)
+            count += 1
+    logger.info(f"Found {count} containers with not existing storage directories.")
 
 
 if __name__ == "__main__":
-    main()
+    app()

--- a/tests/bfabric_scripts/test_bfabric_list_not_existing_storage_directories.py
+++ b/tests/bfabric_scripts/test_bfabric_list_not_existing_storage_directories.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
+import datetime
 from pathlib import Path
 
 import pytest
-from bfabric_scripts.bfabric_list_not_existing_storage_directories import (
-    list_not_existing_storage_dirs,
-)
+from freezegun import freeze_time
+from inline_snapshot import snapshot
 from pytest_mock import MockerFixture
 
 from bfabric.results.result_container import ResultContainer
+from bfabric_scripts.bfabric_list_not_existing_storage_directories import (
+    list_not_existing_storage_dirs,
+)
 
 
+@freeze_time("2025-07-25")
 def test_list_not_existing_storage_directories(
-    capfd: pytest.CaptureFixture[str], mocker: MockerFixture, tmp_path: Path
+    capfd: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+    tmp_path: Path,
 ) -> None:
     # create a few directories
     existing = [tmp_path / d for d in ["p3000", "p3100", "p3200"]]
@@ -26,16 +32,22 @@ def test_list_not_existing_storage_directories(
     )
 
     # call the function
-    list_not_existing_storage_dirs(client, tmp_path, cache_path=tmp_path / "cache.json")
+    list_not_existing_storage_dirs(root_dir=tmp_path, client=client)
 
     # check output
     out, err = capfd.readouterr()
-    assert err == ""
+    assert err == snapshot(
+        """\
+INFO Checking containers modified after cutoff date: 2025-07-11
+INFO Found 2 containers with not existing storage directories.
+"""
+    )
+    # assert err == ""
     assert out == "3050\n3300\n"
 
     client.read.assert_called_once_with(
         endpoint="container",
-        obj={"technologyid": [2, 4], "createdafter": "2023-12-31T00:00:00"},
+        obj={"technologyid": [2, 4], "modifiedafter": "2025-07-11"},
         return_id_only=True,
         max_results=None,
     )


### PR DESCRIPTION
Instead of the file based cache, it will check all containers modified within a sliding time window (default 14 days).

Script becomes more readable as a result and should also better handle cases where retrospectively technologies are added to containers.