### PR TITLE
Fix docs deployment to preserve /dev/ and root content

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -35,11 +35,21 @@ jobs:
         run: nox -s docs
       - name: Deploy to /dev/ on gh-pages
         run: |
-          pip install ghp-import
-          ghp-import --force --no-jekyll \
-            --prefix dev \
-            --message "Update dev docs preview from ${GITHUB_SHA::8}" \
-            --push site
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin gh-pages 2>/dev/null \
+            && git worktree add gh-pages origin/gh-pages \
+            || git worktree add --orphan gh-pages gh-pages
+
+          rm -rf gh-pages/dev
+          cp -r site gh-pages/dev
+          touch gh-pages/.nojekyll
+
+          cd gh-pages && git add -A
+          git diff --cached --quiet || git commit -m "docs(dev): ${GITHUB_SHA::8}"
+          git push origin HEAD:gh-pages
   deploy-production:
     name: Deploy Production Docs
     runs-on: ubuntu-latest
@@ -59,9 +69,21 @@ jobs:
         run: pip install nox uv
       - name: Build documentation
         run: nox -s docs
-      - name: Publish documentation to GitHub Pages
+      - name: Deploy production docs to gh-pages
         run: |
-          pip install ghp-import
-          ghp-import --force --no-jekyll \
-            --message "Update production docs from ${GITHUB_SHA::8}" \
-            --push site
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin gh-pages 2>/dev/null \
+            && git worktree add gh-pages origin/gh-pages \
+            || git worktree add --orphan gh-pages gh-pages
+
+          cd gh-pages
+          find . -maxdepth 1 ! -name '.' ! -name '.git' ! -name 'dev' -exec rm -rf {} +
+          cp -r ../site/* .
+          touch .nojekyll
+
+          git add -A
+          git diff --cached --quiet || git commit -m "docs: ${GITHUB_SHA::8}"
+          git push origin HEAD:gh-pages

--- a/noxfile.py
+++ b/noxfile.py
@@ -319,17 +319,6 @@ def docs(session):
 
 
 @nox.session(default=False)
-def publish_docs(session):
-    """Publish documentation to GitHub Pages by updating gh-pages branch."""
-    site_dir = Path("site")
-    if not site_dir.exists():
-        session.error("Site directory does not exist. Run 'nox -s docs' first.")
-
-    session.install("ghp-import")
-    session.run("ghp-import", "--force", "--no-jekyll", "--push", "site")
-
-
-@nox.session(default=False)
 def code_style(session):
     session.install("ruff")
     session.run("ruff", "check", "bfabric")


### PR DESCRIPTION

- Replace `ghp-import` with git worktree operations so dev and production deploys no longer clobber each other
- Place `.nojekyll` at the gh-pages root (not under `dev/`) so Jekyll doesn't strip `_static/` directories
- Remove the `nox publish_docs` session since deployment is CI-only

Closes #480