### PR TITLE
Raise on missing empdegree in User.is_employee

### DIFF
--- a/bfabric/src/bfabric/entities/user.py
+++ b/bfabric/src/bfabric/entities/user.py
@@ -17,7 +17,18 @@ class User(Entity):
 
     @property
     def is_employee(self) -> bool:
-        """Whether the user is an employee on the B-Fabric instance (``empdegree`` present and > 0)."""
+        """Whether the user is an employee on the B-Fabric instance (``empdegree`` > 0).
+
+        :raises ValueError: if the ``empdegree`` field is not present on the user record.
+            The field is typically only visible when the record is fetched with feeder
+            credentials; a silent ``False`` would be indistinguishable from a genuine
+            non-employee and mask the permissions issue.
+        """
+        if self.get("empdegree") is None:
+            raise ValueError(
+                "User.is_employee: 'empdegree' is not present on the user record. "
+                "This field typically requires feeder credentials to be visible."
+            )
         empdegree = self.get("empdegree")
         if not isinstance(empdegree, str | int | float) or isinstance(empdegree, bool):
             return False

--- a/bfabric_rest_proxy/tests/test_user_is_employee_endpoint.py
+++ b/bfabric_rest_proxy/tests/test_user_is_employee_endpoint.py
@@ -26,11 +26,10 @@ def mock_find_by_login(mocker):
 class TestIsEmployee:
     """Unit tests for the pure `is_employee` helper."""
 
-    def test_empdegree_missing_returns_false(
-        self, mock_bfabric_user_client, mock_bfabric_feeder_client, mock_find_by_login
-    ):
+    def test_empdegree_missing_raises(self, mock_bfabric_user_client, mock_bfabric_feeder_client, mock_find_by_login):
         mock_find_by_login.return_value = _user()
-        assert is_employee(user_client=mock_bfabric_user_client, feeder_client=mock_bfabric_feeder_client) is False
+        with pytest.raises(ValueError, match="empdegree"):
+            is_employee(user_client=mock_bfabric_user_client, feeder_client=mock_bfabric_feeder_client)
 
     def test_empdegree_positive_integer_returns_true(
         self, mock_bfabric_user_client, mock_bfabric_feeder_client, mock_find_by_login
@@ -72,7 +71,7 @@ class TestUserIsEmployeeEndpoint:
         assert response.json() == {"is_employee": True}
 
     def test_non_employee_returns_false(self, client, mock_find_by_login):
-        mock_find_by_login.return_value = _user()
+        mock_find_by_login.return_value = _user(empdegree="0")
 
         response = client.post(
             "/user/is_employee",

--- a/tests/bfabric/entities/test_user.py
+++ b/tests/bfabric/entities/test_user.py
@@ -24,13 +24,17 @@ def _user(bfabric_instance: str, **fields: object) -> User:
         ("-10", False),
         ("", False),
         ("not-a-number", False),
-        (None, False),
     ],
 )
 def test_is_employee(empdegree, expected, bfabric_instance):
-    fields = {} if empdegree is None else {"empdegree": empdegree}
-    assert _user(bfabric_instance, **fields).is_employee is expected
+    assert _user(bfabric_instance, empdegree=empdegree).is_employee is expected
 
 
-def test_is_employee_missing_field(bfabric_instance):
-    assert _user(bfabric_instance).is_employee is False
+def test_is_employee_missing_field_raises(bfabric_instance):
+    with pytest.raises(ValueError, match="empdegree"):
+        _ = _user(bfabric_instance).is_employee
+
+
+def test_is_employee_none_value_raises(bfabric_instance):
+    with pytest.raises(ValueError, match="empdegree"):
+        _ = _user(bfabric_instance, empdegree=None).is_employee


### PR DESCRIPTION
`User.is_employee` previously returned `False` whenever `empdegree` was absent or unparseable. In practice the `empdegree` field is only visible when the user record is fetched with feeder credentials (see #486, #488), so a missing field indicates "we can't see it" rather than "user is not an employee". 