### PR TITLE
Add BfabricTokenValidationFailedError for token errors

### DIFF
--- a/bfabric/docs/api_reference/exceptions_and_errors/index.md
+++ b/bfabric/docs/api_reference/exceptions_and_errors/index.md
@@ -20,6 +20,12 @@ Complete reference for all exception types in bfabricPy.
     :show-inheritance:
 ```
 
+```{eval-rst}
+.. autoclass:: bfabric.errors.BfabricTokenValidationFailedError
+    :members:
+    :show-inheritance:
+```
+
 ## See Also
 
 - [Error Handling](../../user_guides/error_handling.md) - Complete error handling guide

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -14,9 +14,6 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `use_client` decorator now injects two optional CLI parameters to decorated functions:
     - `config_env`: Override the config environment (e.g. 'TEST'). Falls back to `BFABRICPY_CONFIG_ENV` env var or the config file default.
     - `config_file`: Override the config file path (default: ~/.bfabricpy.yml).
-
-### Added
-
 - `BfabricTokenValidationFailedError` exception in `bfabric.errors`: raised by `get_token_data_async` (and `get_token_data`) when token validation fails, with named constructors `expired_token()` and `invalid_token()`.
 
 ### Fixed

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -15,6 +15,10 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
     - `config_env`: Override the config environment (e.g. 'TEST'). Falls back to `BFABRICPY_CONFIG_ENV` env var or the config file default.
     - `config_file`: Override the config file path (default: ~/.bfabricpy.yml).
 
+### Added
+
+- `BfabricTokenValidationFailedError` exception in `bfabric.errors`: raised by `get_token_data_async` (and `get_token_data`) when token validation fails, with named constructors `expired_token()` and `invalid_token()`.
+
 ### Fixed
 
 - `FindMixin.find_all` now correctly handles string IDs (e.g., `["1", "2"]`) in addition to integer IDs.

--- a/bfabric/docs/user_guides/error_handling.md
+++ b/bfabric/docs/user_guides/error_handling.md
@@ -114,6 +114,50 @@ else:
     print(f"Found sample: {entity['name']}")
 ```
 
+## Token Authentication Error Handling
+
+When using token-based authentication via `get_token_data` or `get_token_data_async` (called internally by `Bfabric.connect_token`), two specific exceptions may be raised.
+
+### BfabricTokenValidationFailedError
+
+Raised when the token is expired or otherwise invalid:
+
+```python
+from bfabric import Bfabric
+from bfabric.errors import BfabricTokenValidationFailedError
+from bfabric.experimental.webapp_integration_settings import TokenValidationSettings
+
+settings = TokenValidationSettings(
+    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
+    supported_bfabric_instances=["https://fgcz-bfabric.uzh.ch/bfabric/"],
+)
+
+try:
+    client, token_data = Bfabric.connect_token(token=token, settings=settings)
+except BfabricTokenValidationFailedError as e:
+    print(f"Token validation failed: {e}")
+    # e.g. "Token validation failed: token has expired."
+    # e.g. "Token validation failed: token is invalid."
+```
+
+The exception is constructed via two named constructors:
+
+- `BfabricTokenValidationFailedError.expired_token()` — raised when the token has passed its expiration time.
+- `BfabricTokenValidationFailedError.invalid_token()` — raised when the token signature or content is otherwise invalid.
+
+### BfabricInstanceNotConfiguredError
+
+Raised when the B-Fabric instance that issued the token is not listed in `supported_bfabric_instances`:
+
+```python
+from bfabric.errors import BfabricInstanceNotConfiguredError
+
+try:
+    client, token_data = Bfabric.connect_token(token=token, settings=settings)
+except BfabricInstanceNotConfiguredError as e:
+    print(f"Instance not supported: {e}")
+```
+
 ## See Also
 
 - [Exceptions and Errors](../api_reference/exceptions_and_errors/index.md) - Complete API reference for exception types

--- a/bfabric/docs/user_guides/error_handling.md
+++ b/bfabric/docs/user_guides/error_handling.md
@@ -118,8 +118,8 @@ else:
 
 `get_token_data` / `get_token_data_async` (called internally by `Bfabric.connect_token`) raise:
 
-- `BfabricTokenValidationFailedError` — token is expired or otherwise invalid.
-- `BfabricInstanceNotConfiguredError` — token's origin instance is not in `supported_bfabric_instances`.
+- {class}`~bfabric.errors.BfabricTokenValidationFailedError` — token is expired or otherwise invalid.
+- {class}`~bfabric.errors.BfabricInstanceNotConfiguredError` — token's origin instance is not in `supported_bfabric_instances`.
 
 ```python
 from bfabric.errors import (

--- a/bfabric/docs/user_guides/error_handling.md
+++ b/bfabric/docs/user_guides/error_handling.md
@@ -116,44 +116,21 @@ else:
 
 ## Token Authentication Error Handling
 
-When using token-based authentication via `get_token_data` or `get_token_data_async` (called internally by `Bfabric.connect_token`), two specific exceptions may be raised.
+`get_token_data` / `get_token_data_async` (called internally by `Bfabric.connect_token`) raise:
 
-### BfabricTokenValidationFailedError
-
-Raised when the token is expired or otherwise invalid:
+- `BfabricTokenValidationFailedError` — token is expired or otherwise invalid.
+- `BfabricInstanceNotConfiguredError` — token's origin instance is not in `supported_bfabric_instances`.
 
 ```python
