### PR TITLE
Prepare bfabric_app_runner 0.6.1 release

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -4,10 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## \[Unreleased\]
 
+## \[0.6.1\] - 2026-06-11
+
 ### Changed
 
 - `_operation_copy_rsync` now uses `rsync -rltvP` instead of `-Pav`, so staged input files are owned by the user running the app_runner with umask-derived permissions, matching the existing `cp`/`scp` fallbacks.
 - `output_registration._save_dataset` now uses `bfabric.operations.dataset.create_dataset` instead of the legacy `bfabric_save_csv2dataset` from `bfabric.experimental`.
+- Requires `bfabric>=1.19.0` (the operations module). This fixes an `ImportError` for `bfabric_save_csv2dataset` when app_runner 0.6.0 was installed against bfabric 1.19.0.
 
 ## \[0.6.0\] - 2026-04-20
 

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -6,14 +6,14 @@ build-backend = "hatchling.build"
 name = "bfabric_app_runner"
 description = "Application runner for B-Fabric apps"
 readme = "README.md"
-version = "0.6.0"
+version = "0.6.1"
 license = { text = "GPL-3.0" }
 authors = [
     {name = "Leonardo Schwarz", email = "leonardo.schwarz@fgcz.ethz.ch"},
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "bfabric>=1.18.0,<2",
+    "bfabric>=1.19.0,<2",
     "cyclopts>=4.0,<5.0",
     "pydantic>=2.12.3,<3.0",
     "glom>=24.11,<25.0",


### PR DESCRIPTION
Urgent release because `bfabric` 1.19.0 (released Jun 10) removed `bfabric_save_csv2dataset` from `bfabric.experimental.upload_dataset` as part of the experimental→operations move (#500). The published app_runner 0.6.0 (released Apr 20, before that move) still imported it, so any deployment that upgraded `bfabric` to 1.19.0 under the old app_runner hit `ImportError: cannot import name 'bfabric_save_csv2dataset'`.