### PR TITLE
Add EntityReader.query_one helper

### DIFF
--- a/.basedpyright/baseline.bfabric.json
+++ b/.basedpyright/baseline.bfabric.json
@@ -2008,14 +2008,6 @@
                     "endColumn": 26,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
             }
         ],
         "./bfabric/src/bfabric/entities/dataset.py": [

--- a/.basedpyright/baseline.bfabric.json
+++ b/.basedpyright/baseline.bfabric.json
@@ -1402,14 +1402,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 17,

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -19,6 +19,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ### Changed
 
+- `EntityReader.query` now accepts an `expected_type` keyword argument for typed narrowing of results (matches `read_uris`/`read_ids`); raises `TypeError` on mismatch.
 - `User.find_by_login` now delegates to `EntityReader.query_one`; no longer triggers the `FindMixin` deprecation warning.
 
 ### Fixed

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -15,6 +15,11 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
     - `config_env`: Override the config environment (e.g. 'TEST'). Falls back to `BFABRICPY_CONFIG_ENV` env var or the config file default.
     - `config_file`: Override the config file path (default: ~/.bfabricpy.yml).
 - `BfabricTokenValidationFailedError` exception in `bfabric.errors`: raised by `get_token_data_async` (and `get_token_data`) when token validation fails, with named constructors `expired_token()` and `invalid_token()`.
+- `EntityReader.query_one(entity_type, obj, *, expected_type=Entity)`: returns at most one entity (or `None`) matching the given query; typed-narrowing wrapper around `EntityReader.query` with `max_results=1`.
+
+### Changed
+
+- `User.find_by_login` now delegates to `EntityReader.query_one`; no longer triggers the `FindMixin` deprecation warning.
 
 ### Fixed
 

--- a/bfabric/src/bfabric/entities/core/entity_reader.py
+++ b/bfabric/src/bfabric/entities/core/entity_reader.py
@@ -27,7 +27,7 @@ class EntityReader:
     This class provides multiple methods to read entities from B-Fabric:
     - By URI(s): :meth:`read_uri`, :meth:`read_uris`
     - By ID(s): :meth:`read_id`, :meth:`read_ids`
-    - By query criteria: :meth:`query`
+    - By query criteria: :meth:`query`, :meth:`query_one`
 
     All methods use the cache stack when available to minimize API calls.
     """
@@ -206,6 +206,39 @@ class EntityReader:
         }
         cache_stack.item_put_all(entities=entities.values())
         return entities
+
+    def query_one(
+        self,
+        entity_type: str,
+        obj: ApiRequestObjectType,
+        bfabric_instance: str | None = None,
+        *,
+        expected_type: type[EntityT] = Entity,
+    ) -> EntityT | None:
+        """Query for a single entity by search criteria.
+
+        Thin wrapper over :meth:`query` with ``max_results=1`` for the common
+        look-up-by-field pattern. Returns ``None`` if no match.
+
+        Args:
+            entity_type: B-Fabric entity type to query
+            obj: Dictionary of search criteria (e.g., ``{"login": "alice"}``)
+            bfabric_instance: B-Fabric instance URL (defaults to client's configured instance)
+            expected_type: Entity class to validate and cast the result
+
+        Returns:
+            Entity object (typed as ``expected_type``) or ``None`` if not found
+
+        Raises:
+            TypeError: If the matched entity is not an instance of ``expected_type``
+        """
+        results = self.query(entity_type, obj, bfabric_instance=bfabric_instance, max_results=1)
+        entity = next(iter(results.values()), None)
+        if entity is None:
+            return None
+        if not isinstance(entity, expected_type):
+            raise TypeError(f"Expected {expected_type.__name__}, got {type(entity).__name__}")
+        return entity
 
     def _retrieve_entities(self, uris: list[EntityUri]) -> dict[EntityUri, Entity]:
         """Retrieve entities from B-Fabric API.

--- a/bfabric/src/bfabric/entities/core/entity_reader.py
+++ b/bfabric/src/bfabric/entities/core/entity_reader.py
@@ -176,7 +176,9 @@ class EntityReader:
         obj: ApiRequestObjectType,
         bfabric_instance: str | None = None,
         max_results: int | None = 100,
-    ) -> dict[EntityUri, Entity | None]:
+        *,
+        expected_type: type[EntityT] = Entity,
+    ) -> dict[EntityUri, EntityT]:
         """Query entities by search criteria and return them as Entity objects.
 
         Combines ``client.read()`` with automatic entity instantiation and caching.
@@ -186,9 +188,13 @@ class EntityReader:
             obj: Dictionary of search criteria (e.g., ``{"name": "MySample"}``)
             bfabric_instance: B-Fabric instance URL (defaults to client's configured instance)
             max_results: Maximum number of results to return (default: 100, None for all)
+            expected_type: Entity class to validate and cast all results
 
         Returns:
             Dictionary mapping entity URIs to their objects
+
+        Raises:
+            TypeError: If any matched entity is not an instance of ``expected_type``
         """
         bfabric_instance = bfabric_instance if bfabric_instance is not None else self._client.config.base_url
         # TODO limitation of the current implementation
