### PR TITLE
Expose token entity/job info through BfabricUser

### DIFF
--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/middleware.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/middleware.py
@@ -136,6 +136,10 @@ class BfabricAuthMiddleware:
             bfabric_instance=result.token_data.caller,
             bfabric_auth_login=result.token_data.user,
             bfabric_auth_password=result.token_data.user_ws_password.get_secret_value(),
+            entity_class=result.token_data.entity_class,
+            entity_id=result.token_data.entity_id,
+            job_id=result.token_data.job_id,
+            application_id=result.token_data.application_id,
         )
 
         # Store session data by modifying scope["session"] directly, this is supported by starlette's SessionMiddleware

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
@@ -18,7 +18,7 @@ class SessionData(BaseModel):
     bfabric_instance: str
     bfabric_auth_login: str
     bfabric_auth_password: str
-    entity_class: str | None = None
-    entity_id: int | None = None
-    job_id: int | None = None
-    application_id: int | None = None
+    entity_class: str
+    entity_id: int
+    job_id: int
+    application_id: int

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
@@ -18,3 +18,7 @@ class SessionData(BaseModel):
     bfabric_instance: str
     bfabric_auth_login: str
     bfabric_auth_password: str
+    entity_class: str | None = None
+    entity_id: int | None = None
+    job_id: int | None = None
+    application_id: int | None = None

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
@@ -13,6 +13,10 @@ class SessionData(BaseModel):
     :ivar bfabric_instance: Bfabric instance URL
     :ivar bfabric_auth_login: Bfabric authentication login
     :ivar bfabric_auth_password: Bfabric authentication password
