### PR TITLE
Release candidates: bfabric 1.20.0rc1 + bfabric_scripts 1.16.0rc1

### DIFF
--- a/.github/workflows/pr_release_preview.yml
+++ b/.github/workflows/pr_release_preview.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install hatch
         run: pip install hatch
       - name: Check which packages will be released
@@ -117,7 +117,7 @@ jobs:
           - python-version: "3.13"
             resolution: "lowest-direct"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -59,7 +59,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: actions/setup-python@v6

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       packages_to_release: ${{ steps.check-versions.outputs.packages-to-release }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set PyPI repository URL
         id: set-repo-url
         run: |
@@ -56,7 +56,7 @@ jobs:
       # Run sequentially to ensure proper order of releases
       max-parallel: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -10,7 +10,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: |
@@ -50,7 +50,7 @@ jobs:
     name: Code Style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: 3.11
@@ -66,7 +66,7 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Check "TODO" differences
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,9 @@ Each package's docs live alongside its source. Skim the index when working in a 
 - Tests must NOT contain `__init__.py` files (enforced by `check_test_inits` nox session)
 - Test order is randomised via [pytest-random-order](https://github.com/pytest-dev/pytest-random-order) (`addopts = "--random-order"`), so both modules and the tests within them run in a shuffled order to surface hidden inter-test dependencies. The seed is printed in the pytest header; reproduce a specific order with `pytest --random-order-seed=<N>`. Tests must therefore be isolation-safe; quarantine a genuinely order-dependent module with `pytestmark = pytest.mark.random_order(disabled=True)` only as a last resort.
 - Test conftest sets `BFABRICPY_CONFIG_ENV=__MOCK` to avoid real credentials
+- Tests use the pytest-mock `mocker` fixture for **all** mocking — do not `import unittest.mock`.
+  Use `mocker.patch(...)`, `mocker.patch.object(...)`, `mocker.patch.dict(...)`, `mocker.MagicMock()`,
+  `mocker.Mock()`, `mocker.mock_open(...)`, etc. (`pytest-mock` is a test dependency in every package.)
 - Ruff linting is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores)
 - Line length: 120 (ruff and black)
 - basedpyright uses per-package baseline files at `.basedpyright/baseline.{package}.json` — **do not edit baseline files to silence new errors**; fix the code or add a targeted `# pyright: ignore[...]` comment on the offending line. Baselines only exist to grandfather in pre-existing errors.

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,8 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+## \[1.20.0rc1\] - 2026-06-23
+
 ### Added
 
 - OAuth 2.0 authentication for the `Bfabric` client. New factory methods:

--- a/bfabric/pyproject.toml
+++ b/bfabric/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "bfabric"
 description = "Python client for the B-Fabric API"
 readme = "../README.md"
-version = "1.19.0"
+version = "1.20.0rc1"
 license = { text = "GPL-3.0" }
 authors = [
     { name = "Christian Panse", email = "cp@fgcz.ethz.ch" },

--- a/bfabric/src/bfabric/_oauth/_constants.py
+++ b/bfabric/src/bfabric/_oauth/_constants.py
@@ -1,4 +1,4 @@
 """Shared constants for the OAuth module."""
 
 DEFAULT_CLIENT_ID = "bfabric-cli"
-DEFAULT_OAUTH_SCOPE = "api:read api:write"
+DEFAULT_OAUTH_SCOPE = "api:read api:write openid profile email groups"

--- a/bfabric/src/bfabric/_oauth/device_code.py
+++ b/bfabric/src/bfabric/_oauth/device_code.py
@@ -150,7 +150,7 @@ def device_code_login(
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param client_id: OAuth client ID (default ``"bfabric-cli"``)
-    :param scope: OAuth scope (default ``"api:read api:write"``)
+    :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param timeout: Seconds to wait for the user to authorize (default 600)
     :returns: Token dict with ``access_token``, ``refresh_token``, etc.
     :raises RuntimeError: On timeout, expired token, or access denied

--- a/bfabric/src/bfabric/_oauth/pkce.py
+++ b/bfabric/src/bfabric/_oauth/pkce.py
@@ -145,7 +145,7 @@ def pkce_login(
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param client_id: OAuth client ID (default ``"bfabric-cli"``)
-    :param scope: OAuth scope (default ``"api:read api:write"``)
+    :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param port: Local port for the callback server (``0`` = auto-assign)
     :param open_browser: Whether to open the authorization URL in the browser.
         If ``False`` (or if the browser fails to open), the URL is printed to stderr.

--- a/bfabric/src/bfabric/_oauth/registration.py
+++ b/bfabric/src/bfabric/_oauth/registration.py
@@ -27,7 +27,7 @@ _GRANT_TYPE_TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange"
 
 def _default_grant_types(service_user: str | None) -> list[str]:
     """Return the default grant types for webapp registration."""
-    grant_types = [_GRANT_TYPE_TOKEN_EXCHANGE, "refresh_token"]
+    grant_types = [_GRANT_TYPE_TOKEN_EXCHANGE, "refresh_token", "authorization_code"]
     if service_user is not None:
         grant_types.append("client_credentials")
     return grant_types
@@ -48,15 +48,15 @@ def register_client(
     Requires an employee Bearer token for authorization.
 
     By default, requests the grant types needed for webapp operation:
-    ``token-exchange`` and ``refresh_token`` always, plus ``client_credentials``
-    when *service_user* is provided. Pass *grant_types* to override.
+    ``token-exchange``, ``refresh_token`` and ``authorization_code`` always, plus
+    ``client_credentials`` when *service_user* is provided. Pass *grant_types* to override.
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param token: Employee Bearer token for authorization
     :param client_name: Human-readable name for the client
     :param redirect_uri: OAuth redirect URI for the client
     :param service_user: Optional service user login to enable ``client_credentials`` grant
-    :param scope: OAuth scope string (default ``"api:read api:write"``)
+    :param scope: OAuth scope string (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param grant_types: Explicit list of grant types to request (overrides the default)
     :returns: Registration response containing ``client_id``, ``client_secret``, etc.
     """
@@ -109,7 +109,7 @@ def register_webapp(
     :param app_name: Human-readable name for both the OAuth client and the application
     :param web_url: The webapp URL (used as both OAuth redirect URI and application ``weburl``)
     :param service_user: Optional service user login to enable ``client_credentials`` grant
-    :param scope: OAuth scope string (default ``"api:read api:write"``)
+    :param scope: OAuth scope string (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param application_id: Existing application ID to update (omit to create a new application)
     :param technology_id: Technology ID for the application
     :param description: Application description

--- a/bfabric/src/bfabric/_oauth/url_token.py
+++ b/bfabric/src/bfabric/_oauth/url_token.py
@@ -32,6 +32,20 @@ class UrlTokenContext(BaseModel):
     client_id: str | None = None
     subject: str | None = Field(default=None, alias="sub")
     expires_at: datetime | None = Field(default=None, alias="exp")
+    issuer: str | None = Field(default=None, alias="iss")
+    groups: list[str] | None = Field(default=None)
+    email: str | None = Field(default=None)
+    name: str | None = Field(default=None)
+
+    @property
+    def base_url(self) -> str | None:
+        """B-Fabric instance base URL derived from ``iss``, trailing slash stripped."""
+        return self.issuer.rstrip("/") if self.issuer else None
+
+    @property
+    def is_employee(self) -> bool:
+        """Whether the token's groups claim includes the ``employee`` group."""
+        return self.groups is not None and "employee" in self.groups
 
 
 # Module-level JWKS cache: {base_url: (jwks_dict, fetched_at)}

--- a/bfabric/src/bfabric/_oauth/webapp_client.py
+++ b/bfabric/src/bfabric/_oauth/webapp_client.py
@@ -49,7 +49,7 @@ class WebappClient:
         :param launch_token: The short-lived JWT from the URL ``jwt`` parameter
         :param client_id: OAuth client ID for the webapp
         :param client_secret: OAuth client secret for the webapp
-        :param scope: OAuth scope for the service account (default ``"api:read api:write"``)
+        :param scope: OAuth scope for the service account (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
         :param user_token_cache_path: Optional path to cache user tokens on disk
         :param service_token_cache_path: Optional path to cache service tokens on disk
         """

--- a/bfabric_rest_proxy/tests/conftest.py
+++ b/bfabric_rest_proxy/tests/conftest.py
@@ -6,8 +6,6 @@ no real API calls are made during testing.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
@@ -26,9 +24,9 @@ from bfabric_rest_proxy.settings import ServerSettings
 
 
 @pytest.fixture
-def mock_settings():
+def mock_settings(mocker):
     """Mock ServerSettings for testing."""
-    settings = MagicMock(spec=ServerSettings)
+    settings = mocker.MagicMock(spec=ServerSettings)
     settings.default_bfabric_instance = "https://test.bfabric.example.com/"
     settings.supported_bfabric_instances = ["https://test.bfabric.example.com/"]
     # BfabricAuth requires passwords of at least 32 characters

--- a/bfabric_rest_proxy/tests/test_read_endpoint.py
+++ b/bfabric_rest_proxy/tests/test_read_endpoint.py
@@ -4,8 +4,6 @@ This module tests the /read endpoint with mocked Bfabric client to ensure
 no real API calls are made during testing.
 """
 
-from unittest.mock import MagicMock
-
 import pytest
 from bfabric.results.result_container import ResultContainer
 
@@ -106,10 +104,10 @@ class TestReadEndpoint:
         assert call_args.kwargs["offset"] == 10
         assert call_args.kwargs["max_results"] == 50
 
-    def test_read_calls_to_list_dict(self, client, mock_bfabric_user_client):
+    def test_read_calls_to_list_dict(self, client, mock_bfabric_user_client, mocker):
         """Test that the response is properly converted to list dict."""
         # Create a mock ResultContainer
-        mock_result = MagicMock()
+        mock_result = mocker.MagicMock()
         mock_result.to_list_dict.return_value = [
             {"id": 1, "name": "test1"},
             {"id": 2, "name": "test2"},

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -2,13 +2,15 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-Versioning currently follows `X.Y.Z` where
+Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bfabric` core package version:
 
 - `X` is used for major changes, that contain breaking changes
-- `Y` should be the current bfabric release
-- `Z` is increased for feature releases, that should not break the API
+- `Y` is increased for feature releases, that should not break the API
+- `Z` is increased for bug-fix releases
 
 ## \[Unreleased\]
+
+## \[1.16.0rc1\] - 2026-06-23
 
 ### Added
 

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "bfabric_scripts"
 description = "Python command line scripts for the B-Fabric API"
 readme = "../README.md"
-version = "1.15.0"
+version = "1.16.0rc1"
 
 dependencies = [
     "bfabric>=1.18.0,<2",

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 import cyclopts
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.registration import register_client
 from bfabric.config import DEFAULT_CONFIG_FILE
 
@@ -79,7 +80,7 @@ def cmd_login_register(
     service_user: Annotated[
         str | None, cyclopts.Parameter(help="Service user login (enables client_credentials grant).")
     ] = None,
-    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = "api:read api:write",
+    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = DEFAULT_OAUTH_SCOPE,
     grant_types: Annotated[
         list[str] | None,
         cyclopts.Parameter(help="Grant types to request (overrides default webapp grants)."),

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/register_webapp.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/register_webapp.py
@@ -9,6 +9,7 @@ from typing import Annotated
 
 import cyclopts
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric.config import DEFAULT_CONFIG_FILE
 
 
@@ -23,7 +24,7 @@ def cmd_login_register_webapp(
     service_user: Annotated[
         str | None, cyclopts.Parameter(help="Service user login (enables client_credentials grant).")
     ] = None,
-    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = "api:read api:write",
+    scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = DEFAULT_OAUTH_SCOPE,
     application_id: Annotated[
         int | None, cyclopts.Parameter(help="Existing application ID to update (omit to create new).")
     ] = None,

--- a/noxfile.py
+++ b/noxfile.py
@@ -327,7 +327,7 @@ def code_style(session):
     session.run("ruff", "check", "bfabric")
 
 
-@nox.session
+@nox.session(python="3.11")
 @nox.parametrize("package", WORKSPACE_PACKAGES)
 def licensecheck(session, package) -> None:
     """Runs the license check."""

--- a/tests/bfabric/engine/test_engine_suds.py
+++ b/tests/bfabric/engine/test_engine_suds.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 from pydantic import SecretStr
 from suds import MethodNotFound
@@ -17,8 +15,8 @@ def engine_suds():
 
 
 @pytest.fixture
-def mock_auth():
-    return MagicMock(login="test_user", password=SecretStr("test_pass"))
+def mock_auth(mocker):
+    return mocker.MagicMock(login="test_user", password=SecretStr("test_pass"))
 
 
 @pytest.fixture
@@ -27,8 +25,8 @@ def mock_suds_service(mocker, engine_suds):
 
 
 @pytest.fixture
-def mock_client(mock_suds_service):
-    mock_client = MagicMock(spec=Client)
+def mock_client(mocker, mock_suds_service):
+    mock_client = mocker.MagicMock(spec=Client)
     mock_client.service = mock_suds_service
     return mock_client
 
@@ -99,8 +97,8 @@ def test_convert_results(engine_suds, mocker):
     mock_suds_asdict = mocker.patch("bfabric.engine.engine_suds.suds_asdict_recursive")
     mock_clean_result = mocker.patch("bfabric.engine.engine_suds.clean_result")
 
-    mock_response = MagicMock()
-    mock_response.sample = [MagicMock(), MagicMock()]
+    mock_response = mocker.MagicMock()
+    mock_response.sample = [mocker.MagicMock(), mocker.MagicMock()]
     mock_response.__getitem__.side_effect = {
         "sample": mock_response.sample,
         "numberofpages": 2,
@@ -126,8 +124,8 @@ def test_get_suds_service(mocker, mock_client, mock_suds_service):
     assert service == mock_suds_service
 
 
-def test_convert_results_no_results(engine_suds):
-    mock_response = MagicMock()
+def test_convert_results_no_results(engine_suds, mocker):
+    mock_response = mocker.MagicMock()
     mock_response.numberofpages = 0
     del mock_response.sample
 

--- a/tests/bfabric/engine/test_engine_zeep.py
+++ b/tests/bfabric/engine/test_engine_zeep.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 import zeep
 from pydantic import SecretStr
@@ -16,13 +14,13 @@ def engine_zeep():
 
 
 @pytest.fixture
-def mock_auth():
-    return MagicMock(login="test_user", password=SecretStr("test_pass"))
+def mock_auth(mocker):
+    return mocker.MagicMock(login="test_user", password=SecretStr("test_pass"))
 
 
 @pytest.fixture
-def mock_zeep_client():
-    return MagicMock(spec=zeep.Client, settings=MagicMock())
+def mock_zeep_client(mocker):
+    return mocker.MagicMock(spec=zeep.Client, settings=mocker.MagicMock())
 
 
 def test_read(engine_zeep, mock_auth, mock_zeep_client, mocker):
@@ -114,7 +112,7 @@ def test_delete_empty_list(engine_zeep, mock_auth, mock_zeep_client, mocker):
 
 
 def test_get_client(engine_zeep, mocker):
-    mock_zeep_client = mocker.patch("zeep.Client", return_value=MagicMock(spec=zeep.Client))
+    mock_zeep_client = mocker.patch("zeep.Client", return_value=mocker.MagicMock(spec=zeep.Client))
 
     client = engine_zeep._get_client("sample")
 
@@ -131,8 +129,8 @@ def test_convert_results(engine_zeep, mocker):
     mock_serialize_object = mocker.patch("bfabric.engine.engine_zeep.serialize_object")
     mock_clean_result = mocker.patch("bfabric.engine.engine_zeep.clean_result")
 
-    mock_response = MagicMock()
-    mock_response.sample = [MagicMock(), MagicMock()]
+    mock_response = mocker.MagicMock()
+    mock_response.sample = [mocker.MagicMock(), mocker.MagicMock()]
     mock_response.__getitem__.side_effect = {
         "sample": mock_response.sample,
         "numberofpages": 2,
@@ -150,8 +148,8 @@ def test_convert_results(engine_zeep, mocker):
     assert mock_clean_result.call_count == 2
 
 
-def test_convert_results_no_results(engine_zeep):
-    mock_response = MagicMock()
+def test_convert_results_no_results(engine_zeep, mocker):
+    mock_response = mocker.MagicMock()
     mock_response.__getitem__.side_effect = {"numberofpages": 0}.__getitem__
     del mock_response.sample
 

--- a/tests/bfabric/oauth/test_device_code.py
+++ b/tests/bfabric/oauth/test_device_code.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.device_code import (
     _poll_for_token,
     _request_device_code,
@@ -315,7 +316,7 @@ class TestDeviceCodeLogin:
         mock_request.assert_called_once_with(
             "https://example.com/bfabric",
             client_id="bfabric-cli",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
         )
         assert mock_poll.call_args[0][0] == "https://example.com/bfabric"
 

--- a/tests/bfabric/oauth/test_registration.py
+++ b/tests/bfabric/oauth/test_registration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.registration import register_client, register_webapp
 
 
@@ -35,8 +36,8 @@ class TestRegisterClient:
             json={
                 "client_name": "my-app",
                 "redirect_uris": ["http://localhost:8050/callback"],
-                "grant_types": [_TOKEN_EXCHANGE, "refresh_token"],
-                "scope": "api:read api:write",
+                "grant_types": [_TOKEN_EXCHANGE, "refresh_token", "authorization_code"],
+                "scope": DEFAULT_OAUTH_SCOPE,
             },
             headers={"Authorization": "Bearer bearer-token"},
             timeout=30,
@@ -55,7 +56,12 @@ class TestRegisterClient:
 
         call_body = mock_httpx_post.call_args[1]["json"]
         assert call_body["service_user_login"] == "gfeeder"
-        assert call_body["grant_types"] == [_TOKEN_EXCHANGE, "refresh_token", "client_credentials"]
+        assert call_body["grant_types"] == [
+            _TOKEN_EXCHANGE,
+            "refresh_token",
+            "authorization_code",
+            "client_credentials",
+        ]
 
     def test_without_service_user_no_client_credentials_grant(self, mock_httpx_post):
         register_client(
@@ -66,7 +72,7 @@ class TestRegisterClient:
         )
 
         call_body = mock_httpx_post.call_args[1]["json"]
-        assert call_body["grant_types"] == [_TOKEN_EXCHANGE, "refresh_token"]
+        assert call_body["grant_types"] == [_TOKEN_EXCHANGE, "refresh_token", "authorization_code"]
         assert "service_user_login" not in call_body
 
     def test_with_scope(self, mock_httpx_post):
@@ -103,7 +109,7 @@ class TestRegisterClient:
 
         call_body = mock_httpx_post.call_args[1]["json"]
         assert "service_user_login" not in call_body
-        assert call_body["scope"] == "api:read api:write"
+        assert call_body["scope"] == DEFAULT_OAUTH_SCOPE
 
     def test_normalizes_trailing_slash(self, mock_httpx_post):
         register_client(
@@ -170,7 +176,7 @@ class TestRegisterWebapp:
             client_name="My Webapp",
             redirect_uri="https://myapp.example.com/",
             service_user=None,
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
         )
         mock_client.save.assert_called_once_with(
             "application",

--- a/tests/bfabric/oauth/test_webapp_client.py
+++ b/tests/bfabric/oauth/test_webapp_client.py
@@ -4,6 +4,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.url_token import UrlTokenContext
 from bfabric._oauth.webapp_client import WebappClient
 
@@ -160,7 +161,7 @@ class TestWebappClientCreate:
             client_secret="csecret",
         )
 
-        assert mock_connect_oauth.call_args.kwargs["scope"] == "api:read api:write"
+        assert mock_connect_oauth.call_args.kwargs["scope"] == DEFAULT_OAUTH_SCOPE
 
 
 class TestWebappClientFrozen:

--- a/tests/bfabric/test_bfabric.py
+++ b/tests/bfabric/test_bfabric.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import SecretStr
 
 from bfabric import Bfabric, BfabricAPIEngineType, BfabricClientConfig, BfabricAuth
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
 from bfabric.config.config_data import ConfigData
@@ -438,7 +439,7 @@ class TestConnectOAuth:
             client_id="my-id",
             client_secret="my-secret",
             token_url="https://example.com/bfabric/rest/oauth/token",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             grant_type="client_credentials",
             token_cache_path=None,
         )
@@ -538,7 +539,7 @@ class TestConnectPkce:
         mock_pkce_login.assert_called_once_with(
             "https://example.com/bfabric",
             client_id="bfabric-cli",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             port=0,
             open_browser=True,
             timeout=120.0,
@@ -549,7 +550,7 @@ class TestConnectPkce:
             token_url="https://example.com/bfabric/rest/oauth/token",
             token=mock_pkce_login.return_value,
             grant_type="refresh_token",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             token_cache_path=None,
         )
         assert client._credential_provider == mock_provider_cls.return_value
@@ -619,7 +620,7 @@ class TestConnectDeviceCode:
         mock_device_code_login.assert_called_once_with(
             "https://example.com/bfabric",
             client_id="bfabric-cli",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             timeout=600.0,
         )
         mock_provider_cls.assert_called_once_with(
@@ -628,7 +629,7 @@ class TestConnectDeviceCode:
             token_url="https://example.com/bfabric/rest/oauth/token",
             token=mock_device_code_login.return_value,
             grant_type="refresh_token",
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             token_cache_path=None,
         )
         assert client._credential_provider == mock_provider_cls.return_value

--- a/tests/bfabric/test_bfabric.py
+++ b/tests/bfabric/test_bfabric.py
@@ -401,7 +401,9 @@ def test_upload_resource(bfabric_instance, mocker):
 def test_get_version_message(mock_config, bfabric_instance):
     mock_config.base_url = "dummy_url"
     line1, line2 = bfabric_instance._get_version_message()
-    pattern = r"bfabricPy v\d+\.\d+\.\d+ \(EngineSUDS, dummy_url, U=None, PY=\d\.\d+\.\d+\)"
+    # version allows PEP 440 pre/post/dev suffixes (e.g. 1.20.0rc1), not just X.Y.Z
+    version_re = r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?"
+    pattern = rf"bfabricPy v{version_re} \(EngineSUDS, dummy_url, U=None, PY=\d\.\d+\.\d+\)"
     assert re.match(pattern, line1)
     year = datetime.datetime.now().year
     assert line2 == f"Copyright (C) 2014-{year} Functional Genomics Center Zurich"

--- a/tests/bfabric_app_runner/actions/test_config_file.py
+++ b/tests/bfabric_app_runner/actions/test_config_file.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import MagicMock
 
 from bfabric_app_runner.actions.config_file import ActionConfig, FromConfigFile
 
@@ -31,7 +30,7 @@ class TestFromConfigFile:
         mocker.patch("yaml.safe_load", return_value=expected_yaml_data)
 
         # Mock ActionConfig.model_validate
-        mock_action_config = MagicMock()
+        mock_action_config = mocker.MagicMock()
         # Set up __iter__ to return key-value pairs
         mock_action_config.__iter__.return_value = [
             ("work_dir", Path("/test/work/dir")),

--- a/tests/bfabric_app_runner/bfabric_integration/submitter/config/test_slurm_params.py
+++ b/tests/bfabric_app_runner/bfabric_integration/submitter/config/test_slurm_params.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 
@@ -42,10 +41,10 @@ def test_slurm_config_template_evaluation(slurm_config_file_template, variables_
     assert config_file.job_script == Path("~/test/job-42").expanduser()
 
 
-def test_slurm_parameters_creation():
+def test_slurm_parameters_creation(mocker):
     """Test SlurmParameters creation and sbatch_params merging."""
     # Mock workunit params
-    mock_workunit_params = Mock(spec=SlurmWorkunitParams)
+    mock_workunit_params = mocker.Mock(spec=SlurmWorkunitParams)
     mock_workunit_params.as_dict.return_value = {"--time": "01:00:00", "--mem": "4G"}
 
     # Create SlurmParameters

--- a/tests/bfabric_app_runner/commands/test_command_python_env.py
+++ b/tests/bfabric_app_runner/commands/test_command_python_env.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -136,7 +135,7 @@ class TestPythonEnvironment:
     def test_log_packages(self, temp_env_path, sample_command, mock_uv, mocker):
         """Test that log_packages runs pip list command."""
         mock_subprocess = mocker.patch("bfabric_app_runner.commands.command_python_env.subprocess.run")
-        mock_subprocess.return_value = MagicMock(stdout="package1==1.0\npackage2==2.0\n")
+        mock_subprocess.return_value = mocker.MagicMock(stdout="package1==1.0\npackage2==2.0\n")
 
         env = PythonEnvironment(temp_env_path, sample_command)
         env.log_packages()
@@ -247,10 +246,10 @@ class TestCachedEnvironmentStrategy:
         command = CommandPythonEnv(pylock=Path("/test/req.txt"), command="script.py", python_version="3.13")
 
         # Mock different mtimes
-        mocker.patch("pathlib.Path.stat", return_value=MagicMock(st_mtime=1000))
+        mocker.patch("pathlib.Path.stat", return_value=mocker.MagicMock(st_mtime=1000))
         hash1 = strategy._compute_env_hash(command)
 
-        mocker.patch("pathlib.Path.stat", return_value=MagicMock(st_mtime=2000))
+        mocker.patch("pathlib.Path.stat", return_value=mocker.MagicMock(st_mtime=2000))
         hash2 = strategy._compute_env_hash(command)
 
         assert hash1 != hash2

--- a/tests/bfabric_app_runner/output_registration/test_save_link.py
+++ b/tests/bfabric_app_runner/output_registration/test_save_link.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 from bfabric.results.result_container import ResultContainer
@@ -8,13 +6,13 @@ from bfabric_app_runner.specs.outputs_spec import SaveLinkSpec
 
 
 @pytest.fixture()
-def mock_client():
-    return MagicMock()
+def mock_client(mocker):
+    return mocker.MagicMock()
 
 
 @pytest.fixture()
-def mock_workunit_definition():
-    mock = MagicMock()
+def mock_workunit_definition(mocker):
+    mock = mocker.MagicMock()
     mock.registration.workunit_id = 42
     return mock
 

--- a/tests/bfabric_scripts/cli/login/test_cmd_login_register.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_login_register.py
@@ -5,6 +5,7 @@ import time
 import pytest
 import yaml
 
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric_scripts.cli.login.register import cmd_login_register
 
 
@@ -106,7 +107,7 @@ class TestCmdLoginRegister:
             client_name="My App",
             redirect_uri="http://localhost/callback",
             service_user=None,
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             grant_types=None,
         )
         output = capsys.readouterr()
@@ -153,7 +154,7 @@ class TestCmdLoginRegister:
             client_name="My App",
             redirect_uri="http://localhost/callback",
             service_user=None,
-            scope="api:read api:write",
+            scope=DEFAULT_OAUTH_SCOPE,
             grant_types=None,
         )
 

--- a/tests/bfabric_scripts/test_api_parser.py
+++ b/tests/bfabric_scripts/test_api_parser.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 from pytest_mock import MockerFixture
-from unittest.mock import MagicMock
 
 from bfabric_scripts.cli.api.parser import (
     FieldModel,
@@ -101,15 +100,15 @@ class TestParameterModel:
 class TestParseFieldRecursive:
     """Tests for _parse_field_recursive function."""
 
-    def test_parse_simple_field(self) -> None:
+    def test_parse_simple_field(self, mocker: MockerFixture) -> None:
         """Test parsing a simple field without children."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "simple_field"
         field_mock.type = "string"
         field_mock.required.return_value = False
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=0, max_depth=5)
 
@@ -119,15 +118,15 @@ class TestParseFieldRecursive:
         assert result.multi_occurrence is False
         assert result.children == []
 
-    def test_parse_required_field(self) -> None:
+    def test_parse_required_field(self, mocker: MockerFixture) -> None:
         """Test parsing a field marked as required."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "required_field"
         field_mock.type = "int"
         field_mock.required.return_value = True
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=0, max_depth=5)
 
@@ -135,15 +134,15 @@ class TestParseFieldRecursive:
         assert result.required is True
         assert result.multi_occurrence is False
 
-    def test_parse_field_max_depth_exceeded(self) -> None:
+    def test_parse_field_max_depth_exceeded(self, mocker: MockerFixture) -> None:
         """Test that recursion stops at max_depth."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "field"
         field_mock.type = "string"
         field_mock.required.return_value = False
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         # At max depth, should not recurse even if type exists
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=5, max_depth=5)
@@ -151,15 +150,15 @@ class TestParseFieldRecursive:
         assert result.name == "field"
         assert result.children == []
 
-    def test_parse_field_skips_builtin_types(self) -> None:
+    def test_parse_field_skips_builtin_types(self, mocker: MockerFixture) -> None:
         """Test that built-in XML Schema types are skipped."""
-        field_mock = MagicMock()
+        field_mock = mocker.MagicMock()
         field_mock.name = "xml_field"
         field_mock.type = ("string", "http://www.w3.org/2001/XMLSchema")
         field_mock.required.return_value = False
         field_mock.multi_occurrence.return_value = False
 
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
         result = _parse_field_recursive(field_mock, schema_mock, current_depth=0, max_depth=5)
 
@@ -169,32 +168,32 @@ class TestParseFieldRecursive:
     def test_parse_field_with_nested_type(self, mocker: MockerFixture) -> None:
         """Test parsing a field with nested custom type."""
         # Create nested field
-        nested_field_mock = MagicMock()
+        nested_field_mock = mocker.MagicMock()
         nested_field_mock.name = "nested_field"
         nested_field_mock.type = "simple_type"
         nested_field_mock.required.return_value = False
         nested_field_mock.multi_occurrence.return_value = False
 
         # Create parent field with custom type
-        parent_field_mock = MagicMock()
+        parent_field_mock = mocker.MagicMock()
         parent_field_mock.name = "parent_field"
         parent_field_mock.type = ("CustomType", "http://example.com/schema")
         parent_field_mock.required.return_value = False
         parent_field_mock.multi_occurrence.return_value = False
 
         # Mock schema and type resolution
-        schema_mock = MagicMock()
+        schema_mock = mocker.MagicMock()
 
-        resolved_type_mock = MagicMock()
+        resolved_type_mock = mocker.MagicMock()
         resolved_type_mock.children.return_value = [(nested_field_mock, None)]
 
-        type_def_mock = MagicMock()
+        type_def_mock = mocker.MagicMock()
         type_def_mock.resolve.return_value = resolved_type_mock
 
         # Mock TypeQuery
         mocker.patch(
             "bfabric_scripts.cli.api.parser.TypeQuery",
-            return_value=MagicMock(execute=MagicMock(return_value=type_def_mock)),
+            return_value=mocker.MagicMock(execute=mocker.MagicMock(return_value=type_def_mock)),
         )
 
         result = _parse_field_recursive(parent_field_mock, schema_mock, current_depth=0, max_depth=5)
@@ -210,39 +209,39 @@ class TestParseMethodSignature:
     def test_parse_method_signature_basic(self, mocker: MockerFixture) -> None:
         """Test basic method signature parsing."""
         # Mock parameter field
-        param_field_mock = MagicMock()
+        param_field_mock = mocker.MagicMock()
         param_field_mock.name = "field1"
         param_field_mock.type = "string"
         param_field_mock.required.return_value = False
         param_field_mock.multi_occurrence.return_value = False
 
         # Mock parameter schema
-        param_schema_mock = MagicMock()
-        resolved_param_mock = MagicMock()
+        param_schema_mock = mocker.MagicMock()
+        resolved_param_mock = mocker.MagicMock()
         resolved_param_mock.name = "ParamType"
         resolved_param_mock.required.return_value = True
         resolved_param_mock.children.return_value = [(param_field_mock, None)]
         param_schema_mock.resolve.return_value = resolved_param_mock
 
         # Mock method binding
-        binding_mock = MagicMock()
+        binding_mock = mocker.MagicMock()
         binding_mock.param_defs.return_value = [("testParam", param_schema_mock)]
 
         # Mock method
-        method_mock = MagicMock()
+        method_mock = mocker.MagicMock()
         method_mock.method.binding.input = binding_mock
-        method_mock.method.binding.input.wsdl.schema = MagicMock()
+        method_mock.method.binding.input.wsdl.schema = mocker.MagicMock()
 
         # Mock service
-        service_mock = MagicMock()
-        service_mock.testMethod = MagicMock(method=method_mock.method)
+        service_mock = mocker.MagicMock()
+        service_mock.testMethod = mocker.MagicMock(method=method_mock.method)
         mocker.patch.object(service_mock, "testMethod", method_mock)
 
         # Mock client
-        client_mock = MagicMock()
+        client_mock = mocker.MagicMock()
         client_mock._engine._get_suds_service.return_value = service_mock
         mocker.patch.object(service_mock, "testMethod", method_mock)
-        client_mock._engine._get_suds_service.return_value = MagicMock(testMethod=method_mock)
+        client_mock._engine._get_suds_service.return_value = mocker.MagicMock(testMethod=method_mock)
 
         # Call function
         result = parse_method_signature(client_mock, "test_endpoint", "testMethod")
@@ -257,18 +256,18 @@ class TestParseMethodSignature:
     def test_parse_method_signature_empty_parameters(self, mocker: MockerFixture) -> None:
         """Test parsing a method with no parameters."""
         # Mock method with no parameters
-        binding_mock = MagicMock()
+        binding_mock = mocker.MagicMock()
         binding_mock.param_defs.return_value = []
 
-        method_mock = MagicMock()
+        method_mock = mocker.MagicMock()
         method_mock.method.binding.input = binding_mock
-        method_mock.method.binding.input.wsdl.schema = MagicMock()
+        method_mock.method.binding.input.wsdl.schema = mocker.MagicMock()
 
         # Mock service and client
-        service_mock = MagicMock()
+        service_mock = mocker.MagicMock()
         service_mock.testMethod = method_mock
 
-        client_mock = MagicMock()
+        client_mock = mocker.MagicMock()
         client_mock._engine._get_suds_service.return_value = service_mock
 
         # Call function


### PR DESCRIPTION
## Summary

Prerelease (release-candidate) versions so the OAuth/OIDC work (#521) can be tested on PyPI ahead of a full release. `pip`/`uv` exclude prereleases by default, so normal installs of `bfabric` / `bfabric_scripts` stay on the current stable versions — only an explicit `==…rc1` (or `--pre`) install picks these up.

- `bfabric`: 1.19.0 → **1.20.0rc1**
- `bfabric_scripts`: 1.15.0 → **1.16.0rc1**
- Each changelog's `[Unreleased]` section is promoted to a dated rc heading so the release pipeline extracts proper notes. These get promoted again to the final `[1.20.0]` / `[1.16.0]` entries when the rc graduates.
- `bfabric_scripts` versioning-convention note updated to independent semver (`Y` = feature releases; no longer "the current bfabric release"), matching the choice of `1.16.0rc1` over a bfabric-synced number.

> [!IMPORTANT]
> **Merging this PR publishes both release candidates to production PyPI.** `bfabric_app_runner` (0.6.1) is already on PyPI, so version auto-detection skips it — only these two are released. Merging also pushes tags `bfabric/1.20.0rc1` + `bfabric_scripts/1.16.0rc1` and creates draft GitHub releases.

Install for testing (both pinned, otherwise scripts-rc resolves against stable `bfabric`):

```
pip install "bfabric==1.20.0rc1" "bfabric_scripts==1.16.0rc1"
```
