### PR TITLE
Fix ghp-import flags to preserve gh-pages content

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Deploy to /dev/ on gh-pages
         run: |
           pip install ghp-import
-          ghp-import --no-jekyll \
+          ghp-import --force --no-jekyll \
             --prefix dev \
             --message "Update dev docs preview from ${GITHUB_SHA::8}" \
             --push site
@@ -62,6 +62,6 @@ jobs:
       - name: Publish documentation to GitHub Pages
         run: |
           pip install ghp-import
-          ghp-import --no-jekyll \
+          ghp-import --force --no-jekyll \
             --message "Update production docs from ${GITHUB_SHA::8}" \
             --push site


### PR DESCRIPTION
## Summary
- Keep `--force` (needed for CI push) but remove `--no-history` (which wiped everything)
- Replace `nox -s publish_docs` with direct `ghp-import` call in production deploy

Fixes the deploy-dev job wiping production docs and the rejected push error from CI.