### PR TITLE
Fix invalid-JSON output of bfabric-cli api update/create (#503)

### DIFF
--- a/.basedpyright/baseline.bfabric_scripts.json
+++ b/.basedpyright/baseline.bfabric_scripts.json
@@ -2410,66 +2410,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnusedCallResult",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnusedParameter",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 29,
                     "lineCount": 1
                 }
             }

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -12,6 +12,7 @@ Versioning currently follows `X.Y.Z` where
 
 ### Added
 
+- `bfabric-cli api create` and `bfabric-cli api update` now accept a `--format json|yaml|tsv|table_rich` flag (default `json`), reusing the same renderer as `bfabric-cli api read`. The output formatting logic is now shared via a new internal `output_format` module.
 - `bfabric-cli dataset update` command: updates an existing dataset with a change preview before confirmation. Supports `csv`/`tsv`/`xlsx`/`parquet` subcommands and the same `forbidden_chars` / `warn_trailing_spaces` validation flags as `dataset upload`.
 - `bfabric-cli auth` command group for OAuth authentication and client management:
     - `auth pkce <base_url>` — browser-based OAuth login; caches tokens and writes the config environment.
@@ -21,6 +22,11 @@ Versioning currently follows `X.Y.Z` where
     - `auth register-webapp` — register an OAuth client together with a linked B-Fabric application.
     - `auth status` — show the current authentication status for an environment.
     - `auth logout` — clear cached OAuth tokens.
