### PR TITLE
Fix app_runner 0.6.1: drop unpublished DEFAULT_CONFIG_FILE, cap bfabric at <1.20

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `_operation_copy_rsync` now uses `rsync -rltvP` instead of `-Pav`, so staged input files are owned by the user running the app_runner with umask-derived permissions, matching the existing `cp`/`scp` fallbacks.
 - `output_registration._save_dataset` now uses `bfabric.operations.dataset.create_dataset` instead of the legacy `bfabric_save_csv2dataset` from `bfabric.experimental`.
 - Requires `bfabric>=1.19.0` (the operations module). This fixes an `ImportError` for `bfabric_save_csv2dataset` when app_runner 0.6.0 was installed against bfabric 1.19.0.
+- The `bfabric` dependency is now capped at `<1.20` (patch-level upgrades only). app_runner is built against a specific bfabric minor, so this keeps the cross-package coupling explicit and prevents an untested future bfabric minor from being resolved silently.
+
+### Fixed
+
+- `command_docker.py` no longer imports `bfabric.config.DEFAULT_CONFIG_FILE`, which is not present in published bfabric 1.19.0; it uses the literal `Path("~/.bfabricpy.yml")` again (the value `DEFAULT_CONFIG_FILE` is defined as). This fixes an `ImportError` when constructing docker commands and during release validation.
 
 ## \[0.6.0\] - 2026-04-20
 

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "bfabric>=1.19.0,<2",
+    "bfabric>=1.19.0,<1.20",
     "cyclopts>=4.0,<5.0",
     "pydantic>=2.12.3,<3.0",
     "glom>=24.11,<25.0",

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_docker.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_docker.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import shlex
 import os
-from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric_app_runner.commands.command_exec import execute_command_exec
 from bfabric_app_runner.specs.app.commands_spec import CommandExec, CommandDocker, MountOptions
 
@@ -13,7 +12,7 @@ def _collect_mount_options(options: MountOptions, work_dir: Path) -> list[tuple[
     """
     mounts = []
     if options.share_bfabric_config:
-        mounts.append((DEFAULT_CONFIG_FILE, Path("/home/user/.bfabricpy.yml"), True))
+        mounts.append((Path("~/.bfabricpy.yml"), Path("/home/user/.bfabricpy.yml"), True))
     # TODO reconsider if we ever want work_dir_target to be customizable to be different from host path
     #      (currently things will break down if this is configured)
     work_dir_target = work_dir if options.work_dir_target is None else options.work_dir_target

--- a/tests/bfabric_app_runner/commands/test_command_docker.py
+++ b/tests/bfabric_app_runner/commands/test_command_docker.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric_app_runner.commands.command_docker import _collect_mount_options, execute_command_docker, _to_shell
 from bfabric_app_runner.specs.app.commands_spec import (
     CommandDocker,
@@ -26,7 +25,7 @@ class TestCollectMountOptions:
         # Should have 2 default mounts: bfabric config and work dir
         assert len(mounts) == 2
         assert mounts[0] == (
-            DEFAULT_CONFIG_FILE.expanduser().absolute(),
+            Path("~/.bfabricpy.yml").expanduser().absolute(),
             Path("/home/user/.bfabricpy.yml"),
             True,
         )


### PR DESCRIPTION
Further fixes for 0.6.1 production fix.