### PR TITLE
Fix dataset handling of none values

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,10 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+### Fixed
+
+- `Dataset` correctly handles `None` values in items.
+
 ## \[1.16.0\] - 2025-12-15
 
 ### Added

--- a/bfabric/src/bfabric/entities/dataset.py
+++ b/bfabric/src/bfabric/entities/dataset.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import io
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Any
 
 from polars import DataFrame
-from pydantic import BaseModel
+from pydantic import BaseModel, BeforeValidator
 
 from bfabric.entities.core.entity import Entity
 
@@ -18,8 +18,14 @@ class _AttributeData(BaseModel):
     type: str
 
 
+def _remove_none(value: Any) -> str:  # pyright: ignore[reportAny, reportExplicitAny]
+    if value is None:
+        return ""
+    return str(value)  # pyright: ignore[reportAny]
+
+
 class _ItemDataField(BaseModel):
-    value: str = ""
+    value: Annotated[str, BeforeValidator(_remove_none)] = ""
     attributeposition: int
 
 

--- a/tests/bfabric/entities/test_dataset.py
+++ b/tests/bfabric/entities/test_dataset.py
@@ -11,7 +11,7 @@ from bfabric.entities.dataset import Dataset
 
 
 @pytest.fixture()
-def mock_data_dict() -> dict[str, int | list[dict[str, str]] | list[dict[str, list[dict[str, str]]]]]:
+def mock_data_dict() -> dict[str, int | list[dict[str, str]] | list[dict[str, list[dict[str, str | None]]]]]:
     return {
         "id": 1234,
         "attribute": [
@@ -21,7 +21,7 @@ def mock_data_dict() -> dict[str, int | list[dict[str, str]] | list[dict[str, li
         "item": [
             {"field": [{"value": "Red", "attributeposition": "1"}, {"value": "Square", "attributeposition": "2"}]},
             {"field": [{"value": "Blue", "attributeposition": "1"}, {"value": "Circle", "attributeposition": "2"}]},
-            {"field": [{"value": "Green", "attributeposition": "1"}, {"attributeposition": "2"}]},
+            {"field": [{"value": None, "attributeposition": "1"}, {"attributeposition": "2"}]},
         ],
     }
 
@@ -37,7 +37,7 @@ def mock_data_dict_rearranged() -> dict[str, int | list[dict[str, str]] | list[d
         "item": [
             {"field": [{"value": "Square", "attributeposition": "2"}, {"value": "Red", "attributeposition": "1"}]},
             {"field": [{"value": "Circle", "attributeposition": "2"}, {"value": "Blue", "attributeposition": "1"}]},
-            {"field": [{"attributeposition": "2"}, {"value": "Green", "attributeposition": "1"}]},
+            {"field": [{"attributeposition": "2"}, {"value": "", "attributeposition": "1"}]},
         ],
     }
 
@@ -48,8 +48,8 @@ def mock_dataset(mock_data_dict: dict[str, Any], mock_client, bfabric_instance) 
 
 
 @pytest.fixture()
-def mock_empty_dataset(mock_client) -> Dataset:
-    return Dataset({"id": 1234, "attribute": [], "item": []}, client=mock_client)
+def mock_empty_dataset(mock_client, bfabric_instance) -> Dataset:
+    return Dataset({"id": 1234, "attribute": [], "item": []}, client=mock_client, bfabric_instance=bfabric_instance)
 
 
 def test_data_dict(mock_dataset: Dataset, mock_data_dict: dict[str, Any]) -> None:
@@ -66,15 +66,15 @@ def test_column_types(mock_dataset: Dataset) -> None:
 
 
 @pytest.mark.parametrize("rearranged_data_dict", [True, False])
-def test_to_polars(request, rearranged_data_dict: bool, mock_client) -> None:
+def test_to_polars(request, rearranged_data_dict: bool, mock_client, bfabric_instance) -> None:
     data_dict = request.getfixturevalue("mock_data_dict_rearranged" if rearranged_data_dict else "mock_data_dict")
-    mock_dataset = Dataset(data_dict, client=mock_client)
+    mock_dataset = Dataset(data_dict, client=mock_client, bfabric_instance=bfabric_instance)
     df = mock_dataset.to_polars()
     pl.testing.assert_frame_equal(
         df,
         pl.DataFrame(
             {
-                "Color": ["Red", "Blue", "Green"],
+                "Color": ["Red", "Blue", ""],
                 "Shape": ["Square", "Circle", ""],
             }
         ),
@@ -93,7 +93,7 @@ def test_write_csv(mocker: MockFixture, mock_dataset: Dataset) -> None:
 
 def test_get_csv(mock_dataset: Dataset) -> None:
     csv = mock_dataset.get_csv()
-    assert csv == 'Color,Shape\nRed,Square\nBlue,Circle\nGreen,""\n'
+    assert csv == 'Color,Shape\nRed,Square\nBlue,Circle\n"",""\n'
 
 
 def test_get_parquet(mock_dataset: Dataset) -> None:
@@ -103,7 +103,7 @@ def test_get_parquet(mock_dataset: Dataset) -> None:
         df,
         pl.DataFrame(
             {
-                "Color": ["Red", "Blue", "Green"],
+                "Color": ["Red", "Blue", ""],
                 "Shape": ["Square", "Circle", ""],
             }
         ),


### PR DESCRIPTION
I don't know why this wasn't caught earlier during testing, but there was a problem with `None` values which is fixed by this change.