+
+### Fixed
+
+- `bfabric-cli api update` and `bfabric-cli api create` previously printed results via `rich.pretty.pprint`, which produced Python `repr` syntax (single-quoted keys). This is not valid JSON, so piping to `jq` failed. Output now defaults to valid JSON. ([#503](https://github.com/fgcz/bfabricPy/issues/503))
+- `bfabric-cli api read --format json` (and the new JSON output paths for `create`/`update`) now serialise non-native types such as `datetime` and `Decimal` (returned by the Zeep engine) to strings instead of raising a `TypeError`.
 
 ### Changed
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
@@ -2,10 +2,11 @@ import cyclopts
 from cyclopts import Parameter
 from loguru import logger
 from pydantic import BaseModel, field_validator
-from rich.pretty import pprint
+from rich.console import Console
 
 from bfabric import Bfabric
 from bfabric.utils.cli_integration import use_client
+from bfabric_scripts.cli.api.output_format import OutputFormat, render_output
 from bfabric_scripts.cli.api.query_repr import Query
 
 app = cyclopts.App()
@@ -14,9 +15,11 @@ app = cyclopts.App()
 @Parameter(name="*")
 class Params(BaseModel):
     endpoint: str
-    """Endpoint to update, e.g. 'resource'."""
+    """Endpoint to create an entity in, e.g. 'resource'."""
     attributes: Query
-    """List of attribute-value pairs to update the entity with."""
+    """List of attribute-value pairs for the new entity."""
+    format: OutputFormat = OutputFormat.JSON
+    """Output format."""
 
     @field_validator("attributes")
     def _must_not_contain_id(cls, value):
@@ -34,4 +37,10 @@ def cmd_api_create(params: Params, *, client: Bfabric) -> None:
     attributes_dict = params.attributes.to_dict(duplicates="error")
     result = client.save(params.endpoint, attributes_dict)
     logger.info(f"{params.endpoint} entity with ID {result[0]['id']} created successfully.")
-    pprint(result)
+    _ = render_output(
+        result.to_list_dict(),
+        output_format=params.format,
+        endpoint=params.endpoint,
+        client=client,
+        console=Console(),
+    )

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/output_format.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/output_format.py
@@ -90,18 +90,16 @@ def _print_table_rich(
     table = Table(*output_columns)
     for x in res:
         entry_url = f"{config.base_url}/{endpoint}/show.html?id={x['id']}"
-        values = []
+        values: list[str] = []
         for column in output_columns:
             if column == "id":
-                values.append(f"[link={entry_url}]{x['id']}[/link]")  # pyright: ignore[reportUnknownMemberType]
+                values.append(f"[link={entry_url}]{x['id']}[/link]")
             elif column == "groupingvar":
                 val = x.get(column)
-                values.append(
-                    (val.get("name", "") if isinstance(val, dict) else "") or ""
-                )  # pyright: ignore[reportUnknownMemberType]
+                values.append(str(val.get("name", "")) if isinstance(val, dict) else "")
             elif isinstance(val := x.get(column), dict):
-                values.append(str(val.get("id", "")))  # pyright: ignore[reportUnknownMemberType]
+                values.append(str(val.get("id", "")))
             else:
-                values.append(str(x.get(column, "")))  # pyright: ignore[reportUnknownMemberType]
-        table.add_row(*values)  # pyright: ignore[reportUnknownArgumentType]
+                values.append(str(x.get(column, "")))
+        table.add_row(*values)
     console_out.print(table)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/output_format.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/output_format.py
@@ -1,0 +1,107 @@
+import json
+from enum import Enum
+
+import polars as pl
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from bfabric import Bfabric, BfabricClientConfig
+from bfabric.typing import ApiResponseObjectType
+from bfabric.utils.polars_utils import flatten_relations
+
+
+class OutputFormat(Enum):
+    JSON = "json"
+    YAML = "yaml"
+    TSV = "tsv"
+    TABLE_RICH = "table_rich"
+
+
+def render_output(
+    results: list[ApiResponseObjectType],
+    *,
+    output_format: OutputFormat,
+    endpoint: str,
+    client: Bfabric,
+    console: Console,
+    columns: list[str] | None = None,
+    max_columns: int | None = 7,
+) -> str | None:
+    """Renders *results* in the requested format.
+
+    Returns the rendered string (for JSON/YAML/TSV) or None (for TABLE_RICH, which writes
+    directly to *console*).
+    """
+    if output_format == OutputFormat.TABLE_RICH:
+        output_columns = _determine_output_columns(
+            results=results,
+            columns=columns,
+            max_columns=max_columns,
+        )
+        _print_table_rich(client.config, console, endpoint, results, output_columns=output_columns)
+        return None
+
+    if columns:
+        results = [{k: x.get(k) for k in columns} for x in results]
+
+    if output_format == OutputFormat.JSON:
+        # default=str makes the output engine-agnostic: the Zeep engine can return
+        # datetime/Decimal objects that are not natively JSON-serialisable.
+        result = json.dumps(results, indent=2, default=str)
+    elif output_format == OutputFormat.YAML:
+        result = yaml.dump(results)
+    elif output_format == OutputFormat.TSV:
+        result = flatten_relations(pl.DataFrame(results)).write_csv(separator="\t")
+    else:
+        raise ValueError(f"output format {output_format} not supported")  # pyright: ignore[reportUnreachable]
+
+    print(result)
+    return result
+
+
+def _determine_output_columns(
+    results: list[ApiResponseObjectType],
+    columns: list[str] | None,
+    max_columns: int | None,
+) -> list[str]:
+    if not columns:
+        if max_columns is not None and max_columns < 1:
+            raise ValueError("max_columns must be at least 1")
+        columns = ["id"]
+        if not results:
+            return columns
+        available_columns = sorted(set(results[0].keys()) - {"id"})
+        if max_columns is None:
+            columns += available_columns
+        else:
+            columns += available_columns[:max_columns]
+    return columns
+
+
+def _print_table_rich(
+    config: BfabricClientConfig,
+    console_out: Console,
+    endpoint: str,
+    res: list[ApiResponseObjectType],
+    output_columns: list[str],
+) -> None:
+    """Prints the results as a rich table to the console."""
+    table = Table(*output_columns)
+    for x in res:
+        entry_url = f"{config.base_url}/{endpoint}/show.html?id={x['id']}"
+        values = []
+        for column in output_columns:
+            if column == "id":
+                values.append(f"[link={entry_url}]{x['id']}[/link]")  # pyright: ignore[reportUnknownMemberType]
+            elif column == "groupingvar":
+                val = x.get(column)
+                values.append(
+                    (val.get("name", "") if isinstance(val, dict) else "") or ""
+                )  # pyright: ignore[reportUnknownMemberType]
+            elif isinstance(val := x.get(column), dict):
+                values.append(str(val.get("id", "")))  # pyright: ignore[reportUnknownMemberType]
+            else:
+                values.append(str(x.get(column, "")))  # pyright: ignore[reportUnknownMemberType]
+        table.add_row(*values)  # pyright: ignore[reportUnknownArgumentType]
+    console_out.print(table)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
@@ -1,29 +1,21 @@
-import json
-from enum import Enum
 from pathlib import Path
 from typing import Annotated, cast
 
 import cyclopts
-import polars as pl
 import pydantic
-import yaml
 from loguru import logger
 from pydantic import BaseModel
 from rich.console import Console
-from rich.table import Table
 
-from bfabric import Bfabric, BfabricClientConfig
+from bfabric import Bfabric
 from bfabric.typing import ApiResponseObjectType
 from bfabric.utils.cli_integration import use_client
-from bfabric.utils.polars_utils import flatten_relations
+from bfabric_scripts.cli.api.output_format import OutputFormat, render_output
 from bfabric_scripts.cli.api.query_repr import Query
 
-
-class OutputFormat(Enum):
-    JSON = "json"
-    YAML = "yaml"
-    TSV = "tsv"
-    TABLE_RICH = "table_rich"
+# Re-export so that existing callers (e.g. tests) can still do:
+#   from bfabric_scripts.cli.api.read import OutputFormat, render_output
+__all__ = ["OutputFormat", "render_output"]
 
 
 class Params(BaseModel):
@@ -66,37 +58,6 @@ def perform_query(params: Params, client: Bfabric) -> list[ApiResponseObjectType
     return results
 
 
-def render_output(
-    results: list[ApiResponseObjectType], params: Params, client: Bfabric, console: Console
-) -> str | None:
-    """Renders the results in the specified output format."""
-    if params.format == OutputFormat.TABLE_RICH:
-        output_columns = _determine_output_columns(
-            results=results,
-            columns=params.columns,
-            max_columns=params.cli_max_columns,
-            output_format=params.format,
-        )
-        _print_table_rich(client.config, console, params.endpoint, results, output_columns=output_columns)
-        return None
-    else:
-        if params.columns:
-            results = [{k: x.get(k) for k in params.columns} for x in results]
-
-        if params.format == OutputFormat.JSON:
-            result = json.dumps(results, indent=2)
-        elif params.format == OutputFormat.YAML:
-            result = yaml.dump(results)
-        elif params.format == OutputFormat.TSV:
-            result = flatten_relations(pl.DataFrame(results)).write_csv(separator="\t")
-        else:
-            raise ValueError(f"output format {params.format} not supported")
-
-        # TODO check if we can add back colors (but it broke some stuff, because of forced line breaks, so be careful)
-        print(result)
-        return result
-
-
 @use_client
 def cmd_api_read(params: Annotated[Params, cyclopts.Parameter(name="*")], *, client: Bfabric) -> None | int:
     """Reads entities from B-Fabric."""
@@ -115,54 +76,18 @@ def cmd_api_read(params: Annotated[Params, cyclopts.Parameter(name="*")], *, cli
     # Print/export output
     results = sorted(results, key=lambda x: cast(int, x["id"]))
     console_out = Console()
-    output = render_output(results, params=params, client=client, console=console_out)
+    output = render_output(
+        results,
+        output_format=params.format,
+        endpoint=params.endpoint,
+        client=client,
+        console=console_out,
+        columns=params.columns or None,
+        max_columns=params.cli_max_columns,
+    )
     if params.file:
         if output is None:
             logger.error("File output is not supported for the specified output format.")
             return 1
         params.file.write_text(output)
         logger.info(f"Results written to {params.file} (size: {params.file.stat().st_size} bytes)")
-
-
-def _determine_output_columns(
-    results: list[ApiResponseObjectType],
-    columns: list[str] | None,
-    max_columns: int,
-    output_format: OutputFormat,
-) -> list[str]:
-    if not columns:
-        if max_columns < 1:
-            raise ValueError("max_columns must be at least 1")
-        columns = ["id"]
-        if not results:
-            return columns
-        available_columns = sorted(set(results[0].keys()) - {"id"})
-        columns += available_columns[:max_columns]
-
-    return columns
-
-
-def _print_table_rich(
-    config: BfabricClientConfig,
-    console_out: Console,
-    endpoint: str,
-    res: list[ApiResponseObjectType],
-    output_columns: list[str],
-) -> None:
-    """Prints the results as a rich table to the console."""
-    table = Table(*output_columns)
-    for x in res:
-        entry_url = f"{config.base_url}/{endpoint}/show.html?id={x['id']}"
-        values = []
-        for column in output_columns:
-            if column == "id":
-                values.append(f"[link={entry_url}]{x['id']}[/link]")
-            elif column == "groupingvar":
-                val = x.get(column)
-                values.append((val.get("name", "") if isinstance(val, dict) else "") or "")
-            elif isinstance(val := x.get(column), dict):
-                values.append(str(val.get("id", "")))
-            else:
-                values.append(str(x.get(column, "")))
-        table.add_row(*values)
-    console_out.print(table)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
@@ -1,11 +1,13 @@
 import rich
 import rich.prompt
+from bfabric_scripts.cli.api.output_format import OutputFormat, render_output
 from bfabric_scripts.cli.api.query_repr import Query
 from cyclopts import Parameter
 from loguru import logger
 from pydantic import BaseModel, model_validator
+from rich.console import Console
 from rich.panel import Panel
-from rich.pretty import Pretty, pprint
+from rich.pretty import Pretty
 
 from bfabric import Bfabric
 from bfabric.utils.cli_integration import use_client
@@ -21,6 +23,8 @@ class Params(BaseModel):
     """List of attribute-value pairs to update the entity with."""
     no_confirm: bool = False
     """If set, the update will be performed without asking for confirmation."""
+    format: OutputFormat = OutputFormat.JSON
+    """Output format."""
 
     @model_validator(mode="after")
     def entity_id_not_in_attributes(self) -> "Params":
@@ -48,7 +52,13 @@ def cmd_api_update(params: Params, *, client: Bfabric) -> None:
 
     result = client.save(params.endpoint, {"id": params.entity_id, **attributes_dict})
     logger.info(f"Entity with ID {params.entity_id} updated successfully.")
-    pprint(result)
+    _ = render_output(
+        result.to_list_dict(),
+        output_format=params.format,
+        endpoint=params.endpoint,
+        client=client,
+        console=Console(),
+    )
 
 
 def _confirm_action(attributes_dict: dict[str, str], client: Bfabric, endpoint: str, entity_id: int) -> bool:

--- a/tests/bfabric_cli/test_cli_api_create.py
+++ b/tests/bfabric_cli/test_cli_api_create.py
@@ -1,0 +1,74 @@
+import json
+
+import pytest
+from bfabric import Bfabric
+from bfabric.results.result_container import ResultContainer
+from bfabric_scripts.cli.api.create import Params, cmd_api_create
+from bfabric_scripts.cli.api.output_format import OutputFormat
+
+
+@pytest.fixture
+def mock_client(mocker):
+    client = mocker.Mock(spec=Bfabric)
+    client.config.base_url = "http://test-bfabric.com"
+    return client
+
+
+@pytest.fixture
+def save_result():
+    return ResultContainer(
+        [{"id": 42, "name": "Test Entity", "status": "AVAILABLE"}],
+        total_pages_api=1,
+        errors=[],
+    )
+
+
+class TestCreateOutputFormat:
+    def test_default_format_is_json(self):
+        params = Params(endpoint="workunit", attributes=[("name", "foo")])
+        assert params.format == OutputFormat.JSON
+
+    def test_create_emits_valid_json_by_default(self, mock_client, save_result, capsys):
+        # Arrange
+        mock_client.save.return_value = save_result
+        params = Params(endpoint="workunit", attributes=[("name", "Test Entity")])
+
+        # Act
+        cmd_api_create(params, client=mock_client)
+
+        # Assert — output must be parseable JSON (the bug was Python repr with single quotes)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert isinstance(parsed, list)
+        assert parsed[0]["id"] == 42
+
+    def test_create_format_json_explicit(self, mock_client, save_result, capsys):
+        mock_client.save.return_value = save_result
+        params = Params(endpoint="workunit", attributes=[("name", "Test Entity")], format=OutputFormat.JSON)
+
+        cmd_api_create(params, client=mock_client)
+
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed[0]["status"] == "AVAILABLE"
+
+    def test_create_format_yaml(self, mock_client, save_result, capsys):
+        import yaml
+
+        mock_client.save.return_value = save_result
+        params = Params(endpoint="workunit", attributes=[("name", "Test Entity")], format=OutputFormat.YAML)
+
+        cmd_api_create(params, client=mock_client)
+
+        captured = capsys.readouterr()
+        parsed = yaml.safe_load(captured.out)
+        assert isinstance(parsed, list)
+        assert parsed[0]["id"] == 42
+
+    def test_create_passes_correct_args_to_save(self, mock_client, save_result):
+        mock_client.save.return_value = save_result
+        params = Params(endpoint="workunit", attributes=[("name", "Test Entity"), ("status", "available")])
+
+        cmd_api_create(params, client=mock_client)
+
+        mock_client.save.assert_called_once_with("workunit", {"name": "Test Entity", "status": "available"})

--- a/tests/bfabric_cli/test_cli_api_output_format.py
+++ b/tests/bfabric_cli/test_cli_api_output_format.py
@@ -1,0 +1,74 @@
+"""Tests for the shared output_format module (issue #503 fix)."""
+
+import datetime
+import decimal
+import json
+
+import pytest
+from bfabric_scripts.cli.api.output_format import OutputFormat, _determine_output_columns, render_output
+
+
+@pytest.fixture
+def mock_client(mocker):
+    client = mocker.Mock()
+    client.config.base_url = "http://test-bfabric.com"
+    return client
+
+
+@pytest.fixture
+def sample_results():
+    return [
+        {"id": 1, "name": "Alpha"},
+        {"id": 2, "name": "Beta"},
+    ]
+
+
+class TestRenderOutputJsonSafety:
+    """Ensure JSON output survives non-JSON-native values (Zeep engine produces these)."""
+
+    def test_datetime_values_are_serialised(self, mock_client, mocker):
+        results = [{"id": 1, "created": datetime.datetime(2024, 1, 1, 12, 0, 0)}]
+        output = render_output(
+            results,
+            output_format=OutputFormat.JSON,
+            endpoint="workunit",
+            client=mock_client,
+            console=mocker.Mock(),
+        )
+        parsed = json.loads(output)
+        # The datetime should be serialised to a string (default=str)
+        assert isinstance(parsed[0]["created"], str)
+
+    def test_decimal_values_are_serialised(self, mock_client, mocker):
+        results = [{"id": 1, "amount": decimal.Decimal("3.14")}]
+        output = render_output(
+            results,
+            output_format=OutputFormat.JSON,
+            endpoint="workunit",
+            client=mock_client,
+            console=mocker.Mock(),
+        )
+        parsed = json.loads(output)
+        assert parsed[0]["amount"] == "3.14"
+
+    def test_plain_dict_roundtrips(self, mock_client, sample_results, mocker):
+        output = render_output(
+            sample_results,
+            output_format=OutputFormat.JSON,
+            endpoint="resource",
+            client=mock_client,
+            console=mocker.Mock(),
+        )
+        parsed = json.loads(output)
+        assert parsed == sample_results
+
+
+class TestDetermineOutputColumnsMaxColumnsNone:
+    def test_none_max_columns_returns_all_available(self):
+        results = [{"id": 1, "name": "x", "status": "y", "type": "z"}]
+        columns = _determine_output_columns(results=results, columns=None, max_columns=None)
+        assert set(columns) == {"id", "name", "status", "type"}
+
+    def test_zero_max_columns_raises(self):
+        with pytest.raises(ValueError, match="max_columns must be at least 1"):
+            _determine_output_columns(results=[{"id": 1}], columns=None, max_columns=0)

--- a/tests/bfabric_cli/test_cli_api_read.py
+++ b/tests/bfabric_cli/test_cli_api_read.py
@@ -5,14 +5,8 @@ import pytest
 import yaml
 from bfabric import Bfabric
 from bfabric.results.result_container import ResultContainer
-from bfabric_scripts.cli.api.read import (
-    Params,
-    OutputFormat,
-    perform_query,
-    cmd_api_read,
-    render_output,
-    _determine_output_columns,
-)
+from bfabric_scripts.cli.api.output_format import OutputFormat, _determine_output_columns, render_output
+from bfabric_scripts.cli.api.read import Params, cmd_api_read, perform_query
 
 
 @pytest.fixture
@@ -88,7 +82,14 @@ class TestRenderOutput:
         params = Params(endpoint="resource", columns=["id", "name"], format=OutputFormat.JSON)
 
         # Act
-        output = render_output(sample_results, params, mocker.Mock(), mocker.Mock())
+        output = render_output(
+            sample_results,
+            output_format=params.format,
+            endpoint=params.endpoint,
+            client=mocker.Mock(),
+            console=mocker.Mock(),
+            columns=["id", "name"],
+        )
 
         # Assert
         parsed = json.loads(output)
@@ -100,7 +101,14 @@ class TestRenderOutput:
         params = Params(endpoint="resource", columns=["id", "name"], format=OutputFormat.YAML)
 
         # Act
-        output = render_output(sample_results, params, mocker.Mock(), mocker.Mock())
+        output = render_output(
+            sample_results,
+            output_format=params.format,
+            endpoint=params.endpoint,
+            client=mocker.Mock(),
+            console=mocker.Mock(),
+            columns=["id", "name"],
+        )
 
         # Assert
         parsed = yaml.safe_load(output)
@@ -110,12 +118,19 @@ class TestRenderOutput:
     def test_render_tsv_output(self, sample_results, mocker):
         # Arrange
         params = Params(endpoint="resource", columns=["id", "name"], format=OutputFormat.TSV)
-        mock_flatten = mocker.patch("bfabric_scripts.cli.api.read.flatten_relations")
+        mock_flatten = mocker.patch("bfabric_scripts.cli.api.output_format.flatten_relations")
         mock_df = mocker.Mock()
         mock_flatten.return_value = mock_df
 
         # Act
-        render_output(sample_results, params, mocker.Mock(), mocker.Mock())
+        render_output(
+            sample_results,
+            output_format=params.format,
+            endpoint=params.endpoint,
+            client=mocker.Mock(),
+            console=mocker.Mock(),
+            columns=["id", "name"],
+        )
 
         # Assert
         mock_flatten.assert_called_once()
@@ -129,9 +144,7 @@ class TestDetermineOutputColumns:
         specified_columns = ["id", "name"]
 
         # Act
-        columns = _determine_output_columns(
-            results=results, columns=specified_columns, max_columns=7, output_format=OutputFormat.TABLE_RICH
-        )
+        columns = _determine_output_columns(results=results, columns=specified_columns, max_columns=7)
 
         # Assert
         assert columns == ["id", "name"]
@@ -141,9 +154,7 @@ class TestDetermineOutputColumns:
         results = [{"id": 1, "name": "Test", "status": "active", "type": "sample"}]
 
         # Act
-        columns = _determine_output_columns(
-            results=results, columns=None, max_columns=2, output_format=OutputFormat.TABLE_RICH
-        )
+        columns = _determine_output_columns(results=results, columns=None, max_columns=2)
 
         # Assert
         assert len(columns) == 3  # id + 2 more columns
@@ -155,18 +166,14 @@ class TestDetermineOutputColumns:
 
         # Act/Assert
         with pytest.raises(ValueError, match="max_columns must be at least 1"):
-            _determine_output_columns(
-                results=results, columns=None, max_columns=0, output_format=OutputFormat.TABLE_RICH
-            )
+            _determine_output_columns(results=results, columns=None, max_columns=0)
 
     def test_determine_output_columns_empty_results(self):
         # Arrange
         results = []
 
         # Act
-        columns = _determine_output_columns(
-            results=results, columns=None, max_columns=7, output_format=OutputFormat.TABLE_RICH
-        )
+        columns = _determine_output_columns(results=results, columns=None, max_columns=7)
 
         # Assert
         assert columns == ["id"]  # Should return default columns when no results available
@@ -218,7 +225,7 @@ class TestReadFunction:
         # Arrange
         mock_perform_query = mocker.patch("bfabric_scripts.cli.api.read.perform_query")
         mock_perform_query.return_value = sample_results
-        mock_flatten = mocker.patch("bfabric_scripts.cli.api.read.flatten_relations")
+        mock_flatten = mocker.patch("bfabric_scripts.cli.api.output_format.flatten_relations")
         mock_df = mocker.Mock()
         mock_df.write_csv.return_value = "mocked,csv,content"
         mock_flatten.return_value = mock_df

--- a/tests/bfabric_cli/test_cli_api_update.py
+++ b/tests/bfabric_cli/test_cli_api_update.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+from bfabric import Bfabric
+from bfabric.results.result_container import ResultContainer
+from bfabric_scripts.cli.api.update import Params, cmd_api_update
+from bfabric_scripts.cli.api.output_format import OutputFormat
+
+
+@pytest.fixture
+def mock_client(mocker):
+    client = mocker.Mock(spec=Bfabric)
+    client.config.base_url = "http://test-bfabric.com"
+    return client
+
+
+@pytest.fixture
+def save_result():
+    return ResultContainer(
+        [{"id": 42, "name": "Test Workunit", "status": "AVAILABLE"}],
+        total_pages_api=1,
+        errors=[],
+    )
+
+
+class TestUpdateOutputFormat:
+    def test_default_format_is_json(self):
+        params = Params(endpoint="workunit", entity_id=42, attributes=[("status", "available")])
+        assert params.format == OutputFormat.JSON
+
+    def test_update_emits_valid_json_by_default(self, mock_client, save_result, capsys):
+        # Arrange — reproduces the exact scenario from issue #503
+        mock_client.save.return_value = save_result
+        params = Params(
+            endpoint="workunit",
+            entity_id=42,
+            attributes=[("status", "available")],
+            no_confirm=True,
+        )
+
+        # Act
+        cmd_api_update(params, client=mock_client)
+
+        # Assert — output must be parseable JSON (the bug was Python repr with single quotes)
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert isinstance(parsed, list)
+        assert parsed[0]["id"] == 42
+
+    def test_update_format_json_explicit(self, mock_client, save_result, capsys):
+        mock_client.save.return_value = save_result
+        params = Params(
+            endpoint="workunit",
+            entity_id=42,
+            attributes=[("status", "available")],
+            no_confirm=True,
+            format=OutputFormat.JSON,
+        )
+
+        cmd_api_update(params, client=mock_client)
+
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed[0]["status"] == "AVAILABLE"
+
+    def test_update_format_yaml(self, mock_client, save_result, capsys):
+        import yaml
+
+        mock_client.save.return_value = save_result
+        params = Params(
+            endpoint="workunit",
+            entity_id=42,
+            attributes=[("status", "available")],
+            no_confirm=True,
+            format=OutputFormat.YAML,
+        )
+
+        cmd_api_update(params, client=mock_client)
+
+        captured = capsys.readouterr()
+        parsed = yaml.safe_load(captured.out)
+        assert isinstance(parsed, list)
+        assert parsed[0]["id"] == 42
+
+    def test_update_passes_correct_args_to_save(self, mock_client, save_result):
+        mock_client.save.return_value = save_result
+        params = Params(
+            endpoint="workunit",
+            entity_id=42,
+            attributes=[("status", "available")],
+            no_confirm=True,
+        )
+
+        cmd_api_update(params, client=mock_client)
+
+        mock_client.save.assert_called_once_with("workunit", {"id": 42, "status": "available"})


### PR DESCRIPTION
Closes #503.


- Extracted output-rendering from `api/read.py` into a new shared `api/output_format.py` module 
- Consistently use it
- Harden JSON output paths with `json.dumps(..., default=str)` so `datetime`/`Decimal` objects from the Zeep engine are serialised to strings rather than raising `TypeErr (not sure if also relevant for suds)