-from bfabric import Bfabric
-from bfabric.errors import BfabricTokenValidationFailedError
-from bfabric.experimental.webapp_integration_settings import TokenValidationSettings
-
-settings = TokenValidationSettings(
-    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
-    supported_bfabric_instances=["https://fgcz-bfabric.uzh.ch/bfabric/"],
+from bfabric.errors import (
+    BfabricInstanceNotConfiguredError,
+    BfabricTokenValidationFailedError,
 )
 
 try:
     client, token_data = Bfabric.connect_token(token=token, settings=settings)
 except BfabricTokenValidationFailedError as e:
     print(f"Token validation failed: {e}")
-    # e.g. "Token validation failed: token has expired."
-    # e.g. "Token validation failed: token is invalid."
-```
-
-The exception is constructed via two named constructors:
-
-- `BfabricTokenValidationFailedError.expired_token()` — raised when the token has passed its expiration time.
-- `BfabricTokenValidationFailedError.invalid_token()` — raised when the token signature or content is otherwise invalid.
-
-### BfabricInstanceNotConfiguredError
-
-Raised when the B-Fabric instance that issued the token is not listed in `supported_bfabric_instances`:
-
-```python
-from bfabric.errors import BfabricInstanceNotConfiguredError
-
-try:
-    client, token_data = Bfabric.connect_token(token=token, settings=settings)
 except BfabricInstanceNotConfiguredError as e:
     print(f"Instance not supported: {e}")
 ```

--- a/bfabric/src/bfabric/errors.py
+++ b/bfabric/src/bfabric/errors.py
@@ -62,6 +62,18 @@ class BfabricInstanceNotConfiguredError(RuntimeError):
         super().__init__(f"Instance '{instance_name}' is not configured as supported.")
 
 
+class BfabricTokenValidationFailedError(RuntimeError):
+    """Raised when token validation fails (expired or otherwise invalid)."""
+
+    @classmethod
+    def expired_token(cls) -> BfabricTokenValidationFailedError:
+        return cls("Token validation failed: token has expired.")
+
+    @classmethod
+    def invalid_token(cls) -> BfabricTokenValidationFailedError:
+        return cls("Token validation failed: token is invalid.")
+
+
 # TODO: Also test for response-level errors
 def get_response_errors(response: Any, endpoint: str) -> list[BfabricRequestError]:
     """

--- a/bfabric/src/bfabric/rest/token_data.py
+++ b/bfabric/src/bfabric/rest/token_data.py
@@ -17,8 +17,10 @@ from pydantic import (
     WrapValidator,
 )
 
+from pydantic import ValidationError
+
 from bfabric.entities.core.import_entity import import_entity
-from bfabric.errors import BfabricInstanceNotConfiguredError
+from bfabric.errors import BfabricInstanceNotConfiguredError, BfabricTokenValidationFailedError
 
 if TYPE_CHECKING:
     from bfabric import Bfabric
@@ -88,16 +90,25 @@ async def get_token_data_async(
     """Returns the token data for the provided token.
 
     Raises:
-        httpx.HTTPError: If the HTTP request fails (covers connection errors, timeouts, 4xx/5xx status).
-        pydantic.ValidationError: If the response body is not valid JSON or doesn't match the TokenData schema.
+        BfabricTokenValidationFailedError: If token validation fails due to an expired or otherwise invalid token.
     """
     url = urllib.parse.urljoin(f"{base_url}/", "rest/token/validate")
     async with contextlib.nullcontext(http_client) if http_client is not None else httpx.AsyncClient() as client:
         response = await client.get(
             url, params={"token": token.get_secret_value() if isinstance(token, SecretStr) else token}
         )
-    _ = response.raise_for_status()
-    return TokenData.model_validate_json(response.text)
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        if "Token expired" in response.text:
+            raise BfabricTokenValidationFailedError.expired_token() from e
+        raise BfabricTokenValidationFailedError.invalid_token() from e
+    try:
+        return TokenData.model_validate_json(response.text)
+    except ValidationError as e:
+        if "Token expired" in response.text:
+            raise BfabricTokenValidationFailedError.expired_token() from e
+        raise BfabricTokenValidationFailedError.invalid_token() from e
 
 
 def get_token_data(base_url: str, token: str) -> TokenData:
@@ -114,8 +125,7 @@ async def validate_token(
     """Validates the token according to the provided settings.
 
     Raises:
-        httpx.HTTPError: If the HTTP request fails (covers connection errors, timeouts, 4xx/5xx status).
-        pydantic.ValidationError: If the response body is not valid JSON or doesn't match the TokenData schema.
+        BfabricTokenValidationFailedError: If token validation fails due to an expired or otherwise invalid token.
         BfabricInstanceNotConfiguredError: If the caller is not configured as supported.
     """
     token_data = await get_token_data_async(

--- a/bfabric/src/bfabric/rest/token_data.py
+++ b/bfabric/src/bfabric/rest/token_data.py
@@ -99,13 +99,8 @@ async def get_token_data_async(
         )
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as e:
-        if "Token expired" in response.text:
-            raise BfabricTokenValidationFailedError.expired_token() from e
-        raise BfabricTokenValidationFailedError.invalid_token() from e
-    try:
         return TokenData.model_validate_json(response.text)
-    except ValidationError as e:
+    except (httpx.HTTPStatusError, ValidationError) as e:
         if "Token expired" in response.text:
             raise BfabricTokenValidationFailedError.expired_token() from e
         raise BfabricTokenValidationFailedError.invalid_token() from e

--- a/bfabric/src/bfabric/rest/token_data.py
+++ b/bfabric/src/bfabric/rest/token_data.py
@@ -98,7 +98,7 @@ async def get_token_data_async(
             url, params={"token": token.get_secret_value() if isinstance(token, SecretStr) else token}
         )
     try:
-        response.raise_for_status()
+        _ = response.raise_for_status()
         return TokenData.model_validate_json(response.text)
     except (httpx.HTTPStatusError, ValidationError) as e:
         if "Token expired" in response.text:

--- a/tests/bfabric/rest/test_token_data.py
+++ b/tests/bfabric/rest/test_token_data.py
@@ -5,6 +5,7 @@ import pytest
 import httpx
 from pydantic import SecretStr, ValidationError
 
+from bfabric.errors import BfabricTokenValidationFailedError
 from bfabric.rest.token_data import TokenData, get_token_data, get_token_data_async
 
 
@@ -113,8 +114,8 @@ async def test_get_token_data_async(mocker, token_data, base_url, extra_slash: s
 
 
 @pytest.mark.asyncio
-async def test_get_token_data_async_when_response_error(mocker, base_url):
-    mock_response = mocker.Mock()
+async def test_get_token_data_async_when_expired_token_in_http_error(mocker, base_url):
+    mock_response = mocker.Mock(text="Token expired")
     mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
         "Mocked HTTP error", request=mocker.Mock(), response=mocker.Mock()
     )
@@ -122,26 +123,46 @@ async def test_get_token_data_async_when_response_error(mocker, base_url):
     mock_client = mocker.AsyncMock()
     mock_client.get.return_value = mock_response
 
-    with pytest.raises(httpx.HTTPStatusError):
+    with pytest.raises(BfabricTokenValidationFailedError, match="expired"):
         await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
-
-    mock_client.get.assert_called_once_with(f"{base_url}/rest/token/validate", params={"token": "mock-token"})
 
 
 @pytest.mark.asyncio
-async def test_get_token_data_async_when_json_decode_error(mocker, base_url):
-    mock_response = mocker.Mock(text="not json")
+async def test_get_token_data_async_when_other_http_error(mocker, base_url):
+    mock_response = mocker.Mock(text="Some other error")
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Mocked HTTP error", request=mocker.Mock(), response=mocker.Mock()
+    )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.get.return_value = mock_response
+
+    with pytest.raises(BfabricTokenValidationFailedError, match="invalid"):
+        await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
+
+
+@pytest.mark.asyncio
+async def test_get_token_data_async_when_expired_token_in_body(mocker, base_url):
+    mock_response = mocker.Mock(text="Token expired")
     mock_response.raise_for_status = mocker.Mock()
 
     mock_client = mocker.AsyncMock()
     mock_client.get.return_value = mock_response
 
-    with pytest.raises(ValidationError) as err:
+    with pytest.raises(BfabricTokenValidationFailedError, match="expired"):
         await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
 
-    assert "Invalid JSON" in str(err.value)
 
-    mock_client.get.assert_called_once_with(f"{base_url}/rest/token/validate", params={"token": "mock-token"})
+@pytest.mark.asyncio
+async def test_get_token_data_async_when_invalid_json_body(mocker, base_url):
+    mock_response = mocker.Mock(text='{"unexpected": "schema"}')
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_client = mocker.AsyncMock()
+    mock_client.get.return_value = mock_response
+
+    with pytest.raises(BfabricTokenValidationFailedError, match="invalid"):
+        await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
 
 
 def test_get_token_data(mocker, token_data, base_url):


### PR DESCRIPTION
Fixes #337

- Adds `BfabricTokenValidationFailedError` to `bfabric.errors` with `expired_token()` and `invalid_token()` named constructors
- `get_token_data_async` now catches `httpx.HTTPStatusError` and `pydantic.ValidationError` and re-raises as `BfabricTokenValidationFailedError`, classifying based on whether "Token expired" appears in the response body
- Callers no longer need to write boilerplate to detect expired tokens 
