### PR TITLE
Add specific token validation error subclasses

### DIFF
--- a/.basedpyright/baseline.bfabric_app_runner.json
+++ b/.basedpyright/baseline.bfabric_app_runner.json
@@ -2940,22 +2940,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,10 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+### Added
+
+- `BfabricTokenExpiredError` and `BfabricTokenInvalidError` in `bfabric.errors`: specific subclasses of `BfabricTokenValidationFailedError`, which will be raised instead of the generic `BfabricTokenValidationFailedError`.
+
 ## \[1.18.0\] - 2026-04-20
 
 ### Added

--- a/bfabric/src/bfabric/errors.py
+++ b/bfabric/src/bfabric/errors.py
@@ -63,15 +63,25 @@ class BfabricInstanceNotConfiguredError(RuntimeError):
 
 
 class BfabricTokenValidationFailedError(RuntimeError):
-    """Raised when token validation fails (expired or otherwise invalid)."""
+    """Raised when token validation fails. Base class for the more specific subclasses below.
 
-    @classmethod
-    def expired_token(cls) -> BfabricTokenValidationFailedError:
-        return cls("Token validation failed: token has expired.")
+    Catch this class to handle any validation failure; catch :class:`BfabricTokenExpiredError`
+    or :class:`BfabricTokenInvalidError` to react to a specific kind.
+    """
 
-    @classmethod
-    def invalid_token(cls) -> BfabricTokenValidationFailedError:
-        return cls("Token validation failed: token is invalid.")
+
+class BfabricTokenExpiredError(BfabricTokenValidationFailedError):
+    """Raised when token validation fails because the token has expired."""
+
+    def __init__(self, message: str = "Token validation failed: token has expired.") -> None:
+        super().__init__(message)
+
+
+class BfabricTokenInvalidError(BfabricTokenValidationFailedError):
+    """Raised when token validation fails because the token is malformed, unknown, or rejected."""
+
+    def __init__(self, message: str = "Token validation failed: token is invalid.") -> None:
+        super().__init__(message)
 
 
 # TODO: Also test for response-level errors

