### PR TITLE
Fix User.is_employee property

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -13,6 +13,10 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - `BfabricTokenExpiredError` and `BfabricTokenInvalidError` in `bfabric.errors`: specific subclasses of `BfabricTokenValidationFailedError`, which will be raised instead of the generic `BfabricTokenValidationFailedError`.
 
+### Fixed
+
+- `User.is_employee` returns `False` when `empdegree` is missing or `None`, instead of raising `ValueError`.
+
 ## \[1.18.0\] - 2026-04-20
 
 ### Added

--- a/bfabric/src/bfabric/entities/user.py
+++ b/bfabric/src/bfabric/entities/user.py
@@ -19,16 +19,13 @@ class User(Entity):
     def is_employee(self) -> bool:
         """Whether the user is an employee on the B-Fabric instance (``empdegree`` > 0).
 
-        :raises ValueError: if the ``empdegree`` field is not present on the user record.
-            The field is typically only visible when the record is fetched with feeder
-            credentials; a silent ``False`` would be indistinguishable from a genuine
-            non-employee and mask the permissions issue.
+        The ``empdegree`` field is typically only readable with feeder credentials,
+        so this property only returns a meaningful answer when the user record was
+        fetched with such credentials. If ``empdegree`` is missing or ``None`` (either
+        because the field is genuinely unset or because the caller lacks permission
+        to read it), this returns ``False``. Callers that need authoritative employee
+        status must fetch the user record with feeder credentials.
         """
-        if self.get("empdegree") is None:
-            raise ValueError(
-                "User.is_employee: 'empdegree' is not present on the user record. "
-                "This field typically requires feeder credentials to be visible."
-            )
         empdegree = self.get("empdegree")
         if not isinstance(empdegree, str | int | float) or isinstance(empdegree, bool):
             return False

--- a/bfabric_rest_proxy/pyproject.toml
+++ b/bfabric_rest_proxy/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "bfabric>=1.15.1,<2",
+    "bfabric>=1.18.1,<2",
     "fastapi>=0.124.0",
     "pydantic-settings>=2.12.0",
 ]

--- a/bfabric_rest_proxy/tests/test_user_is_employee_endpoint.py
+++ b/bfabric_rest_proxy/tests/test_user_is_employee_endpoint.py
@@ -26,10 +26,17 @@ def mock_find_by_login(mocker):
 class TestIsEmployee:
     """Unit tests for the pure `is_employee` helper."""
 
-    def test_empdegree_missing_raises(self, mock_bfabric_user_client, mock_bfabric_feeder_client, mock_find_by_login):
+    def test_empdegree_missing_returns_false(
+        self, mock_bfabric_user_client, mock_bfabric_feeder_client, mock_find_by_login
+    ):
         mock_find_by_login.return_value = _user()
-        with pytest.raises(ValueError, match="empdegree"):
-            is_employee(user_client=mock_bfabric_user_client, feeder_client=mock_bfabric_feeder_client)
+        assert is_employee(user_client=mock_bfabric_user_client, feeder_client=mock_bfabric_feeder_client) is False
+
+    def test_empdegree_none_returns_false(
+        self, mock_bfabric_user_client, mock_bfabric_feeder_client, mock_find_by_login
+    ):
+        mock_find_by_login.return_value = _user(empdegree=None)
+        assert is_employee(user_client=mock_bfabric_user_client, feeder_client=mock_bfabric_feeder_client) is False
 
     def test_empdegree_positive_integer_returns_true(
         self, mock_bfabric_user_client, mock_bfabric_feeder_client, mock_find_by_login
@@ -72,6 +79,17 @@ class TestUserIsEmployeeEndpoint:
 
     def test_non_employee_returns_false(self, client, mock_find_by_login):
         mock_find_by_login.return_value = _user(empdegree="0")
+
+        response = client.post(
+            "/user/is_employee",
+            json={"login": "test_user", "webservicepassword": "y" * 32},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"is_employee": False}
+
+    def test_missing_empdegree_returns_false(self, client, mock_find_by_login):
+        mock_find_by_login.return_value = _user()
 
         response = client.post(
             "/user/is_employee",

--- a/tests/bfabric/entities/test_user.py
+++ b/tests/bfabric/entities/test_user.py
@@ -30,11 +30,9 @@ def test_is_employee(empdegree, expected, bfabric_instance):
     assert _user(bfabric_instance, empdegree=empdegree).is_employee is expected
 
 
-def test_is_employee_missing_field_raises(bfabric_instance):
-    with pytest.raises(ValueError, match="empdegree"):
-        _ = _user(bfabric_instance).is_employee
+def test_is_employee_missing_field_returns_false(bfabric_instance):
+    assert _user(bfabric_instance).is_employee is False
 
 
-def test_is_employee_none_value_raises(bfabric_instance):
-    with pytest.raises(ValueError, match="empdegree"):
-        _ = _user(bfabric_instance, empdegree=None).is_employee
+def test_is_employee_none_value_returns_false(bfabric_instance):
+    assert _user(bfabric_instance, empdegree=None).is_employee is False


### PR DESCRIPTION
The raise was counterproductive and caused a bug when querying for non-employees.