### PR TITLE
Replace unittest.mock imports with pytest-mock mocker fixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,9 @@ Each package's docs live alongside its source. Skim the index when working in a 
 - Tests must NOT contain `__init__.py` files (enforced by `check_test_inits` nox session)
 - Test order is randomised via [pytest-random-order](https://github.com/pytest-dev/pytest-random-order) (`addopts = "--random-order"`), so both modules and the tests within them run in a shuffled order to surface hidden inter-test dependencies. The seed is printed in the pytest header; reproduce a specific order with `pytest --random-order-seed=<N>`. Tests must therefore be isolation-safe; quarantine a genuinely order-dependent module with `pytestmark = pytest.mark.random_order(disabled=True)` only as a last resort.
 - Test conftest sets `BFABRICPY_CONFIG_ENV=__MOCK` to avoid real credentials
+- Tests use the pytest-mock `mocker` fixture for **all** mocking — do not `import unittest.mock`.
+  Use `mocker.patch(...)`, `mocker.patch.object(...)`, `mocker.patch.dict(...)`, `mocker.MagicMock()`,
+  `mocker.Mock()`, `mocker.mock_open(...)`, etc. (`pytest-mock` is a test dependency in every package.)
 - Ruff linting is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores)
 - Line length: 120 (ruff and black)
 - basedpyright uses per-package baseline files at `.basedpyright/baseline.{package}.json` — **do not edit baseline files to silence new errors**; fix the code or add a targeted `# pyright: ignore[...]` comment on the offending line. Baselines only exist to grandfather in pre-existing errors.

--- a/bfabric_rest_proxy/tests/conftest.py
+++ b/bfabric_rest_proxy/tests/conftest.py
@@ -6,8 +6,6 @@ no real API calls are made during testing.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
@@ -26,9 +24,9 @@ from bfabric_rest_proxy.settings import ServerSettings
 
 
 @pytest.fixture
-def mock_settings():
+def mock_settings(mocker):
     """Mock ServerSettings for testing."""
-    settings = MagicMock(spec=ServerSettings)
+    settings = mocker.MagicMock(spec=ServerSettings)
     settings.default_bfabric_instance = "https://test.bfabric.example.com/"
     settings.supported_bfabric_instances = ["https://test.bfabric.example.com/"]
     # BfabricAuth requires passwords of at least 32 characters

--- a/bfabric_rest_proxy/tests/test_read_endpoint.py
+++ b/bfabric_rest_proxy/tests/test_read_endpoint.py
@@ -4,8 +4,6 @@ This module tests the /read endpoint with mocked Bfabric client to ensure
 no real API calls are made during testing.
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 from bfabric.results.result_container import ResultContainer
 
@@ -106,10 +104,10 @@ class TestReadEndpoint:
         assert call_args.kwargs["offset"] == 10
         assert call_args.kwargs["max_results"] == 50
 
-    def test_read_calls_to_list_dict(self, client, mock_bfabric_user_client):
+    def test_read_calls_to_list_dict(self, client, mock_bfabric_user_client, mocker):
         """Test that the response is properly converted to list dict."""
         # Create a mock ResultContainer
