### PR TITLE
feature/url-token-oidc-claims

### DIFF
--- a/bfabric/src/bfabric/_oauth/_constants.py
+++ b/bfabric/src/bfabric/_oauth/_constants.py
@@ -1,4 +1,4 @@
 """Shared constants for the OAuth module."""
 
 DEFAULT_CLIENT_ID = "bfabric-cli"
-DEFAULT_OAUTH_SCOPE = "api:read api:write"
+DEFAULT_OAUTH_SCOPE = "api:read api:write openid profile email groups"

--- a/bfabric/src/bfabric/_oauth/device_code.py
+++ b/bfabric/src/bfabric/_oauth/device_code.py
@@ -150,7 +150,7 @@ def device_code_login(
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param client_id: OAuth client ID (default ``"bfabric-cli"``)
-    :param scope: OAuth scope (default ``"api:read api:write"``)
+    :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param timeout: Seconds to wait for the user to authorize (default 600)
     :returns: Token dict with ``access_token``, ``refresh_token``, etc.
     :raises RuntimeError: On timeout, expired token, or access denied

--- a/bfabric/src/bfabric/_oauth/pkce.py
+++ b/bfabric/src/bfabric/_oauth/pkce.py
@@ -145,7 +145,7 @@ def pkce_login(
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param client_id: OAuth client ID (default ``"bfabric-cli"``)
-    :param scope: OAuth scope (default ``"api:read api:write"``)
+    :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param port: Local port for the callback server (``0`` = auto-assign)
     :param open_browser: Whether to open the authorization URL in the browser.
         If ``False`` (or if the browser fails to open), the URL is printed to stderr.

--- a/bfabric/src/bfabric/_oauth/registration.py
+++ b/bfabric/src/bfabric/_oauth/registration.py
@@ -27,7 +27,7 @@ _GRANT_TYPE_TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange"
 
 def _default_grant_types(service_user: str | None) -> list[str]:
     """Return the default grant types for webapp registration."""
-    grant_types = [_GRANT_TYPE_TOKEN_EXCHANGE, "refresh_token"]
+    grant_types = [_GRANT_TYPE_TOKEN_EXCHANGE, "refresh_token", "authorization_code"]
     if service_user is not None:
         grant_types.append("client_credentials")
     return grant_types
@@ -48,8 +48,8 @@ def register_client(
     Requires an employee Bearer token for authorization.
 
     By default, requests the grant types needed for webapp operation:
-    ``token-exchange`` and ``refresh_token`` always, plus ``client_credentials``
-    when *service_user* is provided. Pass *grant_types* to override.
+    ``token-exchange``, ``refresh_token`` and ``authorization_code`` always, plus
+    ``client_credentials`` when *service_user* is provided. Pass *grant_types* to override.
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param token: Employee Bearer token for authorization

--- a/bfabric/src/bfabric/_oauth/registration.py
+++ b/bfabric/src/bfabric/_oauth/registration.py
@@ -56,7 +56,7 @@ def register_client(
     :param client_name: Human-readable name for the client
     :param redirect_uri: OAuth redirect URI for the client
     :param service_user: Optional service user login to enable ``client_credentials`` grant
-    :param scope: OAuth scope string (default ``"api:read api:write"``)
+    :param scope: OAuth scope string (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param grant_types: Explicit list of grant types to request (overrides the default)
     :returns: Registration response containing ``client_id``, ``client_secret``, etc.
     """
@@ -109,7 +109,7 @@ def register_webapp(
     :param app_name: Human-readable name for both the OAuth client and the application
     :param web_url: The webapp URL (used as both OAuth redirect URI and application ``weburl``)
     :param service_user: Optional service user login to enable ``client_credentials`` grant
-    :param scope: OAuth scope string (default ``"api:read api:write"``)
+    :param scope: OAuth scope string (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param application_id: Existing application ID to update (omit to create a new application)
     :param technology_id: Technology ID for the application
     :param description: Application description

--- a/bfabric/src/bfabric/_oauth/url_token.py
+++ b/bfabric/src/bfabric/_oauth/url_token.py
@@ -38,6 +38,11 @@ class UrlTokenContext(BaseModel):
     name: str | None = Field(default=None)
 
     @property
+    def base_url(self) -> str | None:
+        """B-Fabric instance base URL derived from ``iss``, trailing slash stripped."""
+        return self.issuer.rstrip("/") if self.issuer else None
+
+    @property
     def is_employee(self) -> bool:
         """Whether the token's groups claim includes the ``employee`` group."""
         return self.groups is not None and "employee" in self.groups

--- a/bfabric/src/bfabric/_oauth/url_token.py
+++ b/bfabric/src/bfabric/_oauth/url_token.py
@@ -32,6 +32,15 @@ class UrlTokenContext(BaseModel):
     client_id: str | None = None
     subject: str | None = Field(default=None, alias="sub")
     expires_at: datetime | None = Field(default=None, alias="exp")
+    issuer: str | None = Field(default=None, alias="iss")
+    groups: list[str] | None = Field(default=None)
+    email: str | None = Field(default=None)
+    name: str | None = Field(default=None)
+
+    @property
+    def is_employee(self) -> bool:
+        """Whether the token's groups claim includes the ``employee`` group."""
+        return self.groups is not None and "employee" in self.groups
 
 
 # Module-level JWKS cache: {base_url: (jwks_dict, fetched_at)}

--- a/bfabric/src/bfabric/_oauth/webapp_client.py
+++ b/bfabric/src/bfabric/_oauth/webapp_client.py
@@ -49,7 +49,7 @@ class WebappClient:
         :param launch_token: The short-lived JWT from the URL ``jwt`` parameter
         :param client_id: OAuth client ID for the webapp
         :param client_secret: OAuth client secret for the webapp
-        :param scope: OAuth scope for the service account (default ``"api:read api:write"``)
+        :param scope: OAuth scope for the service account (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
         :param user_token_cache_path: Optional path to cache user tokens on disk
         :param service_token_cache_path: Optional path to cache service tokens on disk
         """

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 import cyclopts
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.registration import register_client
 from bfabric.config import DEFAULT_CONFIG_FILE
 
@@ -79,7 +80,7 @@ def cmd_login_register(
     service_user: Annotated[
         str | None, cyclopts.Parameter(help="Service user login (enables client_credentials grant).")
     ] = None,
-    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = "api:read api:write",
+    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = DEFAULT_OAUTH_SCOPE,
     grant_types: Annotated[
         list[str] | None,
         cyclopts.Parameter(help="Grant types to request (overrides default webapp grants)."),

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/register_webapp.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/register_webapp.py
@@ -9,6 +9,7 @@ from typing import Annotated
 
 import cyclopts
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric.config import DEFAULT_CONFIG_FILE
 
 
@@ -23,7 +24,7 @@ def cmd_login_register_webapp(
     service_user: Annotated[
         str | None, cyclopts.Parameter(help="Service user login (enables client_credentials grant).")
     ] = None,
-    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = "api:read api:write",
+    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = DEFAULT_OAUTH_SCOPE,
     application_id: Annotated[
         int | None, cyclopts.Parameter(help="Existing application ID to update (omit to create new).")
     ] = None,

--- a/tests/bfabric/oauth/test_device_code.py
+++ b/tests/bfabric/oauth/test_device_code.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.device_code import (
     _poll_for_token,
     _request_device_code,
@@ -315,7 +316,7 @@ class TestDeviceCodeLogin:
         mock_request.assert_called_once_with(
             "https://example.com/bfabric",
             client_id="bfabric-cli",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
         )
         assert mock_poll.call_args[0][0] == "https://example.com/bfabric"
 

--- a/tests/bfabric/oauth/test_registration.py
+++ b/tests/bfabric/oauth/test_registration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.registration import register_client, register_webapp
 
 
@@ -36,7 +37,7 @@ class TestRegisterClient:
                 "client_name": "my-app",
                 "redirect_uris": ["http://localhost:8050/callback"],
                 "grant_types": [_TOKEN_EXCHANGE, "refresh_token"],
-                "scope": "api:read api:write",
+                "scope": DEFAULT_OAUTH_SCOPE,
             },
             headers={"Authorization": "Bearer bearer-token"},
             timeout=30,
@@ -103,7 +104,7 @@ class TestRegisterClient:
 
         call_body = mock_httpx_post.call_args[1]["json"]
         assert "service_user_login" not in call_body
-        assert call_body["scope"] == "api:read api:write"
+        assert call_body["scope"] == DEFAULT_OAUTH_SCOPE
 
     def test_normalizes_trailing_slash(self, mock_httpx_post):
         register_client(
@@ -170,7 +171,7 @@ class TestRegisterWebapp:
             client_name="My Webapp",
             redirect_uri="https://myapp.example.com/",
             service_user=None,
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
         )
         mock_client.save.assert_called_once_with(
             "application",

--- a/tests/bfabric/oauth/test_registration.py
+++ b/tests/bfabric/oauth/test_registration.py
@@ -36,7 +36,7 @@ class TestRegisterClient:
             json={
                 "client_name": "my-app",
                 "redirect_uris": ["http://localhost:8050/callback"],
-                "grant_types": [_TOKEN_EXCHANGE, "refresh_token"],
+                "grant_types": [_TOKEN_EXCHANGE, "refresh_token", "authorization_code"],
                 "scope": DEFAULT_OAUTH_SCOPE,
             },
             headers={"Authorization": "Bearer bearer-token"},
@@ -56,7 +56,12 @@ class TestRegisterClient:
 
         call_body = mock_httpx_post.call_args[1]["json"]
         assert call_body["service_user_login"] == "gfeeder"
-        assert call_body["grant_types"] == [_TOKEN_EXCHANGE, "refresh_token", "client_credentials"]
+        assert call_body["grant_types"] == [
+            _TOKEN_EXCHANGE,
+            "refresh_token",
+            "authorization_code",
+            "client_credentials",
+        ]
 
     def test_without_service_user_no_client_credentials_grant(self, mock_httpx_post):
         register_client(
@@ -67,7 +72,7 @@ class TestRegisterClient:
         )
 
         call_body = mock_httpx_post.call_args[1]["json"]
-        assert call_body["grant_types"] == [_TOKEN_EXCHANGE, "refresh_token"]
+        assert call_body["grant_types"] == [_TOKEN_EXCHANGE, "refresh_token", "authorization_code"]
         assert "service_user_login" not in call_body
 
     def test_with_scope(self, mock_httpx_post):

--- a/tests/bfabric/oauth/test_webapp_client.py
+++ b/tests/bfabric/oauth/test_webapp_client.py
@@ -4,6 +4,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.url_token import UrlTokenContext
 from bfabric._oauth.webapp_client import WebappClient
 
@@ -160,7 +161,7 @@ class TestWebappClientCreate:
             client_secret="csecret",
         )
 
-        assert mock_connect_oauth.call_args.kwargs["scope"] == "api:read api:write"
+        assert mock_connect_oauth.call_args.kwargs["scope"] == DEFAULT_OAUTH_SCOPE
 
 
 class TestWebappClientFrozen:

--- a/tests/bfabric/test_bfabric.py
+++ b/tests/bfabric/test_bfabric.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import SecretStr
 
 from bfabric import Bfabric, BfabricAPIEngineType, BfabricClientConfig, BfabricAuth
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
 from bfabric.config.config_data import ConfigData
@@ -438,7 +439,7 @@ class TestConnectOAuth:
             client_id="my-id",
             client_secret="my-secret",
             token_url="https://example.com/bfabric/rest/oauth/token",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             grant_type="client_credentials",
             token_cache_path=None,
         )
@@ -538,7 +539,7 @@ class TestConnectPkce:
         mock_pkce_login.assert_called_once_with(
             "https://example.com/bfabric",
             client_id="bfabric-cli",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             port=0,
             open_browser=True,
             timeout=120.0,
@@ -549,7 +550,7 @@ class TestConnectPkce:
             token_url="https://example.com/bfabric/rest/oauth/token",
             token=mock_pkce_login.return_value,
             grant_type="refresh_token",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             token_cache_path=None,
         )
         assert client._credential_provider == mock_provider_cls.return_value
@@ -619,7 +620,7 @@ class TestConnectDeviceCode:
         mock_device_code_login.assert_called_once_with(
             "https://example.com/bfabric",
             client_id="bfabric-cli",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             timeout=600.0,
         )
         mock_provider_cls.assert_called_once_with(
@@ -628,7 +629,7 @@ class TestConnectDeviceCode:
             token_url="https://example.com/bfabric/rest/oauth/token",
             token=mock_device_code_login.return_value,
             grant_type="refresh_token",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             token_cache_path=None,
         )
         assert client._credential_provider == mock_provider_cls.return_value

--- a/tests/bfabric_scripts/cli/login/test_cmd_login_register.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_login_register.py
@@ -5,6 +5,7 @@ import time
 import pytest
 import yaml
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric_scripts.cli.login.register import cmd_login_register
 
 
@@ -106,7 +107,7 @@ class TestCmdLoginRegister:
             client_name="My App",
             redirect_uri="http://localhost/callback",
             service_user=None,
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             grant_types=None,
         )
         output = capsys.readouterr()
@@ -153,7 +154,7 @@ class TestCmdLoginRegister:
             client_name="My App",
             redirect_uri="http://localhost/callback",
             service_user=None,
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             grant_types=None,
         )
 


### PR DESCRIPTION
Add OIDC claims to UrlTokenContext and expand default OAuth scope

Adds standard OIDC claims (iss, groups, email, name) as typed fields on UrlTokenContext, extracted from the JWT without any extra API call.

Key additions:
- is_employee property on UrlTokenContext — checks the groups claim for "employee", complementing the existing User.is_employee which requires a feeder-credential API call
- DEFAULT_OAUTH_SCOPE expanded to "api:read api:write openid profile email groups" so all OAuth flows request these claims by default

Note: groups, email, and name are scope-gated on the B-Fabric server side — the OAuth client registration must include the corresponding scopes (groups, email, profile) for
these claims to appear in the token. The expanded default scope handles this automatically for newly registered clients using register_client / register_webapp.