### PR TITLE
Fix bfabric_read_samples_of_workunit.py returns the same column name

### DIFF
--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,6 +10,10 @@ Versioning currently follows `X.Y.Z` where
 
 ## \[Unreleased\]
 
+### Fixed
+
+- Fix bfabric_read_samples_of_workunit.py returns the same column name `groupingvar_name` as in the past.
+
 ## \[1.13.38\] - 2025-12-03
 
 ### Changed

--- a/bfabric_scripts/src/bfabric_scripts/bfabric_read_samples_of_workunit.py
+++ b/bfabric_scripts/src/bfabric_scripts/bfabric_read_samples_of_workunit.py
@@ -55,10 +55,10 @@ def bfabric_read_samples_of_workunit(workunit_id: int, client: Bfabric) -> None:
                 raise ValueError("Should not be a list")
             sample = samples[sample_uri]
             data["sample_name"] = sample["name"]
-            data["sample_groupingvar"] = sample["groupingvar"]["name"] if sample["groupingvar"] else "NA"
+            data["groupingvar_name"] = sample["groupingvar"]["name"] if sample["groupingvar"] else "NA"
         else:
             data["sample_name"] = None
-            data["sample_groupingvar"] = "NA"
+            data["groupingvar_name"] = "NA"
         collect.append(data)
 
     table = pl.DataFrame(collect)


### PR DESCRIPTION
While fixing the ordering in the script the name of the column was accidentally changed to what I use elsewhere.
This reverts to `groupingvar_name` as it was before.