+    :ivar entity_class: Target entity class name (e.g. "Workunit")
+    :ivar entity_id: Target entity ID
+    :ivar job_id: ID of the associated job
+    :ivar application_id: ID of the B-Fabric application
     """
 
     bfabric_instance: str

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/user.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/user.py
@@ -43,19 +43,19 @@ class BfabricUser(BaseUser):
         return self._session_data.bfabric_instance
 
     @property
-    def entity_class(self) -> str | None:
+    def entity_class(self) -> str:
         return self._session_data.entity_class
 
     @property
-    def entity_id(self) -> int | None:
+    def entity_id(self) -> int:
         return self._session_data.entity_id
 
     @property
-    def job_id(self) -> int | None:
+    def job_id(self) -> int:
         return self._session_data.job_id
 
     @property
-    def application_id(self) -> int | None:
+    def application_id(self) -> int:
         return self._session_data.application_id
 
     def get_bfabric_client(self) -> Bfabric:

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/user.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/user.py
@@ -42,6 +42,22 @@ class BfabricUser(BaseUser):
     def instance(self) -> str:
         return self._session_data.bfabric_instance
 
+    @property
+    def entity_class(self) -> str | None:
+        return self._session_data.entity_class
+
+    @property
+    def entity_id(self) -> int | None:
+        return self._session_data.entity_id
+
+    @property
+    def job_id(self) -> int | None:
+        return self._session_data.job_id
+
+    @property
+    def application_id(self) -> int | None:
+        return self._session_data.application_id
+
     def get_bfabric_client(self) -> Bfabric:
         """Create a Bfabric client authenticated as this user."""
         config = ConfigData(

--- a/bfabric_asgi_auth/tests/bdd/conftest.py
+++ b/bfabric_asgi_auth/tests/bdd/conftest.py
@@ -68,6 +68,10 @@ def base_app():
                 "identity": user.identity,
                 "login": user.login,
                 "instance": user.instance,
+                "entity_class": user.entity_class,
+                "entity_id": user.entity_id,
+                "job_id": user.job_id,
+                "application_id": user.application_id,
             }
         )
 
@@ -523,6 +527,12 @@ def session_bfabric_session_has_required_fields(context, client):
     # Verify password content matches (not just length)
     assert session_data["bfabric_auth_password"] == token_data.user_ws_password.get_secret_value()
 
+    # Verify token context fields
+    assert session_data["entity_class"] == token_data.entity_class
+    assert session_data["entity_id"] == token_data.entity_id
+    assert session_data["job_id"] == token_data.job_id
+    assert session_data["application_id"] == token_data.application_id
+
 
 @then("the hook should have received token data")
 def hook_received_token_data(context):
@@ -664,3 +674,27 @@ def scope_user_instance(context, instance):
 def websocket_scope_user_set(context):
     """Check WebSocket scope has user set."""
     assert context["websocket_response"]["has_user"] is True
+
+
+@then(parsers.parse('the scope user entity_class should be "{value}"'))
+def scope_user_entity_class(context, value):
+    """Check scope user entity_class."""
+    assert context["user_info"]["entity_class"] == value
+
+
+@then(parsers.parse("the scope user entity_id should be {value:d}"))
+def scope_user_entity_id(context, value):
+    """Check scope user entity_id."""
+    assert context["user_info"]["entity_id"] == value
+
+
+@then(parsers.parse("the scope user job_id should be {value:d}"))
+def scope_user_job_id(context, value):
+    """Check scope user job_id."""
+    assert context["user_info"]["job_id"] == value
+
+
+@then(parsers.parse("the scope user application_id should be {value:d}"))
+def scope_user_application_id(context, value):
+    """Check scope user application_id."""
+    assert context["user_info"]["application_id"] == value

--- a/bfabric_asgi_auth/tests/bdd/features/token_context.feature
+++ b/bfabric_asgi_auth/tests/bdd/features/token_context.feature
@@ -1,0 +1,23 @@
+Feature: Token context on BfabricUser
+  As an app developer
+  I want to access entity_class, entity_id, job_id, and application_id from BfabricUser
+  So that I don't need to use the on_success hook to capture token context
+
+  Background:
+    Given the application is configured with auth middleware
+
+  Scenario: Token context fields are accessible on BfabricUser
+    Given I am authenticated with token "valid_test123"
+    When I request the user info endpoint
+    Then the scope user entity_class should be "Workunit"
+    And the scope user entity_id should be 2
+    And the scope user application_id should be 1
+
+  Scenario: Token context round-trips through session
+    Given I am authenticated with token "valid_test123"
+    When I request the user info endpoint
+    Then the scope user should be a BfabricUser
+    And the scope user login should be "test123"
+    And the scope user entity_class should be "Workunit"
+    And the scope user entity_id should be 2
+    And the scope user application_id should be 1

--- a/bfabric_asgi_auth/tests/unit/test_user.py
+++ b/bfabric_asgi_auth/tests/unit/test_user.py
@@ -55,18 +55,6 @@ class TestBfabricUser:
     def test_application_id(self, user: BfabricUser) -> None:
         assert user.application_id == 7
 
-    def test_token_fields_optional(self) -> None:
-        session_data = SessionData(
-            bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
-            bfabric_auth_login="testuser",
-            bfabric_auth_password="a" * 32,
-        )
-        user = BfabricUser(session_data)
-        assert user.entity_class is None
-        assert user.entity_id is None
-        assert user.job_id is None
-        assert user.application_id is None
-
     def test_get_bfabric_client(self, user: BfabricUser) -> None:
         client = user.get_bfabric_client()
         assert isinstance(client, Bfabric)

--- a/bfabric_asgi_auth/tests/unit/test_user.py
+++ b/bfabric_asgi_auth/tests/unit/test_user.py
@@ -15,6 +15,10 @@ def session_data() -> SessionData:
         bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
         bfabric_auth_login="testuser",
         bfabric_auth_password="a" * 32,
+        entity_class="Workunit",
+        entity_id=42,
+        job_id=123,
+        application_id=7,
     )
 
 
@@ -38,6 +42,30 @@ class TestBfabricUser:
 
     def test_identity(self, user: BfabricUser) -> None:
         assert user.identity == "testuser@https://fgcz-bfabric.uzh.ch/bfabric/"
+
+    def test_entity_class(self, user: BfabricUser) -> None:
+        assert user.entity_class == "Workunit"
+
+    def test_entity_id(self, user: BfabricUser) -> None:
+        assert user.entity_id == 42
+
+    def test_job_id(self, user: BfabricUser) -> None:
+        assert user.job_id == 123
+
+    def test_application_id(self, user: BfabricUser) -> None:
+        assert user.application_id == 7
+
+    def test_token_fields_optional(self) -> None:
+        session_data = SessionData(
+            bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
+            bfabric_auth_login="testuser",
+            bfabric_auth_password="a" * 32,
+        )
+        user = BfabricUser(session_data)
+        assert user.entity_class is None
+        assert user.entity_id is None
+        assert user.job_id is None
+        assert user.application_id is None
 
     def test_get_bfabric_client(self, user: BfabricUser) -> None:
         client = user.get_bfabric_client()


### PR DESCRIPTION
- Adds `entity_class`, `entity_id`, `job_id`, and `application_id` as optional fields on `SessionData` and read-only properties on `BfabricUser`
- Middleware now populates these from `TokenData` during token validation, so app code can use `user.entity_class` and `user.entity_id` directly
- Previously this context was lost after token validation and only accessible via the `on_success` hook
