### PR TITLE
Correctly handle string ids when passed to FindMixin.find_all

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -15,6 +15,10 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
     - `config_env`: Override the config environment (e.g. 'TEST'). Falls back to `BFABRICPY_CONFIG_ENV` env var or the config file default.
     - `config_file`: Override the config file path (default: ~/.bfabricpy.yml).
 
+### Fixed
+
+- `FindMixin.find_all` now correctly handles string IDs (e.g., `["1", "2"]`) in addition to integer IDs.
+
 ## \[1.17.0\] - 2026-03-12
 
 ### Added

--- a/bfabric/src/bfabric/entities/core/entity_reader.py
+++ b/bfabric/src/bfabric/entities/core/entity_reader.py
@@ -12,6 +12,8 @@ from bfabric.entities.core.uri import EntityUri, GroupedUris
 from bfabric.experimental import MultiQuery
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from bfabric import Bfabric
     from bfabric.typing import ApiRequestObjectType, ApiResponseDataType, ApiResponseObjectType
 
@@ -115,7 +117,7 @@ class EntityReader:
     def read_id(
         self,
         entity_type: str,
-        entity_id: int,
+        entity_id: int | str,
         bfabric_instance: str | None = None,
         *,
         expected_type: type[EntityT] = Entity,
@@ -136,7 +138,7 @@ class EntityReader:
         """
         results = self.read_ids(
             entity_type=entity_type,
-            entity_ids=[entity_id],
+            entity_ids=[int(entity_id)],
             bfabric_instance=bfabric_instance,
             expected_type=expected_type,
         )
@@ -145,7 +147,7 @@ class EntityReader:
     def read_ids(
         self,
         entity_type: str,
-        entity_ids: list[int],
+        entity_ids: Sequence[int | str],
         bfabric_instance: str | None = None,
         *,
         expected_type: type[EntityT] = Entity,
@@ -163,7 +165,7 @@ class EntityReader:
         """
         bfabric_instance = bfabric_instance if bfabric_instance is not None else self._client.config.base_url
         uris = [
-            EntityUri.from_components(bfabric_instance=bfabric_instance, entity_type=entity_type, entity_id=id)
+            EntityUri.from_components(bfabric_instance=bfabric_instance, entity_type=entity_type, entity_id=int(id))
             for id in entity_ids
         ]
         return self.read_uris(uris, expected_type=expected_type)

--- a/bfabric/src/bfabric/entities/core/mixins/find_mixin.py
+++ b/bfabric/src/bfabric/entities/core/mixins/find_mixin.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Protocol, TypeVar
 from loguru import logger
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
     from bfabric import Bfabric
     from bfabric.typing import ApiRequestObjectType
@@ -31,7 +31,7 @@ class FindMixin:
         return EntityReader.for_client(client=client).read_id(entity_type=cls.ENDPOINT, entity_id=id)
 
     @classmethod
-    def find_all(cls: type[T], ids: list[int], client: Bfabric) -> dict[int, T]:
+    def find_all(cls: type[T], ids: Sequence[int | str], client: Bfabric) -> dict[int, T]:
         """Returns a dictionary of entities with the given IDs. The order will generally match the input, however,
         if some entities are not found they will be omitted and a warning will be logged.
         """
@@ -42,7 +42,7 @@ class FindMixin:
         )
         results = EntityReader.for_client(client=client).read_ids(
             entity_type=cls.ENDPOINT,
-            entity_ids=ids,
+            entity_ids=list(ids),
             expected_type=cls,  # pyright: ignore[reportArgumentType]
         )
         results_by_id = {uri.components.entity_id: item for uri, item in results.items() if item is not None}
@@ -67,11 +67,11 @@ class FindMixin:
 
 
 def _ensure_results_order(
-    ids_requested: list[int],
+    ids_requested: Sequence[int | str],
     results: Mapping[int, T],
 ) -> dict[int, T]:
     """Ensures the results are in the same order as requested and prints a warning if some results are missing."""
-    results = {entity_id: results[entity_id] for entity_id in ids_requested if entity_id in results}
+    results = {int(entity_id): results[int(entity_id)] for entity_id in ids_requested if int(entity_id) in results}
     if len(results) != len(ids_requested):
         logger.warning(f"Only found {len(results)} out of {len(ids_requested)}.")
     return results

--- a/tests/bfabric/entities/core/test_entity.py
+++ b/tests/bfabric/entities/core/test_entity.py
@@ -145,6 +145,21 @@ class TestFindMixin:
         mock_client.assert_not_called()
 
     @staticmethod
+    def test_find_all_with_string_ids(mocker, mock_client, bfabric_instance) -> None:
+        uri1 = EntityUri.from_components(bfabric_instance, "testendpoint", 1)
+        uri2 = EntityUri.from_components(bfabric_instance, "testendpoint", 2)
+        mock_entity1 = Entity({"id": 1, "name": "Entity 1", "classname": "testendpoint"}, mock_client, bfabric_instance)
+        mock_entity2 = Entity({"id": 2, "name": "Entity 2", "classname": "testendpoint"}, mock_client, bfabric_instance)
+        mocker.patch.object(EntityReader, "read_ids", return_value={uri1: mock_entity1, uri2: mock_entity2})
+
+        entities = Entity.find_all(["1", "2"], mock_client)
+        assert len(entities) == 2
+        assert isinstance(entities[1], Entity)
+        assert isinstance(entities[2], Entity)
+        assert entities[1].data_dict == {"id": 1, "name": "Entity 1", "classname": "testendpoint"}
+        assert entities[2].data_dict == {"id": 2, "name": "Entity 2", "classname": "testendpoint"}
+
+    @staticmethod
     def test_find_by_when_found(mocker, mock_client) -> None:
         mock_client.read.return_value = [{"id": 1, "name": "Test Entity", "classname": "testendpoint"}]
         entities = Entity.find_by({"id": 1}, mock_client)


### PR DESCRIPTION
Fix #438 