### PR TITLE
feat(bfabric): OAuth webapp launch-token primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,16 @@ cd bfabric/docs && make html           # local preview
 - **`results/`** — `ResultContainer` wraps API responses with pagination, error handling, and `to_polars()` conversion.
 - **`utils/cli_integration.py`** — `@use_client` decorator for CLI commands: auto-creates `Bfabric` client, injects config_env/config_file parameters.
 
+### Authentication & OAuth (`bfabric/src/bfabric/_oauth/`)
+
+Auth is the easiest place to reinvent something that already exists — **before adding any new auth/token entry point, check the existing ones in `_oauth/` and the design doc below.** The entry points (one-liners; see the design doc for detail):
+
+- **Password / web-service token** (legacy): `BfabricAuth`; `connect_token()` / `connect_token_async()` (validate a B-Fabric URL token); `from_token_data()`.
+- **OAuth 2.0**: `connect_oauth` (service accounts / client-credentials), `connect_pkce` & `connect_device_code` (interactive login), `connect_pat` (opaque bearer); tokens managed by `OAuthCredentialProvider` (transparent refresh + disk cache).
+- **Webapp launch-token flow: `WebappClient.create()` (`_oauth/webapp_client.py`) is the entry point** — it does the RFC 8693 launch-JWT exchange + local JWT decode into `user`/`service` clients plus `UrlTokenContext`. Reuse or extend it; do **not** re-implement the token exchange or `verify_jwt` decode.
+
+Design & rationale: `bfabric/docs/design/oauth_integration.md`. Note that `bfabric_asgi_auth/docs/design/oauth_simplification_and_migration.md` is a **migration plan/sketch, not current state** — verify it against the code before building on it.
+
 ### CLI (`bfabric_scripts/src/bfabric_scripts/cli/`)
 
 Modern CLI built with **cyclopts**: `bfabric-cli api|dataset|executable|workunit|feeder|external-job`. Legacy scripts (`bfabric_read.py`, etc.) are preserved as entry points.
@@ -92,6 +102,10 @@ Each package's docs live alongside its source. Skim the index when working in a 
 - `bfabric_scripts/docs/changelog.md` — scripts (changelog only; no full docs site)
 - `bfabric_rest_proxy/README.md`, `bfabric_rest_proxy/docs/changelog.md` — REST proxy
 - `bfabric_asgi_auth/README.md`, `bfabric_asgi_auth/docs/changelog.md` — ASGI auth middleware
+
+**Doc types & source of truth.** The human-readable docs above are the source of truth for design and behavior — AGENTS.md only points to them and holds agent-facing conventions, so keep design content there, not duplicated here (duplicates drift). Docs under `*/docs/design/` named for *proposed* or *migration* work describe intended changes, **not** current behavior; verify them against the code before building on them.
+
+**If the docs misled you, fix them.** When you discover an existing capability you nearly duplicated, or a doc statement that contradicts the code (e.g. a documented method that no longer exists), treat it as a doc bug: before finishing, correct that specific doc and any pointer to it here. That is how the map stays trustworthy for the next agent.
 
 ## Key Conventions
 

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,15 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+### Added
+
+- Core OAuth primitives for webapp launch-token integrations (foundation for `bfabric_asgi_auth` and other webapp adapters):
+    - `Bfabric.connect_oauth_token` — build a client from an already-exchanged OAuth token via the refresh-token grant (shared builder for webapp integrations and the interactive flows), with an optional `on_token_refresh` callback invoked after each token refresh.
+    - `bfabric.experimental.webapp_oauth.exchange_launch_token` — exchange a short-lived B-Fabric launch JWT for a long-lived access+refresh token pair (RFC 8693) and decode the verified entity context.
+    - `bfabric.experimental.webapp_oauth_settings` — `OAuthClientCredentials` and `WebappOAuthSettings` configuration models for OAuth webapp deployments.
+    - `OAuthCredentialProvider` accepts an optional `on_token_update` callback (per-process; deliberately not preserved across pickle).
+    - `bfabric._oauth.url_token.verify_jwt` accepts optional `audience`/`issuer` arguments to validate the `aud`/`iss` claims (defaults preserve the previous behavior of not validating them).
+
 ## \[1.20.0rc1\] - 2026-06-23
 
 ### Added

--- a/bfabric/docs/design/oauth_integration.md
+++ b/bfabric/docs/design/oauth_integration.md
@@ -1,5 +1,8 @@
 # OAuth Integration
 
+> This is a **design / rationale overview**. For exact, current signatures, defer to the API reference
+> and the code in `bfabric/src/bfabric/_oauth/` — method names here may lag the code.
+
 ## Overview
 
 Adds OAuth 2.0 support to bfabricPy. The library can now authenticate via PKCE, device code, client credentials, URL tokens, and personal access tokens — in addition to the existing password-based SOAP auth. All OAuth flows are transparent to downstream code: the SOAP engine receives `BfabricAuth(login="__oauth__", password=<jwt>)` automatically.
@@ -18,7 +21,7 @@ Private module under `bfabric/src/bfabric/_oauth/` implementing all OAuth primit
 | `device_code.py` | `device_code_login()` — RFC 8628 device authorization flow for headless environments. |
 | `registration.py` | `register_client()` — RFC 7591 dynamic client registration via HTTP POST. |
 | `token_cache.py` | `TokenCache` — JSON file cache at `~/.bfabric/tokens/{hash}.json` with 0o600 permissions. `compute_token_cache_path()` derives a unique path from `(base_url, client_id, env_name)`. |
-| `url_token.py` | `UrlTokenContext` + `parse_url_token()` — extracts entity context (entity_id, application_id, etc.) from B-Fabric URL token JWTs. |
+| `url_token.py` | `UrlTokenContext` + `verify_jwt()` — verifies a B-Fabric JWT against the server JWKS and extracts entity context (entity_id, application_id, etc.). |
 | `webapp_client.py` | `WebappClient` — dual-identity client bundling a `user` (from URL token) and `service` (from client credentials) `Bfabric` instance. |
 
 ---