--- a/bfabric/src/bfabric/rest/token_data.py
+++ b/bfabric/src/bfabric/rest/token_data.py
@@ -20,7 +20,11 @@ from pydantic import (
 from pydantic import ValidationError
 
 from bfabric.entities.core.import_entity import import_entity
-from bfabric.errors import BfabricInstanceNotConfiguredError, BfabricTokenValidationFailedError
+from bfabric.errors import (
+    BfabricInstanceNotConfiguredError,
+    BfabricTokenExpiredError,
+    BfabricTokenInvalidError,
+)
 
 if TYPE_CHECKING:
     from bfabric import Bfabric
@@ -90,7 +94,8 @@ async def get_token_data_async(
     """Returns the token data for the provided token.
 
     Raises:
-        BfabricTokenValidationFailedError: If token validation fails due to an expired or otherwise invalid token.
+        BfabricTokenExpiredError: If the token has expired.
+        BfabricTokenInvalidError: If the token is malformed, unknown, or rejected.
     """
     url = urllib.parse.urljoin(f"{base_url}/", "rest/token/validate")
     async with contextlib.nullcontext(http_client) if http_client is not None else httpx.AsyncClient() as client:
@@ -102,8 +107,8 @@ async def get_token_data_async(
         return TokenData.model_validate_json(response.text)
     except (httpx.HTTPStatusError, ValidationError) as e:
         if "Token expired" in response.text:
-            raise BfabricTokenValidationFailedError.expired_token() from e
-        raise BfabricTokenValidationFailedError.invalid_token() from e
+            raise BfabricTokenExpiredError() from e
+        raise BfabricTokenInvalidError() from e
 
 
 def get_token_data(base_url: str, token: str) -> TokenData:
@@ -120,7 +125,8 @@ async def validate_token(
     """Validates the token according to the provided settings.
 
     Raises:
-        BfabricTokenValidationFailedError: If token validation fails due to an expired or otherwise invalid token.
+        BfabricTokenExpiredError: If the token has expired.
+        BfabricTokenInvalidError: If the token is malformed, unknown, or rejected.
         BfabricInstanceNotConfiguredError: If the caller is not configured as supported.
     """
     token_data = await get_token_data_async(

--- a/tests/bfabric/rest/test_token_data.py
+++ b/tests/bfabric/rest/test_token_data.py
@@ -5,7 +5,7 @@ import pytest
 import httpx
 from pydantic import SecretStr, ValidationError
 
-from bfabric.errors import BfabricTokenValidationFailedError
+from bfabric.errors import BfabricTokenExpiredError, BfabricTokenInvalidError
 from bfabric.rest.token_data import TokenData, get_token_data, get_token_data_async
 
 
@@ -123,7 +123,7 @@ async def test_get_token_data_async_when_expired_token_in_http_error(mocker, bas
     mock_client = mocker.AsyncMock()
     mock_client.get.return_value = mock_response
 
-    with pytest.raises(BfabricTokenValidationFailedError, match="expired"):
+    with pytest.raises(BfabricTokenExpiredError, match="expired"):
         await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
 
 
@@ -137,7 +137,7 @@ async def test_get_token_data_async_when_other_http_error(mocker, base_url):
     mock_client = mocker.AsyncMock()
     mock_client.get.return_value = mock_response
 
-    with pytest.raises(BfabricTokenValidationFailedError, match="invalid"):
+    with pytest.raises(BfabricTokenInvalidError, match="invalid"):
         await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
 
 
@@ -149,7 +149,7 @@ async def test_get_token_data_async_when_expired_token_in_body(mocker, base_url)
     mock_client = mocker.AsyncMock()
     mock_client.get.return_value = mock_response
 
-    with pytest.raises(BfabricTokenValidationFailedError, match="expired"):
+    with pytest.raises(BfabricTokenExpiredError, match="expired"):
         await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
 
 
@@ -161,7 +161,7 @@ async def test_get_token_data_async_when_invalid_json_body(mocker, base_url):
     mock_client = mocker.AsyncMock()
     mock_client.get.return_value = mock_response
 
-    with pytest.raises(BfabricTokenValidationFailedError, match="invalid"):
+    with pytest.raises(BfabricTokenInvalidError, match="invalid"):
         await get_token_data_async(base_url=base_url, token="mock-token", http_client=mock_client)
 
 

--- a/tests/bfabric/test_errors.py
+++ b/tests/bfabric/test_errors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from bfabric.errors import BfabricTokenExpiredError, BfabricTokenInvalidError, BfabricTokenValidationFailedError
+
+
+def test_token_expired_error_is_a_validation_failed_error() -> None:
+    expired = BfabricTokenExpiredError()
+    invalid = BfabricTokenInvalidError()
+
+    assert isinstance(expired, BfabricTokenValidationFailedError)
+    assert isinstance(invalid, BfabricTokenValidationFailedError)
+    assert "expired" in str(expired)
+    assert "invalid" in str(invalid)
+
+
+def test_token_subclass_constructors_accept_custom_message() -> None:
+    expired = BfabricTokenExpiredError("custom: token aged out")
+    assert "custom: token aged out" in str(expired)
+
+
+def test_subclasses_are_distinguishable_via_isinstance() -> None:
+    expired = BfabricTokenExpiredError()
+    invalid = BfabricTokenInvalidError()
+
+    assert isinstance(expired, BfabricTokenExpiredError)
+    assert not isinstance(expired, BfabricTokenInvalidError)
+    assert isinstance(invalid, BfabricTokenInvalidError)
+    assert not isinstance(invalid, BfabricTokenExpiredError)


### PR DESCRIPTION
Introduce `BfabricTokenExpiredError` and `BfabricTokenInvalidError` as subclasses of `BfabricTokenValidationFailedError`. 