### PR TITLE
Fix regex

### DIFF
--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -14,6 +14,10 @@ Versioning currently follows `X.Y.Z` where
 
 - Delete unused `bfabric_feeder_resource_autoQC.py` script.
 
+### Fixed
+
+- `bfabric_save_importresource_sample.py` sample ID detection has been updated to work with recent queue generator and enabled for metabolomics.
+
 ### Changed
 
 - `bfabric_flask.py` didn't log exceptions properly because it passed the wrong argument `exc_info` instead of `exception`.

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_save_importresource_sample.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_save_importresource_sample.py
@@ -89,12 +89,13 @@ def create_importresource_dict(
 def get_sample_id_from_path(file_path: str) -> int | None:
     """Returns the sample id for a given file path, if it's present in the correct format."""
     match = re.search(
-        r"p([0-9]+)\/(Proteomics\/[A-Z]+_[1-9])\/.*_\d\d\d_S([0-9][0-9][0-9][0-9][0-9][0-9]+)_.*(raw|zip)$",
+        r"p\d+/(?:Proteomics|Metabolomics)/[A-Z]+_[1-9]/.*_\d{3}(?:_C\d+)?_S(?P<S>\d{6,})_.*\.(?:raw|zip)$",
         file_path,
     )
     if match:
-        logger.info(f"found sampleid={match.group(3)} pattern")
-        return int(match.group(3))
+        sample_id = match.group("S")
+        logger.info(f"found sample_id={sample_id} in path={file_path}")
+        return int(sample_id)
 
 
 def get_bfabric_application_and_project_id(bfabric_application_ids: dict[str, int], file_path: str) -> tuple[int, int]:


### PR DESCRIPTION
Fixes #313 

`bfabric_save_importresource_sample.py` sample ID detection has been updated to work with recent queue generator and enabled for metabolomics.