@@ -31,7 +34,7 @@ Private module under `bfabric/src/bfabric/_oauth/` implementing all OAuth primit
 | `Bfabric.connect_oauth(client_id, client_secret, base_url)` | client_credentials | Service accounts / background jobs. |
 | `Bfabric.connect_pkce(base_url, client_id)` | authorization_code + PKCE | Interactive browser login (programmatic). |
 | `Bfabric.connect_device_code(base_url, client_id)` | device_code | Headless interactive login (programmatic). |
-| `Bfabric.from_url_token(base_url, jwt, refresh_token)` | URL token | Webapps launched from B-Fabric. Returns `(Bfabric, UrlTokenContext)`. |
+| `Bfabric.connect_token(token, settings)` / `connect_token_async(...)` | URL token (validated) | Webapps launched from B-Fabric. Returns `(Bfabric, TokenData)`. |
 | `WebappClient.create(base_url, jwt, ..., client_id, client_secret)` | URL token + client_credentials | Dual-identity webapp client. |
 
 ---

--- a/bfabric/docs/design/oauth_integration.md
+++ b/bfabric/docs/design/oauth_integration.md
@@ -22,6 +22,7 @@ Private module under `bfabric/src/bfabric/_oauth/` implementing all OAuth primit
 | `registration.py` | `register_client()` — RFC 7591 dynamic client registration via HTTP POST. |
 | `token_cache.py` | `TokenCache` — JSON file cache at `~/.bfabric/tokens/{hash}.json` with 0o600 permissions. `compute_token_cache_path()` derives a unique path from `(base_url, client_id, env_name)`. |
 | `url_token.py` | `UrlTokenContext` + `verify_jwt()` — verifies a B-Fabric JWT against the server JWKS and extracts entity context (entity_id, application_id, etc.). |
+| `launch_token.py` | `exchange_launch_token()` — the single RFC 8693 launch-token exchange + local JWT decode to `UrlTokenContext`; shared by `WebappClient` and the public `bfabric.experimental.webapp_oauth` facade. |
 | `webapp_client.py` | `WebappClient` — dual-identity client bundling a `user` (from URL token) and `service` (from client credentials) `Bfabric` instance. |
 
 ---

--- a/bfabric/src/bfabric/_oauth/credential_provider.py
+++ b/bfabric/src/bfabric/_oauth/credential_provider.py
@@ -27,6 +27,7 @@ from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.token_cache import TokenCache
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -55,6 +56,7 @@ class OAuthCredentialProvider:
     _grant_type: str
     _leeway: int
     _token_cache_path: Path | None
+    _on_token_refresh: Callable[[dict[str, object]], None] | None
 
     def __init__(
         self,
@@ -67,6 +69,7 @@ class OAuthCredentialProvider:
         grant_type: str = "client_credentials",
         token_cache_path: Path | None = None,
         leeway: int = 30,
+        on_token_update: Callable[[dict[str, object]], None] | None = None,
     ) -> None:
         self._lock = threading.Lock()
         if grant_type == "client_credentials" and not client_secret:
@@ -81,6 +84,10 @@ class OAuthCredentialProvider:
         self._leeway = leeway
         self._token_cache_path = token_cache_path
         self._cache = TokenCache(token_cache_path) if token_cache_path else None