-        mock_result = MagicMock()
+        mock_result = mocker.MagicMock()
         mock_result.to_list_dict.return_value = [
             {"id": 1, "name": "test1"},
             {"id": 2, "name": "test2"},

--- a/tests/bfabric/engine/test_engine_suds.py
+++ b/tests/bfabric/engine/test_engine_suds.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 from pydantic import SecretStr
 from suds import MethodNotFound
@@ -17,8 +15,8 @@ def engine_suds():
 
 
 @pytest.fixture
-def mock_auth():
-    return MagicMock(login="test_user", password=SecretStr("test_pass"))
+def mock_auth(mocker):
+    return mocker.MagicMock(login="test_user", password=SecretStr("test_pass"))
 
 
 @pytest.fixture
@@ -27,8 +25,8 @@ def mock_suds_service(mocker, engine_suds):
 
 
 @pytest.fixture
-def mock_client(mock_suds_service):
-    mock_client = MagicMock(spec=Client)
+def mock_client(mocker, mock_suds_service):
+    mock_client = mocker.MagicMock(spec=Client)
     mock_client.service = mock_suds_service
     return mock_client
 
@@ -99,8 +97,8 @@ def test_convert_results(engine_suds, mocker):
     mock_suds_asdict = mocker.patch("bfabric.engine.engine_suds.suds_asdict_recursive")
     mock_clean_result = mocker.patch("bfabric.engine.engine_suds.clean_result")
 
-    mock_response = MagicMock()
-    mock_response.sample = [MagicMock(), MagicMock()]
+    mock_response = mocker.MagicMock()
+    mock_response.sample = [mocker.MagicMock(), mocker.MagicMock()]
     mock_response.__getitem__.side_effect = {
         "sample": mock_response.sample,
         "numberofpages": 2,
@@ -126,8 +124,8 @@ def test_get_suds_service(mocker, mock_client, mock_suds_service):
     assert service == mock_suds_service
 
 
-def test_convert_results_no_results(engine_suds):
-    mock_response = MagicMock()
+def test_convert_results_no_results(engine_suds, mocker):
+    mock_response = mocker.MagicMock()
     mock_response.numberofpages = 0
     del mock_response.sample
 

--- a/tests/bfabric/engine/test_engine_zeep.py
+++ b/tests/bfabric/engine/test_engine_zeep.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 import zeep
 from pydantic import SecretStr
@@ -16,13 +14,13 @@ def engine_zeep():
 
 
 @pytest.fixture
-def mock_auth():
-    return MagicMock(login="test_user", password=SecretStr("test_pass"))
+def mock_auth(mocker):
+    return mocker.MagicMock(login="test_user", password=SecretStr("test_pass"))
 
 
 @pytest.fixture
-def mock_zeep_client():
-    return MagicMock(spec=zeep.Client, settings=MagicMock())
+def mock_zeep_client(mocker):
+    return mocker.MagicMock(spec=zeep.Client, settings=mocker.MagicMock())
 
 
 def test_read(engine_zeep, mock_auth, mock_zeep_client, mocker):
@@ -114,7 +112,7 @@ def test_delete_empty_list(engine_zeep, mock_auth, mock_zeep_client, mocker):
 
 
 def test_get_client(engine_zeep, mocker):
-    mock_zeep_client = mocker.patch("zeep.Client", return_value=MagicMock(spec=zeep.Client))
+    mock_zeep_client = mocker.patch("zeep.Client", return_value=mocker.MagicMock(spec=zeep.Client))
 
     client = engine_zeep._get_client("sample")
 
@@ -131,8 +129,8 @@ def test_convert_results(engine_zeep, mocker):
     mock_serialize_object = mocker.patch("bfabric.engine.engine_zeep.serialize_object")
     mock_clean_result = mocker.patch("bfabric.engine.engine_zeep.clean_result")
 
-    mock_response = MagicMock()
-    mock_response.sample = [MagicMock(), MagicMock()]
+    mock_response = mocker.MagicMock()
+    mock_response.sample = [mocker.MagicMock(), mocker.MagicMock()]
     mock_response.__getitem__.side_effect = {
         "sample": mock_response.sample,
         "numberofpages": 2,
@@ -150,8 +148,8 @@ def test_convert_results(engine_zeep, mocker):
     assert mock_clean_result.call_count == 2
 
 
-def test_convert_results_no_results(engine_zeep):
-    mock_response = MagicMock()
+def test_convert_results_no_results(engine_zeep, mocker):
+    mock_response = mocker.MagicMock()
     mock_response.__getitem__.side_effect = {"numberofpages": 0}.__getitem__
     del mock_response.sample
 

--- a/tests/bfabric_app_runner/actions/test_config_file.py
+++ b/tests/bfabric_app_runner/actions/test_config_file.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import MagicMock
 
 from bfabric_app_runner.actions.config_file import ActionConfig, FromConfigFile
 
@@ -31,7 +30,7 @@ class TestFromConfigFile:
         mocker.patch("yaml.safe_load", return_value=expected_yaml_data)
 
         # Mock ActionConfig.model_validate
-        mock_action_config = MagicMock()
+        mock_action_config = mocker.MagicMock()
         # Set up __iter__ to return key-value pairs
         mock_action_config.__iter__.return_value = [
             ("work_dir", Path("/test/work/dir")),

--- a/tests/bfabric_app_runner/bfabric_integration/submitter/config/test_slurm_params.py
+++ b/tests/bfabric_app_runner/bfabric_integration/submitter/config/test_slurm_params.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 
@@ -42,10 +41,10 @@ def test_slurm_config_template_evaluation(slurm_config_file_template, variables_
     assert config_file.job_script == Path("~/test/job-42").expanduser()
 
 
-def test_slurm_parameters_creation():
+def test_slurm_parameters_creation(mocker):
     """Test SlurmParameters creation and sbatch_params merging."""
     # Mock workunit params
-    mock_workunit_params = Mock(spec=SlurmWorkunitParams)
+    mock_workunit_params = mocker.Mock(spec=SlurmWorkunitParams)
     mock_workunit_params.as_dict.return_value = {"--time": "01:00:00", "--mem": "4G"}
 
     # Create SlurmParameters

--- a/tests/bfabric_app_runner/commands/test_command_python_env.py
+++ b/tests/bfabric_app_runner/commands/test_command_python_env.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -136,7 +135,7 @@ class TestPythonEnvironment:
     def test_log_packages(self, temp_env_path, sample_command, mock_uv, mocker):
         """Test that log_packages runs pip list command."""
         mock_subprocess = mocker.patch("bfabric_app_runner.commands.command_python_env.subprocess.run")
-        mock_subprocess.return_value = MagicMock(stdout="package1==1.0\npackage2==2.0\n")
+        mock_subprocess.return_value = mocker.MagicMock(stdout="package1==1.0\npackage2==2.0\n")
 
         env = PythonEnvironment(temp_env_path, sample_command)
         env.log_packages()
@@ -247,10 +246,10 @@ class TestCachedEnvironmentStrategy:
         command = CommandPythonEnv(pylock=Path("/test/req.txt"), command="script.py", python_version="3.13")
 
         # Mock different mtimes
-        mocker.patch("pathlib.Path.stat", return_value=MagicMock(st_mtime=1000))
+        mocker.patch("pathlib.Path.stat", return_value=mocker.MagicMock(st_mtime=1000))
         hash1 = strategy._compute_env_hash(command)
 
-        mocker.patch("pathlib.Path.stat", return_value=MagicMock(st_mtime=2000))
+        mocker.patch("pathlib.Path.stat", return_value=mocker.MagicMock(st_mtime=2000))
         hash2 = strategy._compute_env_hash(command)
 
         assert hash1 != hash2

--- a/tests/bfabric_app_runner/output_registration/test_save_link.py
+++ b/tests/bfabric_app_runner/output_registration/test_save_link.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 from bfabric.results.result_container import ResultContainer
@@ -8,13 +6,13 @@ from bfabric_app_runner.specs.outputs_spec import SaveLinkSpec
 
 
 @pytest.fixture()
-def mock_client():
-    return MagicMock()
+def mock_client(mocker):
+    return mocker.MagicMock()
 
 
 @pytest.fixture()
-def mock_workunit_definition():
-    mock = MagicMock()
+def mock_workunit_definition(mocker):
+    mock = mocker.MagicMock()
     mock.registration.workunit_id = 42
     return mock
 

--- a/tests/bfabric_scripts/test_api_parser.py
+++ b/tests/bfabric_scripts/test_api_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 from pytest_mock import MockerFixture
-from unittest.mock import MagicMock
 
 from bfabric_scripts.cli.api.parser import (
     FieldModel,
@@ -101,15 +100,15 @@ class TestParameterModel:
 class TestParseFieldRecursive:
     """Tests for _parse_field_recursive function."""
 
-    def test_parse_simple_field(self) -> None:
+    def test_parse_simple_field(self, mocker: MockerFixture) -> None:
         """Test parsing a simple field without children."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "simple_field"
         field_mock.type = "string"
         field_mock.required.return_value = False
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=0, max_depth=5)
 
@@ -119,15 +118,15 @@ class TestParseFieldRecursive:
         assert result.multi_occurrence is False
         assert result.children == []
 
-    def test_parse_required_field(self) -> None:
+    def test_parse_required_field(self, mocker: MockerFixture) -> None:
         """Test parsing a field marked as required."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "required_field"
         field_mock.type = "int"
         field_mock.required.return_value = True
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=0, max_depth=5)
 
@@ -135,15 +134,15 @@ class TestParseFieldRecursive:
         assert result.required is True
         assert result.multi_occurrence is False
 
-    def test_parse_field_max_depth_exceeded(self) -> None:
+    def test_parse_field_max_depth_exceeded(self, mocker: MockerFixture) -> None:
         """Test that recursion stops at max_depth."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "field"
         field_mock.type = "string"
         field_mock.required.return_value = False
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         # At max depth, should not recurse even if type exists
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=5, max_depth=5)
@@ -151,15 +150,15 @@ class TestParseFieldRecursive:
         assert result.name == "field"
         assert result.children == []
 
-    def test_parse_field_skips_builtin_types(self) -> None:
+    def test_parse_field_skips_builtin_types(self, mocker: MockerFixture) -> None:
         """Test that built-in XML Schema types are skipped."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "xml_field"
         field_mock.type = ("string", "http://www.w3.org/2001/XMLSchema")
         field_mock.required.return_value = False
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=0, max_depth=5)
 
@@ -169,32 +168,32 @@ class TestParseFieldRecursive:
     def test_parse_field_with_nested_type(self, mocker: MockerFixture) -> None:
         """Test parsing a field with nested custom type."""
         # Create nested field
-        nested_field_mock = MagicMock()
+        nested_field_mock = mocker.MagicMock()
         nested_field_mock.name = "nested_field"
         nested_field_mock.type = "simple_type"
         nested_field_mock.required.return_value = False
         nested_field_mock.multi_occurrence.return_value = False
 
         # Create parent field with custom type
-        parent_field_mock = MagicMock()
+        parent_field_mock = mocker.MagicMock()
         parent_field_mock.name = "parent_field"
         parent_field_mock.type = ("CustomType", "http://example.com/schema")
         parent_field_mock.required.return_value = False
         parent_field_mock.multi_occurrence.return_value = False
 
         # Mock schema and type resolution
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
-        resolved_type_mock = MagicMock()
+        resolved_type_mock = mocker.MagicMock()
         resolved_type_mock.children.return_value = [(nested_field_mock, None)]
 
-        type_def_mock = MagicMock()
+        type_def_mock = mocker.MagicMock()
         type_def_mock.resolve.return_value = resolved_type_mock
 
         # Mock TypeQuery
         mocker.patch(
             "bfabric_scripts.cli.api.parser.TypeQuery",
-            return_value=MagicMock(execute=MagicMock(return_value=type_def_mock)),
+            return_value=mocker.MagicMock(execute=mocker.MagicMock(return_value=type_def_mock)),
         )
 
         result = _parse_field_recursive(parent_field_mock, schema_mock, current_depth=0, max_depth=5)
@@ -210,39 +209,39 @@ class TestParseMethodSignature:
     def test_parse_method_signature_basic(self, mocker: MockerFixture) -> None:
         """Test basic method signature parsing."""
         # Mock parameter field
-        param_field_mock = MagicMock()
+        param_field_mock = mocker.MagicMock()
         param_field_mock.name = "field1"
         param_field_mock.type = "string"
         param_field_mock.required.return_value = False
         param_field_mock.multi_occurrence.return_value = False
 
         # Mock parameter schema
-        param_schema_mock = MagicMock()
-        resolved_param_mock = MagicMock()
+        param_schema_mock = mocker.MagicMock()
+        resolved_param_mock = mocker.MagicMock()
         resolved_param_mock.name = "ParamType"
         resolved_param_mock.required.return_value = True
         resolved_param_mock.children.return_value = [(param_field_mock, None)]
         param_schema_mock.resolve.return_value = resolved_param_mock
 
         # Mock method binding
-        binding_mock = MagicMock()
+        binding_mock = mocker.MagicMock()
         binding_mock.param_defs.return_value = [("testParam", param_schema_mock)]
 
         # Mock method
-        method_mock = MagicMock()
+        method_mock = mocker.MagicMock()
         method_mock.method.binding.input = binding_mock
-        method_mock.method.binding.input.wsdl.schema = MagicMock()
+        method_mock.method.binding.input.wsdl.schema = mocker.MagicMock()
 
         # Mock service
-        service_mock = MagicMock()
-        service_mock.testMethod = MagicMock(method=method_mock.method)
+        service_mock = mocker.MagicMock()
+        service_mock.testMethod = mocker.MagicMock(method=method_mock.method)
         mocker.patch.object(service_mock, "testMethod", method_mock)
 
         # Mock client
-        client_mock = MagicMock()
+        client_mock = mocker.MagicMock()
         client_mock._engine._get_suds_service.return_value = service_mock
         mocker.patch.object(service_mock, "testMethod", method_mock)
-        client_mock._engine._get_suds_service.return_value = MagicMock(testMethod=method_mock)
+        client_mock._engine._get_suds_service.return_value = mocker.MagicMock(testMethod=method_mock)
 
         # Call function
         result = parse_method_signature(client_mock, "test_endpoint", "testMethod")
@@ -257,18 +256,18 @@ class TestParseMethodSignature:
     def test_parse_method_signature_empty_parameters(self, mocker: MockerFixture) -> None:
         """Test parsing a method with no parameters."""
         # Mock method with no parameters
-        binding_mock = MagicMock()
+        binding_mock = mocker.MagicMock()
         binding_mock.param_defs.return_value = []
 
-        method_mock = MagicMock()
+        method_mock = mocker.MagicMock()
         method_mock.method.binding.input = binding_mock
-        method_mock.method.binding.input.wsdl.schema = MagicMock()
+        method_mock.method.binding.input.wsdl.schema = mocker.MagicMock()
 
         # Mock service and client
-        service_mock = MagicMock()
+        service_mock = mocker.MagicMock()
         service_mock.testMethod = method_mock
 
-        client_mock = MagicMock()
+        client_mock = mocker.MagicMock()
         client_mock._engine._get_suds_service.return_value = service_mock
 
         # Call function


### PR DESCRIPTION
Consistently use pytest-mock and adapt the guidance in AGENTS.md on test set up.