### PR TITLE
Update bfabric_save_workflowstep.py config handling

### DIFF
--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -14,6 +14,10 @@ Versioning currently follows `X.Y.Z` where
 
 - Delete unused `bfabric_feeder_resource_autoQC.py` script.
 
+### Changed
+
+- Legacy: Update configuration in `bfabric_save_workflowstep.py`. Not relevant for bfabric-app-runner apps.
+
 ## \[1.13.35\] - 2025-09-25
 
 ### Changed

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -16,7 +16,7 @@ Versioning currently follows `X.Y.Z` where
 
 ### Changed
 
-- Legacy: Update configuration in `bfabric_save_workflowstep.py`. Not relevant for bfabric-app-runner apps.
+- Legacy: `bfabric_save_workflowstep.py` reads config from `~/slurmworker/config/legacy_template_steps.yml`. Not relevant for bfabric-app-runner apps.
 
 ## \[1.13.35\] - 2025-09-25
 

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
@@ -93,7 +93,10 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Create an analysis workflow step")
     parser.add_argument("workunitid", metavar="workunitid", type=int, help="workunit id")
     parser.add_argument(
-        "--config-path", default=Path(os.path.expanduser("~/slurmworker/config/legacy_template_steps.yml")), type=Path
+        "--config-path",
+        default=Path(os.path.expanduser("~/slurmworker/config/legacy_template_steps.yml")),
+        type=Path,
+        required=False,
     )
     args = parser.parse_args()
     config = SaveWorkflowStepConfig.model_validate(yaml.safe_load(args.config_path.read_text()))

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
@@ -41,6 +41,10 @@ def save_workflowstep(workunit_id: int | None = None) -> None:
         314: 254,  # DIANN
         255: 256,  # maxquant_scaffold
         266: 258,  # MaxQuant-sampleSizeEstimation
+        302: 259,
+        308: 259,
+        310: 259,
+        315: 290,
     }
     workflowtemplate_ids = {
         224: 59,  # Proteomics Data analysis
@@ -48,6 +52,10 @@ def save_workflowstep(workunit_id: int | None = None) -> None:
         314: 59,
         255: 60,  # Proteomics Results
         266: 60,
+        302: 60,
+        308: 60,
+        310: 60,
+        315: 60,
     }
 
     workunit = Workunit.find(id=workunit_id, client=client)

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
@@ -94,7 +94,7 @@ def main() -> None:
     parser.add_argument("workunitid", metavar="workunitid", type=int, help="workunit id")
     parser.add_argument(
         "--config-path",
-        default=Path(os.path.expanduser("~/slurmworker/config/legacy_template_steps.yml")),
+        default=Path(os.path.expanduser("~/slurmworker/config/legacy_workflow_steps.yml")),
         type=Path,
         required=False,
     )

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_save_workflowstep.py
@@ -93,7 +93,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Create an analysis workflow step")
     parser.add_argument("workunitid", metavar="workunitid", type=int, help="workunit id")
     parser.add_argument(
-        "config_path", default=Path(os.path.expanduser("~/slurmworker/config/legacy_template_steps.yml")), type=Path
+        "--config-path", default=Path(os.path.expanduser("~/slurmworker/config/legacy_template_steps.yml")), type=Path
     )
     args = parser.parse_args()
     config = SaveWorkflowStepConfig.model_validate(yaml.safe_load(args.config_path.read_text()))


### PR DESCRIPTION
This script is for legacy purposes only anyways, as it can be handled directly in bfabric-app-runner now.

Config has been extracted into a file for apps which do not make use of it, so we can update it without releasing bfabric-scripts every time.