+        # Per-process callback fired after each token refresh/re-fetch. Deliberately omitted from
+        # __getstate__ so it is dropped on pickle (it is not picklable); fires under self._lock and
+        # must be fast / non-reentrant.
+        self._on_token_refresh = on_token_update
 
         self._session = OAuth2Session(
             client_id,
@@ -137,6 +144,10 @@ class OAuthCredentialProvider:
     def _on_token_update(self, _new_token: dict[str, object], **_kwargs: object) -> None:
         """Callback invoked by authlib after a token refresh/re-fetch."""
         self._persist()
+        if self._on_token_refresh is not None and self._session.token:  # pyright: ignore[reportUnknownMemberType]
+            self._on_token_refresh(
+                dict(self._session.token)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+            )
 
     def _persist(self) -> None:
         """Write the current token to disk cache if configured."""

--- a/bfabric/src/bfabric/_oauth/launch_token.py
+++ b/bfabric/src/bfabric/_oauth/launch_token.py
@@ -1,0 +1,42 @@
+"""Compose an RFC 8693 launch-token exchange with local JWT verification.
+
+This is the single implementation of the webapp launch-token flow: exchange the short-lived
+launch JWT for a long-lived token pair, then verify + decode the access token locally into a
+:class:`UrlTokenContext`. Both :class:`bfabric._oauth.webapp_client.WebappClient` and the public
+``bfabric.experimental.webapp_oauth`` facade build on it, so the exchange lives in exactly one place.
+"""
+
+from __future__ import annotations
+
+from bfabric._oauth.token_exchange import exchange_token
+from bfabric._oauth.url_token import UrlTokenContext, verify_jwt
+
+
+def exchange_launch_token(
+    base_url: str,
+    launch_token: str,
+    *,
+    client_id: str,
+    client_secret: str,
+) -> tuple[dict[str, object], UrlTokenContext]:
+    """Exchange a short-lived B-Fabric launch JWT for a long-lived token pair + verified context.
+
+    RFC 8693 token exchange, then verify + decode the access token JWT locally for entity context.
+
+    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
+    :param launch_token: The short-lived JWT from the launch URL
+    :param client_id: OAuth client ID for the webapp
+    :param client_secret: OAuth client secret for the webapp
+    :returns: ``(token_dict, context)`` — token_dict includes ``refresh_token``.
+    :raises httpx.HTTPStatusError: if the token-exchange request returns a non-2xx status
+        (e.g. an expired or invalid launch token)
+    :raises joserfc.errors.JoseError: on an invalid/expired access-token JWT
+    :raises KeyError: if the token response contains no ``access_token``
+    """
+    base_url = base_url.rstrip("/")
+    token_dict = exchange_token(base_url, launch_token, client_id=client_id, client_secret=client_secret)
+    # TODO(confirm aud): pass audience=client_id once the server's real aud claim is confirmed.
+    # TODO(confirm iss): pass issuer once confirmed via {base_url}/rest/oauth/.well-known/openid-configuration.
+    claims = verify_jwt(base_url, str(token_dict["access_token"]))
+    context = UrlTokenContext.model_validate(claims)
+    return token_dict, context

--- a/bfabric/src/bfabric/_oauth/url_token.py
+++ b/bfabric/src/bfabric/_oauth/url_token.py
@@ -75,19 +75,30 @@ def _fetch_jwks(base_url: str) -> dict[str, object]:
     return jwks
 
 
-def verify_jwt(base_url: str, token: str) -> dict[str, object]:
+def verify_jwt(
+    base_url: str,
+    token: str,
+    *,
+    audience: str | None = None,
+    issuer: str | None = None,
+) -> dict[str, object]:
     """Verify the JWT signature + expiry against the B-Fabric JWKS endpoint.
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param token: The raw JWT string
+    :param audience: If given, the ``aud`` claim must equal this value (default: not validated)
+    :param issuer: If given, the ``iss`` claim must equal this value (default: not validated)
     :returns: The verified claims dictionary
     :raises: ``joserfc.errors.JoseError`` subclasses on invalid/expired tokens
     """
     jwks_data = _fetch_jwks(base_url)
     key_set = KeySet.import_key_set(jwks_data)  # pyright: ignore[reportArgumentType]
     result = joserfc_jwt.decode(token, key_set)
-    claims_registry = joserfc_jwt.JWTClaimsRegistry(exp={"essential": True})
+    claims_options: dict[str, object] = {"exp": {"essential": True}}
+    if audience is not None:
+        claims_options["aud"] = {"essential": True, "value": audience}
+    if issuer is not None:
+        claims_options["iss"] = {"essential": True, "value": issuer}
+    claims_registry = joserfc_jwt.JWTClaimsRegistry(**claims_options)  # pyright: ignore[reportArgumentType]
     claims_registry.validate(result.claims)
     return dict(result.claims)
-
-

--- a/bfabric/src/bfabric/_oauth/webapp_client.py
+++ b/bfabric/src/bfabric/_oauth/webapp_client.py
@@ -54,43 +54,28 @@ class WebappClient:
         :param service_token_cache_path: Optional path to cache service tokens on disk
         """
         from bfabric.bfabric import Bfabric
-        from bfabric._oauth.credential_provider import OAuthCredentialProvider
-        from bfabric._oauth.token_exchange import exchange_token
-        from bfabric._oauth.url_token import UrlTokenContext, verify_jwt
-        from bfabric.config import BfabricClientConfig
-        from bfabric.config.config_data import ConfigData
+        from bfabric._oauth.launch_token import exchange_launch_token
 
         base_url = base_url.rstrip("/")
-        token_url = f"{base_url}/rest/oauth/token"
 
-        # 1. Exchange the short-lived launch token for access + refresh tokens
-        token_dict = exchange_token(
+        # 1. Exchange the launch token (RFC 8693) and decode the access token to entity context.
+        token_dict, context = exchange_launch_token(
             base_url,
             launch_token,
             client_id=client_id,
             client_secret=client_secret,
         )
 
-        # 2. Decode the access token JWT locally to extract entity claims
-        claims = verify_jwt(base_url, str(token_dict["access_token"]))
-        context = UrlTokenContext.model_validate(claims)
-
-        # 3. Create user client with OAuthCredentialProvider (refresh_token grant)
-        user_provider = OAuthCredentialProvider(
+        # 2. User client: refresh-token grant seeded with the exchanged token.
+        user_client = Bfabric.connect_oauth_token(
+            base_url,
+            token_dict,
             client_id=client_id,
             client_secret=client_secret,
-            token_url=token_url,
-            token=token_dict,
-            grant_type="refresh_token",
             token_cache_path=user_token_cache_path,
         )
-        config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
-        user_client = Bfabric(
-            config_data=ConfigData(client=config, auth=None),
-            _credential_provider=user_provider,
-        )
 
-        # 4. Create service client via connect_oauth (client_credentials grant)
+        # 3. Service client: client-credentials grant.
         service_client = Bfabric.connect_oauth(
             client_id=client_id,
             client_secret=client_secret,

--- a/bfabric/src/bfabric/bfabric.py
+++ b/bfabric/src/bfabric/bfabric.py
@@ -42,7 +42,7 @@ from bfabric.utils.cli_integration import DEFAULT_THEME, HostnameHighlighter
 from bfabric.utils.paginator import BFABRIC_QUERY_LIMIT, compute_requested_pages
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from pydantic import SecretStr
 
@@ -254,6 +254,51 @@ class Bfabric:
             scope=scope,
             grant_type="client_credentials",
             token_cache_path=token_cache_path,
+        )
+        config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
+        config_data = ConfigData(client=config, auth=None)
+        return cls(config_data=config_data, _credential_provider=provider)
+
+    @classmethod
+    def connect_oauth_token(
+        cls,
+        base_url: str,
+        token: dict[str, object],
+        *,
+        client_id: str,
+        client_secret: str = "",
+        scope: str = DEFAULT_OAUTH_SCOPE,
+        token_cache_path: Path | None = None,
+        on_token_refresh: Callable[[dict[str, object]], None] | None = None,
+    ) -> Bfabric:
+        """Returns a new Bfabric instance that authenticates via OAuth 2.0 refresh-token grant.
+
+        Shared builder for ``connect_pkce`` / ``connect_device_code`` / webapp integrations that
+        already hold a token from an RFC 8693 exchange. The returned client transparently refreshes
+        the access token on expiry.
+
+        :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
+        :param token: Initial token dict (must include ``refresh_token``)
+        :param client_id: OAuth client ID for the webapp
+        :param client_secret: OAuth client secret (may be empty for public clients)
+        :param scope: OAuth scope (default ``DEFAULT_OAUTH_SCOPE``)
+        :param token_cache_path: Optional path to cache tokens on disk (survives restarts)
+        :param on_token_refresh: Callback invoked with the full new token dict after each refresh;
+            fires under the provider lock (fast / non-reentrant); NOT preserved across pickle.
+        """
+        from bfabric._oauth.credential_provider import OAuthCredentialProvider
+
+        base_url = base_url.rstrip("/")
+        token_url = f"{base_url}/rest/oauth/token"
+        provider = OAuthCredentialProvider(
+            client_id=client_id,
+            client_secret=client_secret,
+            token_url=token_url,
+            token=token,
+            grant_type="refresh_token",
+            scope=scope,
+            token_cache_path=token_cache_path,
+            on_token_update=on_token_refresh,
         )
         config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
         config_data = ConfigData(client=config, auth=None)

--- a/bfabric/src/bfabric/experimental/webapp_oauth.py
+++ b/bfabric/src/bfabric/experimental/webapp_oauth.py
@@ -2,41 +2,17 @@
 
 Stable (within ``experimental``) entry point for OAuth operations needed by webapp integrations.
 Sibling packages (e.g. ``bfabric_asgi_auth``) import from here instead of ``bfabric._oauth.*``.
-``WebappClient`` is intentionally not re-exported here (module-level import cycle); import it from
-``bfabric._oauth.webapp_client`` directly.
+
+The launch-token exchange itself lives in ``bfabric._oauth.launch_token`` (the single
+implementation, shared with :class:`bfabric._oauth.webapp_client.WebappClient`); this module just
+re-exports it as the public surface. ``WebappClient`` is intentionally not re-exported here
+(module-level import cycle); import it from ``bfabric._oauth.webapp_client`` directly.
 """
 
 from __future__ import annotations
 
 from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
-from bfabric._oauth.token_exchange import exchange_token
-from bfabric._oauth.url_token import UrlTokenContext, verify_jwt
+from bfabric._oauth.launch_token import exchange_launch_token
+from bfabric._oauth.url_token import UrlTokenContext
 
 __all__ = ["DEFAULT_OAUTH_SCOPE", "UrlTokenContext", "exchange_launch_token"]
-
-
-def exchange_launch_token(
-    base_url: str,
-    launch_token: str,
-    *,
-    client_id: str,
-    client_secret: str,
-) -> tuple[dict[str, object], UrlTokenContext]:
-    """Exchange a short-lived B-Fabric launch JWT for a long-lived token pair.
-
-    RFC 8693 token exchange, then verify + decode the access token JWT locally for entity context.
-
-    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-    :param launch_token: The short-lived JWT from the launch URL
-    :param client_id: OAuth client ID for the webapp
-    :param client_secret: OAuth client secret for the webapp
-    :returns: ``(token_dict, context)`` — token_dict includes ``refresh_token``.
-    :raises joserfc.errors.JoseError: on invalid/expired access token JWT
-    """
-    base_url = base_url.rstrip("/")
-    token_dict = exchange_token(base_url, launch_token, client_id=client_id, client_secret=client_secret)
-    claims = verify_jwt(base_url, str(token_dict["access_token"]))
-    # TODO(confirm aud): pass audience=client_id once the server's real aud claim is confirmed.
-    # TODO(confirm iss): pass issuer once confirmed via {base_url}/rest/oauth/.well-known/openid-configuration.
-    context = UrlTokenContext.model_validate(claims)
-    return token_dict, context

--- a/bfabric/src/bfabric/experimental/webapp_oauth.py
+++ b/bfabric/src/bfabric/experimental/webapp_oauth.py
@@ -1,0 +1,42 @@
+"""Public primitives for webapp OAuth 2.0 flows.
+
+Stable (within ``experimental``) entry point for OAuth operations needed by webapp integrations.
+Sibling packages (e.g. ``bfabric_asgi_auth``) import from here instead of ``bfabric._oauth.*``.
+``WebappClient`` is intentionally not re-exported here (module-level import cycle); import it from
+``bfabric._oauth.webapp_client`` directly.
+"""
+
+from __future__ import annotations
+
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
+from bfabric._oauth.token_exchange import exchange_token
+from bfabric._oauth.url_token import UrlTokenContext, verify_jwt
+
+__all__ = ["DEFAULT_OAUTH_SCOPE", "UrlTokenContext", "exchange_launch_token"]
+
+
+def exchange_launch_token(
+    base_url: str,
+    launch_token: str,
+    *,
+    client_id: str,
+    client_secret: str,
+) -> tuple[dict[str, object], UrlTokenContext]:
+    """Exchange a short-lived B-Fabric launch JWT for a long-lived token pair.
+
+    RFC 8693 token exchange, then verify + decode the access token JWT locally for entity context.
+
+    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
+    :param launch_token: The short-lived JWT from the launch URL
+    :param client_id: OAuth client ID for the webapp
+    :param client_secret: OAuth client secret for the webapp
+    :returns: ``(token_dict, context)`` — token_dict includes ``refresh_token``.
+    :raises joserfc.errors.JoseError: on invalid/expired access token JWT
+    """
+    base_url = base_url.rstrip("/")
+    token_dict = exchange_token(base_url, launch_token, client_id=client_id, client_secret=client_secret)
+    claims = verify_jwt(base_url, str(token_dict["access_token"]))
+    # TODO(confirm aud): pass audience=client_id once the server's real aud claim is confirmed.
+    # TODO(confirm iss): pass issuer once confirmed via {base_url}/rest/oauth/.well-known/openid-configuration.
+    context = UrlTokenContext.model_validate(claims)
+    return token_dict, context

--- a/bfabric/src/bfabric/experimental/webapp_oauth_settings.py
+++ b/bfabric/src/bfabric/experimental/webapp_oauth_settings.py
@@ -1,0 +1,22 @@
+"""Configuration models for webapp OAuth 2.0 integrations."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, SecretStr
+
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
+
+
+class OAuthClientCredentials(BaseModel):
+    """OAuth client credentials for a registered webapp."""
+
+    client_id: str
+    client_secret: SecretStr
+    scope: str = DEFAULT_OAUTH_SCOPE
+
+
+class WebappOAuthSettings(BaseModel):
+    """Full OAuth settings for a B-Fabric webapp integration."""
+
+    base_url: str
+    credentials: OAuthClientCredentials

--- a/tests/bfabric/experimental/test_webapp_oauth.py
+++ b/tests/bfabric/experimental/test_webapp_oauth.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from bfabric._oauth.url_token import UrlTokenContext
+from bfabric.experimental.webapp_oauth import exchange_launch_token
+
+
+def test_exchange_launch_token(mocker):
+    token_dict = {"access_token": "at-jwt", "refresh_token": "rt"}
+    mock_exchange = mocker.patch("bfabric.experimental.webapp_oauth.exchange_token", return_value=token_dict)
+    claims = {"sub": "jdoe", "entityId": 5, "entityClassName": "Workunit", "applicationId": 9}
+    mock_verify = mocker.patch("bfabric.experimental.webapp_oauth.verify_jwt", return_value=claims)
+
+    result_token, context = exchange_launch_token(
+        "https://example.com/bfabric/",
+        "launch.jwt",
+        client_id="cid",
+        client_secret="secret",
+    )
+
+    # base_url is normalized (trailing slash stripped) before both calls.
+    mock_exchange.assert_called_once_with(
+        "https://example.com/bfabric", "launch.jwt", client_id="cid", client_secret="secret"
+    )
+    mock_verify.assert_called_once_with("https://example.com/bfabric", "at-jwt")
+    assert result_token == token_dict
+    assert isinstance(context, UrlTokenContext)
+    assert context.subject == "jdoe"
+    assert context.entity_id == 5
+    assert context.entity_class_name == "Workunit"
+    assert context.application_id == 9

--- a/tests/bfabric/experimental/test_webapp_oauth.py
+++ b/tests/bfabric/experimental/test_webapp_oauth.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from bfabric._oauth.url_token import UrlTokenContext
+
+# Imported via the public facade to confirm the re-export works; the implementation lives in
+# bfabric._oauth.launch_token, so the exchange_token/verify_jwt patches target that module.
 from bfabric.experimental.webapp_oauth import exchange_launch_token
 
 
 def test_exchange_launch_token(mocker):
     token_dict = {"access_token": "at-jwt", "refresh_token": "rt"}
-    mock_exchange = mocker.patch("bfabric.experimental.webapp_oauth.exchange_token", return_value=token_dict)
+    mock_exchange = mocker.patch("bfabric._oauth.launch_token.exchange_token", return_value=token_dict)
     claims = {"sub": "jdoe", "entityId": 5, "entityClassName": "Workunit", "applicationId": 9}
-    mock_verify = mocker.patch("bfabric.experimental.webapp_oauth.verify_jwt", return_value=claims)
+    mock_verify = mocker.patch("bfabric._oauth.launch_token.verify_jwt", return_value=claims)
 
     result_token, context = exchange_launch_token(
         "https://example.com/bfabric/",

--- a/tests/bfabric/experimental/test_webapp_oauth_settings.py
+++ b/tests/bfabric/experimental/test_webapp_oauth_settings.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pydantic import SecretStr
+
+from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
+from bfabric.experimental.webapp_oauth_settings import OAuthClientCredentials, WebappOAuthSettings
+
+
+def test_oauth_client_credentials_defaults():
+    creds = OAuthClientCredentials(client_id="cid", client_secret="shh")  # pyright: ignore[reportArgumentType]
+    assert isinstance(creds.client_secret, SecretStr)
+    assert creds.client_secret.get_secret_value() == "shh"
+    assert creds.scope == DEFAULT_OAUTH_SCOPE
+
+
+def test_webapp_oauth_settings():
+    settings = WebappOAuthSettings(
+        base_url="https://example.com/bfabric",
+        credentials=OAuthClientCredentials(
+            client_id="cid",
+            client_secret="shh",  # pyright: ignore[reportArgumentType]
+            scope="api:read",
+        ),
+    )
+    assert settings.base_url == "https://example.com/bfabric"
+    assert settings.credentials.client_id == "cid"
+    assert settings.credentials.scope == "api:read"

--- a/tests/bfabric/oauth/test_credential_provider.py
+++ b/tests/bfabric/oauth/test_credential_provider.py
@@ -149,6 +149,59 @@ class TestRefreshToken:
         assert call_kwargs[1]["grant_type"] == "refresh_token"
 
 
+class TestRefreshCallback:
+    def test_callback_fires_with_new_token(self, mock_oauth2_session, mocker):
+        """The user-supplied on_token_update callback fires with the current token after a refresh."""
+        callback = mocker.MagicMock()
+        provider = OAuthCredentialProvider(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://example.com/rest/oauth/token",
+            on_token_update=callback,
+        )
+        new_token = {"access_token": "refreshed", "expires_at": time.time() + 3600}
+        mock_oauth2_session.token = new_token
+
+        # Simulate authlib invoking the update_token callback after a refresh.
+        provider._on_token_update(new_token)
+
+        callback.assert_called_once_with(new_token)
+
+    def test_callback_not_fired_without_token(self, mock_oauth2_session, mocker):
+        callback = mocker.MagicMock()
+        provider = OAuthCredentialProvider(
+            client_id="id",
+            client_secret="secret",
+            token_url="https://example.com/rest/oauth/token",
+            on_token_update=callback,
+        )
+        mock_oauth2_session.token = None
+
+        provider._on_token_update({})
+
+        callback.assert_not_called()
+
+    def test_callback_dropped_on_pickle(self):
+        """The per-process callback is not picklable and is deliberately dropped on round-trip."""
+        import pickle
+
+        provider = OAuthCredentialProvider(
+            client_id="id",
+            client_secret="",
+            token_url="https://example.com/rest/oauth/token",
+            grant_type="refresh_token",
+            token={"access_token": "at", "refresh_token": "rt", "expires_at": 9999999999},
+            on_token_update=lambda _token: None,
+        )
+        assert provider._on_token_refresh is not None
+
+        restored = pickle.loads(pickle.dumps(provider))  # noqa: S301
+
+        assert restored._on_token_refresh is None
+        # The rest of the provider still round-trips.
+        assert restored.get_auth().password.get_secret_value() == "at"
+
+
 class TestDiskCache:
     def test_uses_disk_cache_on_init(self, tmp_path, mock_oauth2_session):
         import json

--- a/tests/bfabric/oauth/test_url_token.py
+++ b/tests/bfabric/oauth/test_url_token.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 
 import pytest
+from joserfc.errors import JoseError
 
 from bfabric._oauth.url_token import _jwks_cache, verify_jwt
 
@@ -75,3 +76,48 @@ class TestVerifyJwt:
     def test_normalizes_trailing_slash(self, mock_httpx_get, mock_joserfc):
         verify_jwt("https://example.com/bfabric/", "token")
         mock_httpx_get.assert_called_once_with("https://example.com/bfabric/rest/oauth/jwks", timeout=30)
+
+
+class TestVerifyJwtClaims:
+    """Tests for opt-in aud/iss validation.
+
+    These deliberately do NOT use the ``mock_joserfc`` fixture: it stubs out
+    ``JWTClaimsRegistry`` wholesale, but the aud/iss behavior lives *inside*
+    ``JWTClaimsRegistry.validate``. We mock only the JWKS fetch + ``decode`` and leave the real
+    registry so ``validate`` genuinely runs the check.
+    """
+
+    EXP = 1999999999  # far-future expiry so the real registry does not reject on expiry
+
+    @staticmethod
+    def _decode_returns(mocker, claims):
+        mocker.patch("bfabric._oauth.url_token._fetch_jwks", return_value={"keys": []})
+        mocker.patch("bfabric._oauth.url_token.KeySet")
+        result = mocker.MagicMock()
+        result.claims = claims
+        mocker.patch("bfabric._oauth.url_token.joserfc_jwt.decode", return_value=result)
+
+    def test_no_validation_by_default(self, mocker):
+        self._decode_returns(mocker, {"sub": "jdoe", "aud": "anything", "exp": self.EXP})
+        result = verify_jwt("https://example.com/bfabric", "tok")
+        assert result["sub"] == "jdoe"
+
+    def test_matching_audience_and_issuer(self, mocker):
+        self._decode_returns(mocker, {"aud": "client-x", "iss": "https://iss", "exp": self.EXP})
+        result = verify_jwt("https://example.com/bfabric", "tok", audience="client-x", issuer="https://iss")
+        assert result["aud"] == "client-x"
+
+    def test_mismatched_audience_raises(self, mocker):
+        self._decode_returns(mocker, {"aud": "other", "exp": self.EXP})
+        with pytest.raises(JoseError):
+            verify_jwt("https://example.com/bfabric", "tok", audience="client-x")
+
+    def test_missing_required_audience_raises(self, mocker):
+        self._decode_returns(mocker, {"sub": "jdoe", "exp": self.EXP})
+        with pytest.raises(JoseError):
+            verify_jwt("https://example.com/bfabric", "tok", audience="client-x")
+
+    def test_mismatched_issuer_raises(self, mocker):
+        self._decode_returns(mocker, {"iss": "https://evil", "exp": self.EXP})
+        with pytest.raises(JoseError):
+            verify_jwt("https://example.com/bfabric", "tok", issuer="https://iss")

--- a/tests/bfabric/oauth/test_webapp_client.py
+++ b/tests/bfabric/oauth/test_webapp_client.py
@@ -8,11 +8,10 @@ from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.url_token import UrlTokenContext
 from bfabric._oauth.webapp_client import WebappClient
 
-_PATCH_EXCHANGE = "bfabric._oauth.token_exchange.exchange_token"
-_PATCH_VERIFY_JWT = "bfabric._oauth.url_token.verify_jwt"
-_PATCH_PROVIDER = "bfabric._oauth.credential_provider.OAuthCredentialProvider"
+# WebappClient.create composes three building blocks; we mock those, not their internals.
+_PATCH_EXCHANGE_LAUNCH = "bfabric._oauth.launch_token.exchange_launch_token"
+_PATCH_CONNECT_OAUTH_TOKEN = "bfabric.bfabric.Bfabric.connect_oauth_token"
 _PATCH_CONNECT_OAUTH = "bfabric.bfabric.Bfabric.connect_oauth"
-_PATCH_LOG = "bfabric.bfabric.Bfabric._log_version_message"
 
 SAMPLE_CLAIMS = {
     "entityId": 123,
@@ -35,18 +34,26 @@ def mock_token_dict() -> dict[str, object]:
 
 
 @pytest.fixture
-def mock_service_client(mocker):
-    return mocker.MagicMock(name="service_client")
+def mock_context() -> UrlTokenContext:
+    return UrlTokenContext.model_validate(SAMPLE_CLAIMS)
+
+
+@pytest.fixture
+def patched(mocker, mock_token_dict, mock_context):
+    """Patch the three primitives WebappClient.create composes; return the mocks."""
+    user_client = mocker.MagicMock(name="user_client")
+    service_client = mocker.MagicMock(name="service_client")
+    return {
+        "exchange": mocker.patch(_PATCH_EXCHANGE_LAUNCH, return_value=(mock_token_dict, mock_context)),
+        "connect_oauth_token": mocker.patch(_PATCH_CONNECT_OAUTH_TOKEN, return_value=user_client),
+        "connect_oauth": mocker.patch(_PATCH_CONNECT_OAUTH, return_value=service_client),
+        "user": user_client,
+        "service": service_client,
+    }
 
 
 class TestWebappClientCreate:
-    def test_returns_correct_user_service_context(self, mocker, mock_token_dict, mock_service_client):
-        mocker.patch(_PATCH_EXCHANGE, return_value=mock_token_dict)
-        mocker.patch(_PATCH_VERIFY_JWT, return_value=dict(SAMPLE_CLAIMS))
-        mock_provider_cls = mocker.patch(_PATCH_PROVIDER)
-        mocker.patch(_PATCH_CONNECT_OAUTH, return_value=mock_service_client)
-        mocker.patch(_PATCH_LOG)
-
+    def test_returns_correct_user_service_context(self, patched, mock_context):
         wc = WebappClient.create(
             base_url="https://bfabric.example.com/bfabric",
             launch_token="short.lived.jwt",
@@ -54,18 +61,13 @@ class TestWebappClientCreate:
             client_secret="app-secret",
         )
 
-        assert wc.service is mock_service_client
+        assert wc.user is patched["user"]
+        assert wc.service is patched["service"]
+        assert wc.context is mock_context
         assert wc.context.entity_id == 123
         assert wc.context.subject == "jdoe"
-        assert wc.user._credential_provider is mock_provider_cls.return_value
 
-    def test_forwards_parameters_to_exchange_token(self, mocker, mock_token_dict):
-        mock_exchange = mocker.patch(_PATCH_EXCHANGE, return_value=mock_token_dict)
-        mocker.patch(_PATCH_VERIFY_JWT, return_value=dict(SAMPLE_CLAIMS))
-        mocker.patch(_PATCH_PROVIDER)
-        mocker.patch(_PATCH_CONNECT_OAUTH, return_value=mocker.MagicMock())
-        mocker.patch(_PATCH_LOG)
-
+    def test_forwards_parameters_to_exchange_launch_token(self, patched):
         WebappClient.create(
             base_url="https://bfabric.example.com/bfabric",
             launch_token="my.launch.jwt",
@@ -73,39 +75,14 @@ class TestWebappClientCreate:
             client_secret="csecret",
         )
 
-        mock_exchange.assert_called_once_with(
+        patched["exchange"].assert_called_once_with(
             "https://bfabric.example.com/bfabric",
             "my.launch.jwt",
             client_id="cid",
             client_secret="csecret",
         )
 
-    def test_verifies_exchanged_access_token_jwt(self, mocker, mock_token_dict):
-        mocker.patch(_PATCH_EXCHANGE, return_value=mock_token_dict)
-        mock_verify = mocker.patch(_PATCH_VERIFY_JWT, return_value=dict(SAMPLE_CLAIMS))
-        mocker.patch(_PATCH_PROVIDER)
-        mocker.patch(_PATCH_CONNECT_OAUTH, return_value=mocker.MagicMock())
-        mocker.patch(_PATCH_LOG)
-
-        WebappClient.create(
-            base_url="https://bfabric.example.com/bfabric",
-            launch_token="jwt",
-            client_id="cid",
-            client_secret="csecret",
-        )
-
-        mock_verify.assert_called_once_with(
-            "https://bfabric.example.com/bfabric",
-            "new_access_token",
-        )
-
-    def test_creates_user_provider_with_refresh_token(self, mocker, mock_token_dict):
-        mocker.patch(_PATCH_EXCHANGE, return_value=mock_token_dict)
-        mocker.patch(_PATCH_VERIFY_JWT, return_value=dict(SAMPLE_CLAIMS))
-        mock_provider_cls = mocker.patch(_PATCH_PROVIDER)
-        mocker.patch(_PATCH_CONNECT_OAUTH, return_value=mocker.MagicMock())
-        mocker.patch(_PATCH_LOG)
-
+    def test_builds_user_client_from_exchanged_token(self, patched, mock_token_dict):
         WebappClient.create(
             base_url="https://bfabric.example.com/bfabric",
             launch_token="jwt",
@@ -114,22 +91,15 @@ class TestWebappClientCreate:
             user_token_cache_path="/tmp/user_cache",
         )
 
-        mock_provider_cls.assert_called_once_with(
+        patched["connect_oauth_token"].assert_called_once_with(
+            "https://bfabric.example.com/bfabric",
+            mock_token_dict,
             client_id="cid",
             client_secret="csecret",
-            token_url="https://bfabric.example.com/bfabric/rest/oauth/token",
-            token=mock_token_dict,
-            grant_type="refresh_token",
             token_cache_path="/tmp/user_cache",
         )
 
-    def test_forwards_parameters_to_connect_oauth(self, mocker, mock_token_dict):
-        mocker.patch(_PATCH_EXCHANGE, return_value=mock_token_dict)
-        mocker.patch(_PATCH_VERIFY_JWT, return_value=dict(SAMPLE_CLAIMS))
-        mocker.patch(_PATCH_PROVIDER)
-        mock_connect_oauth = mocker.patch(_PATCH_CONNECT_OAUTH, return_value=mocker.MagicMock())
-        mocker.patch(_PATCH_LOG)
-
+    def test_forwards_parameters_to_connect_oauth(self, patched):
         WebappClient.create(
             base_url="https://bfabric.example.com/bfabric",
             launch_token="jwt",
@@ -139,7 +109,7 @@ class TestWebappClientCreate:
             service_token_cache_path="/tmp/svc_cache",
         )
 
-        mock_connect_oauth.assert_called_once_with(
+        patched["connect_oauth"].assert_called_once_with(
             client_id="cid",
             client_secret="csecret",
             base_url="https://bfabric.example.com/bfabric",
@@ -147,13 +117,7 @@ class TestWebappClientCreate:
             token_cache_path="/tmp/svc_cache",
         )
 
-    def test_default_scope(self, mocker, mock_token_dict):
-        mocker.patch(_PATCH_EXCHANGE, return_value=mock_token_dict)
-        mocker.patch(_PATCH_VERIFY_JWT, return_value=dict(SAMPLE_CLAIMS))
-        mocker.patch(_PATCH_PROVIDER)
-        mock_connect_oauth = mocker.patch(_PATCH_CONNECT_OAUTH, return_value=mocker.MagicMock())
-        mocker.patch(_PATCH_LOG)
-
+    def test_default_scope(self, patched):
         WebappClient.create(
             base_url="https://bfabric.example.com/bfabric",
             launch_token="jwt",
@@ -161,47 +125,32 @@ class TestWebappClientCreate:
             client_secret="csecret",
         )
 
-        assert mock_connect_oauth.call_args.kwargs["scope"] == DEFAULT_OAUTH_SCOPE
+        assert patched["connect_oauth"].call_args.kwargs["scope"] == DEFAULT_OAUTH_SCOPE
 
 
 class TestWebappClientFrozen:
     @pytest.fixture
-    def mock_user_client(self, mocker):
-        return mocker.MagicMock(name="user_client")
-
-    @pytest.fixture
-    def mock_service_client(self, mocker):
-        return mocker.MagicMock(name="service_client")
-
-    @pytest.fixture
     def mock_context(self) -> UrlTokenContext:
         return UrlTokenContext(entity_id=1, subject="u")
 
-    def test_cannot_reassign_user(self, mock_user_client, mock_service_client, mock_context, mocker):
-        wc = WebappClient(user=mock_user_client, service=mock_service_client, context=mock_context)
+    def test_cannot_reassign_user(self, mock_context, mocker):
+        wc = WebappClient(user=mocker.MagicMock(), service=mocker.MagicMock(), context=mock_context)
         with pytest.raises(FrozenInstanceError):
             wc.user = mocker.MagicMock()  # type: ignore[misc]
 
-    def test_cannot_reassign_service(self, mock_user_client, mock_service_client, mock_context, mocker):
-        wc = WebappClient(user=mock_user_client, service=mock_service_client, context=mock_context)
+    def test_cannot_reassign_service(self, mock_context, mocker):
+        wc = WebappClient(user=mocker.MagicMock(), service=mocker.MagicMock(), context=mock_context)
         with pytest.raises(FrozenInstanceError):
             wc.service = mocker.MagicMock()  # type: ignore[misc]
 
-    def test_cannot_reassign_context(self, mock_user_client, mock_service_client, mock_context, mocker):
-        wc = WebappClient(user=mock_user_client, service=mock_service_client, context=mock_context)
+    def test_cannot_reassign_context(self, mock_context, mocker):
+        wc = WebappClient(user=mocker.MagicMock(), service=mocker.MagicMock(), context=mock_context)
         with pytest.raises(FrozenInstanceError):
             wc.context = mocker.MagicMock()  # type: ignore[misc]
 
 
 class TestWebappClientIndependence:
-    def test_user_and_service_are_independent(self, mocker):
-        mock_token_dict = {"access_token": "at", "refresh_token": "rt", "token_type": "Bearer"}
-        mocker.patch(_PATCH_EXCHANGE, return_value=mock_token_dict)
-        mocker.patch(_PATCH_VERIFY_JWT, return_value={"sub": "u"})
-        mocker.patch(_PATCH_PROVIDER)
-        mocker.patch(_PATCH_CONNECT_OAUTH, return_value=mocker.MagicMock(name="service"))
-        mocker.patch(_PATCH_LOG)
-
+    def test_user_and_service_are_independent(self, patched):
         wc = WebappClient.create(
             base_url="https://bfabric.example.com/bfabric",
             launch_token="jwt",

--- a/tests/bfabric/test_bfabric.py
+++ b/tests/bfabric/test_bfabric.py
@@ -679,6 +679,70 @@ class TestConnectDeviceCode:
         assert call_kwargs["token_url"] == "https://example.com/bfabric/rest/oauth/token"
 
 
+class TestConnectOauthToken:
+    def test_creates_instance_with_provider(self, mocker):
+        mocker.patch.object(Bfabric, "_log_version_message")
+        mock_provider_cls = mocker.patch("bfabric._oauth.credential_provider.OAuthCredentialProvider")
+        token = {"access_token": "at", "refresh_token": "rt", "token_type": "Bearer"}
+
+        client = Bfabric.connect_oauth_token(
+            "https://example.com/bfabric",
+            token,
+            client_id="webapp-client",
+        )
+
+        mock_provider_cls.assert_called_once_with(
+            client_id="webapp-client",
+            client_secret="",
+            token_url="https://example.com/bfabric/rest/oauth/token",
+            token=token,
+            grant_type="refresh_token",
+            scope=DEFAULT_OAUTH_SCOPE,
+            token_cache_path=None,
+            on_token_update=None,
+        )
+        assert client._credential_provider == mock_provider_cls.return_value
+        assert client._auth is None
+        assert client.config.base_url == "https://example.com/bfabric/"
+
+    def test_threads_refresh_callback_and_secret(self, mocker):
+        mocker.patch.object(Bfabric, "_log_version_message")
+        mock_provider_cls = mocker.patch("bfabric._oauth.credential_provider.OAuthCredentialProvider")
+        callback = mocker.MagicMock()
+        cache_path = Path("/tmp/webapp_cache.json")
+
+        Bfabric.connect_oauth_token(
+            "https://example.com/bfabric",
+            {"access_token": "at", "refresh_token": "rt"},
+            client_id="webapp-client",
+            client_secret="shhh",
+            scope="api:read",
+            token_cache_path=cache_path,
+            on_token_refresh=callback,
+        )
+
+        call_kwargs = mock_provider_cls.call_args[1]
+        assert call_kwargs["client_secret"] == "shhh"
+        assert call_kwargs["scope"] == "api:read"
+        assert call_kwargs["token_cache_path"] == cache_path
+        # The public on_token_refresh maps onto the provider's on_token_update parameter.
+        assert call_kwargs["on_token_update"] is callback
+
+    def test_strips_trailing_slash(self, mocker):
+        mocker.patch.object(Bfabric, "_log_version_message")
+        mock_provider_cls = mocker.patch("bfabric._oauth.credential_provider.OAuthCredentialProvider")
+
+        client = Bfabric.connect_oauth_token(
+            "https://example.com/bfabric///",
+            {"access_token": "at", "refresh_token": "rt"},
+            client_id="webapp-client",
+        )
+
+        assert client.config.base_url == "https://example.com/bfabric/"
+        call_kwargs = mock_provider_cls.call_args[1]
+        assert call_kwargs["token_url"] == "https://example.com/bfabric/rest/oauth/token"
+
+
 class TestConnectPat:
     def test_creates_instance_with_auth(self, mocker):
         mocker.patch.object(Bfabric, "_log_version_message")


### PR DESCRIPTION
Core, opt-in OAuth 2.0 primitives for the webapp launch-token flow, the `WebappClient` dedupe onto them, and auth-doc signposting. Foundation for migrating B-Fabric webapps to OAuth; the `bfabric_asgi_auth` adapter that consumes them is a stacked follow-up.

**Primitives** (additive; defaults preserve current behavior):
- `Bfabric.connect_oauth_token` — client from an already-exchanged token (refresh-token grant), with an `on_token_refresh` callback.
- `OAuthCredentialProvider(on_token_update=…)` — fires after each refresh; dropped on pickle (honors the picklability contract).
- `verify_jwt(audience=…, issuer=…)` — opt-in `aud`/`iss` validation, off by default.
- `bfabric.experimental.webapp_oauth` — `exchange_launch_token`, `OAuthClientCredentials`, `WebappOAuthSettings`.

**Dedupe:** the RFC 8693 launch exchange now lives once in `_oauth/launch_token.py`; `WebappClient.create` and the public facade both consume it. `_oauth` no longer depends on `experimental`.

**Docs:** AGENTS.md gains an auth entry-point map and a doc-maintenance rule; `oauth_integration.md` drift fixed.

**Why this stays draft:** the OAuth exchange and `aud`/`iss` validation are not yet verified against a live B-Fabric server — `aud`/`iss` ship off by default with TODOs, to be confirmed on a test server before any consumer enables the OAuth path.

Testing: `pytest tests/bfabric` (587) and `basedpyright(bfabric)` green; no baseline edits.

🤖 Prepared with assistance from Claude Code.
