### PR TITLE
Fix Python version in publish_release workflow to 3.12

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install hatch
         run: pip install hatch
       - name: Set PyPI repository URL


### PR DESCRIPTION
Fixes #443
which was causing issues with bfabric-app-runner