### PR TITLE
Fix licensecheck nox session failing on Python 3.12+

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -327,7 +327,7 @@ def code_style(session):
     session.run("ruff", "check", "bfabric")
 
 
-@nox.session
+@nox.session(python="3.11")
 @nox.parametrize("package", WORKSPACE_PACKAGES)
 def licensecheck(session, package) -> None:
     """Runs the license check."""


### PR DESCRIPTION
Use Python 3.11 as it is the easiest fix for the licensecheck problem now.