@@ -204,8 +210,11 @@ class EntityReader:
                 instantiate_entity(data_dict=r, client=self._client, bfabric_instance=bfabric_instance) for r in result
             ]
         }
+        for entity in entities.values():
+            if not isinstance(entity, expected_type):
+                raise TypeError(f"Expected {expected_type.__name__}, got {type(entity).__name__}")
         cache_stack.item_put_all(entities=entities.values())
-        return entities
+        return cast("dict[EntityUri, EntityT]", entities)
 
     def query_one(
         self,
@@ -232,13 +241,10 @@ class EntityReader:
         Raises:
             TypeError: If the matched entity is not an instance of ``expected_type``
         """
-        results = self.query(entity_type, obj, bfabric_instance=bfabric_instance, max_results=1)
-        entity = next(iter(results.values()), None)
-        if entity is None:
-            return None
-        if not isinstance(entity, expected_type):
-            raise TypeError(f"Expected {expected_type.__name__}, got {type(entity).__name__}")
-        return entity
+        results = self.query(
+            entity_type, obj, bfabric_instance=bfabric_instance, max_results=1, expected_type=expected_type
+        )
+        return next(iter(results.values()), None)
 
     def _retrieve_entities(self, uris: list[EntityUri]) -> dict[EntityUri, Entity]:
         """Retrieve entities from B-Fabric API.

--- a/bfabric/src/bfabric/entities/core/users.py
+++ b/bfabric/src/bfabric/entities/core/users.py
@@ -33,18 +33,19 @@ class Users:
 
     def get_by_login(self, bfabric_instance: str, login: str) -> User | None:
         """Gets a user by their login name."""
+        from bfabric.entities.user import User as UserEntity
+
         # check if exists
         for user in self._users:
             if user["login"] == login:
                 return user
 
         # retrieve
-        users = self._entity_reader.query(
-            entity_type="user", obj={"login": login}, bfabric_instance=bfabric_instance, max_results=1
+        user = self._entity_reader.query_one(
+            "user", {"login": login}, bfabric_instance=bfabric_instance, expected_type=UserEntity
         )
-        if not users:
+        if user is None:
             return None
-        user = list(users.values())[0]
 
         # store
         self._users.append(user)

--- a/bfabric/src/bfabric/entities/user.py
+++ b/bfabric/src/bfabric/entities/user.py
@@ -13,7 +13,4 @@ class User(Entity):
     @classmethod
     def find_by_login(cls, login: str, client: Bfabric) -> User | None:
         """Finds a user by their login name."""
-        users = cls.find_by({"login": login}, client=client)
-        if not users:
-            return None
-        return list(users.values())[0]
+        return client.reader.query_one("user", {"login": login}, expected_type=cls)

--- a/tests/bfabric/entities/core/test_entity_reader.py
+++ b/tests/bfabric/entities/core/test_entity_reader.py
@@ -460,6 +460,67 @@ class TestQuery:
         assert f"Unsupported B-Fabric instance: {different_instance}" in str(exc_info.value)
 
 
+class TestQueryOne:
+    def test_returns_entity_when_single_match(
+        self, entity_reader, mock_cache_stack, mock_client, bfabric_instance, mock_instantiate_entity
+    ):
+        mock_cache_stack.item_get_all.return_value = {}
+        mock_client.read.return_value = [{"id": 1, "classname": "user", "login": "alice"}]
+        mock_entity = Entity(
+            data_dict={"id": 1, "classname": "user", "login": "alice"},
+            client=mock_client,
+            bfabric_instance=bfabric_instance,
+        )
+        mock_instantiate_entity.return_value = mock_entity
+
+        result = entity_reader.query_one("user", {"login": "alice"})
+
+        assert result is mock_entity
+        mock_client.read.assert_called_once_with("user", obj={"login": "alice"}, max_results=1)
+
+    def test_returns_none_when_no_match(self, entity_reader, mock_cache_stack, mock_client):
+        mock_cache_stack.item_get_all.return_value = {}
+        mock_client.read.return_value = []
+
+        assert entity_reader.query_one("user", {"login": "nobody"}) is None
+
+    def test_expected_type_narrows_result_type(
+        self, entity_reader, mock_cache_stack, mock_client, bfabric_instance, mock_instantiate_entity
+    ):
+        from bfabric.entities import User
+
+        mock_cache_stack.item_get_all.return_value = {}
+        mock_client.read.return_value = [{"id": 1, "classname": "user", "login": "alice"}]
+        user = User(
+            data_dict={"id": 1, "classname": "user", "login": "alice"},
+            client=mock_client,
+            bfabric_instance=bfabric_instance,
+        )
+        mock_instantiate_entity.return_value = user
+
+        result = entity_reader.query_one("user", {"login": "alice"}, expected_type=User)
+
+        assert isinstance(result, User)
+        assert result is user
+
+    def test_raises_on_type_mismatch(
+        self, entity_reader, mock_cache_stack, mock_client, bfabric_instance, mock_instantiate_entity
+    ):
+        from bfabric.entities import User
+
+        mock_cache_stack.item_get_all.return_value = {}
+        mock_client.read.return_value = [{"id": 1, "classname": "project", "name": "p"}]
+        not_a_user = Entity(
+            data_dict={"id": 1, "classname": "project", "name": "p"},
+            client=mock_client,
+            bfabric_instance=bfabric_instance,
+        )
+        mock_instantiate_entity.return_value = not_a_user
+
+        with pytest.raises(TypeError, match="Expected User"):
+            entity_reader.query_one("user", {"login": "alice"}, expected_type=User)
+
+
 class TestRetrieveEntities:
     def test_retrieve_entities(
         self,

--- a/tests/bfabric/entities/core/test_entity_reader.py
+++ b/tests/bfabric/entities/core/test_entity_reader.py
@@ -459,6 +459,23 @@ class TestQuery:
 
         assert f"Unsupported B-Fabric instance: {different_instance}" in str(exc_info.value)
 
+    def test_expected_type_raises_on_mismatch(
+        self, entity_reader, mock_cache_stack, mock_client, bfabric_instance, mock_instantiate_entity
+    ):
+        from bfabric.entities import User
+
+        mock_cache_stack.item_get_all.return_value = {}
+        mock_client.read.return_value = [{"id": 1, "classname": "project", "name": "p"}]
+        not_a_user = Entity(
+            data_dict={"id": 1, "classname": "project", "name": "p"},
+            client=mock_client,
+            bfabric_instance=bfabric_instance,
+        )
+        mock_instantiate_entity.return_value = not_a_user
+
+        with pytest.raises(TypeError, match="Expected User"):
+            entity_reader.query("user", {"login": "alice"}, expected_type=User)
+
 
 class TestQueryOne:
     def test_returns_entity_when_single_match(

--- a/tests/bfabric/entities/core/test_users.py
+++ b/tests/bfabric/entities/core/test_users.py
@@ -45,12 +45,14 @@ class TestGetById:
 class TestGetByName:
     @staticmethod
     def test_not_cached(entity_reader, users, bfabric_instance, mock_user):
-        entity_reader.query.return_value = {"mocked_uri": mock_user}
+        from bfabric.entities.user import User as UserEntity
+
+        entity_reader.query_one.return_value = mock_user
         assert mock_user not in users._users
         user = users.get_by_login(bfabric_instance, login="testuser")
         assert user is mock_user
-        entity_reader.query.assert_called_once_with(
-            entity_type="user", obj={"login": "testuser"}, bfabric_instance=bfabric_instance, max_results=1
+        entity_reader.query_one.assert_called_once_with(
+            "user", {"login": "testuser"}, bfabric_instance=bfabric_instance, expected_type=UserEntity
         )
         assert mock_user in users._users
 
@@ -59,4 +61,4 @@ class TestGetByName:
         users._users.append(mock_user)
         user = users.get_by_login(bfabric_instance, login="testuser")
         assert user is mock_user
-        entity_reader.query.assert_not_called()
+        entity_reader.query_one.assert_not_called()


### PR DESCRIPTION
## Summary
- New `EntityReader.query_one(entity_type, obj, *, expected_type=Entity) -> EntityT | None` — thin wrapper over `query` with `max_results=1` and type-narrowing.
- Migrates the two existing "look up single entity by field" call sites:
  - `User.find_by_login` — also drops the `DeprecationWarning: FindMixin is deprecated` that it was silently propagating.
  - `Users.get_by_login` — same simplification; caching logic unchanged.
- Extracted from PR #486 (bfabric_rest_proxy \`/user/is_employee\` endpoint), where it was originally bundled. Reviewable independently.
