### PR TITLE
Randomise test order with pytest-random-order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ Each package's docs live alongside its source. Skim the index when working in a 
 ## Key Conventions
 
 - Tests must NOT contain `__init__.py` files (enforced by `check_test_inits` nox session)
+- Test order is randomised via [pytest-random-order](https://github.com/pytest-dev/pytest-random-order) (`addopts = "--random-order"`), so both modules and the tests within them run in a shuffled order to surface hidden inter-test dependencies. The seed is printed in the pytest header; reproduce a specific order with `pytest --random-order-seed=<N>`. Tests must therefore be isolation-safe; quarantine a genuinely order-dependent module with `pytestmark = pytest.mark.random_order(disabled=True)` only as a last resort.
 - Test conftest sets `BFABRICPY_CONFIG_ENV=__MOCK` to avoid real credentials
 - Ruff linting is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores)
 - Line length: 120 (ruff and black)

--- a/bfabric/pyproject.toml
+++ b/bfabric/pyproject.toml
@@ -52,7 +52,7 @@ doc = [
     "sphinx-autobuild>=2024.10.3",
     "linkify-it-py",
 ]
-test = ["pytest>=8", "pytest-mock>=3.15", "logot[pytest,loguru]>=1.5.1", "coverage>=7.10.0", "pytest-asyncio>=1.2.0", "dirty-equals>=0.10.0"]
+test = ["pytest>=8", "pytest-mock>=3.15", "logot[pytest,loguru]>=1.5.1", "coverage>=7.10.0", "pytest-asyncio>=1.2.0", "dirty-equals>=0.10.0", "pytest-random-order>=1.1.0"]
 typing = ["mypy", "types-requests", "lxml-stubs", "types-python-dateutil", "types-PyYAML"]
 
 [project.urls]

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -57,6 +57,7 @@ test = [
     "logot>=1.5.1",
     "pyfakefs>=5.10.0",
     "inline-snapshot>=0.30.0",
+    "pytest-random-order>=1.1.0",
 ]
 
 [tool.uv]

--- a/bfabric_asgi_auth/pyproject.toml
+++ b/bfabric_asgi_auth/pyproject.toml
@@ -34,9 +34,11 @@ test = [
     "inline-snapshot>=0.31.0",
     "coverage>=7.11.0",
     "httpx>=0.28.1",
+    "pytest-random-order>=1.1.0",
 ]
 
 [tool.pytest.ini_options]
+addopts = "--random-order"
 testpaths = ["bdd"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]

--- a/bfabric_rest_proxy/pyproject.toml
+++ b/bfabric_rest_proxy/pyproject.toml
@@ -24,6 +24,7 @@ test = [
     "pytest-mock>=3.15.1",
     "pytest-asyncio>=0.21.0",
     "httpx>=0.28.1",
+    "pytest-random-order>=1.1.0",
 ]
 
 [build-system]

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -25,6 +25,7 @@ test = [
     "pyfakefs>=5.10.0",
     "inline-snapshot>=0.30.0",
     "freezegun>=1.5.5",
+    "pytest-random-order>=1.1.0",
 ]
 excel = [
     "fastexcel>=0.18.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ bfabric_scripts = { workspace = true }
 bfabric_app_runner = { workspace = true }
 
 [tool.pytest.ini_options]
+addopts = "--random-order"
 logot_capturer = "logot.loguru.LoguruCapturer"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/bfabric_scripts/conftest.py
+++ b/tests/bfabric_scripts/conftest.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_script_logging() -> None:
+    """Reset the one-shot script-logging guard so log assertions are order-independent.
+
+    ``bfabric.utils.cli_integration.setup_script_logging`` configures the loguru sink only
+    once per process, guarded by the ``BFABRICPY_SCRIPT_LOGGING_SETUP`` env var. In a pytest
+    process that runs many ``@use_client`` commands the sink stays bound to whichever test
+    triggered setup first, so ``capfd``-based log assertions depend on test execution order
+    (and flake under randomised ordering). Clearing the flag around every test forces a fresh
+    setup bound to the current capture.
+    """
+    os.environ.pop("BFABRICPY_SCRIPT_LOGGING_SETUP", None)
+    yield
+    os.environ.pop("BFABRICPY_SCRIPT_LOGGING_SETUP", None)


### PR DESCRIPTION
Integrates [pytest-random-order](https://github.com/pytest-dev/pytest-random-order) so the test suite runs in a shuffled order, surfacing hidden inter-test dependencies. Closes #507.