### PR TITLE
fix(oauth): strip refresh_token for client_credentials grant

### DIFF
--- a/bfabric/src/bfabric/_oauth/credential_provider.py
+++ b/bfabric/src/bfabric/_oauth/credential_provider.py
@@ -124,6 +124,7 @@ class OAuthCredentialProvider:
         """
         token = self._session.token  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
         if token:
+            self._strip_unusable_refresh_token()
             # Let authlib check expiry + refresh/re-fetch as appropriate (operates on self.token).
             logger.debug("Ensuring token is active (refresh if needed)")
             self._session.ensure_active_token()  # pyright: ignore[reportUnknownMemberType]
@@ -132,7 +133,29 @@ class OAuthCredentialProvider:
             logger.debug("No token present, fetching initial token")
             token_endpoint: str | None = self._session.metadata.get("token_endpoint")  # pyright: ignore[reportAny]
             self._session.fetch_token(token_endpoint)  # pyright: ignore[reportUnknownMemberType]
+            self._strip_unusable_refresh_token()
             self._persist()
+
+    def _strip_unusable_refresh_token(self) -> None:
+        """Drop the ``refresh_token`` from a client-credentials session token.
+
+        authlib's :meth:`ensure_active_token` prefers the refresh-token grant whenever the
+        token dict carries a ``refresh_token`` key, *regardless of grant type* (see
+        ``authlib.oauth2.client.OAuth2Client.ensure_active_token``: it checks ``refresh_token``
+        before the ``client_credentials`` branch). Some B-Fabric token endpoints return a
+        ``refresh_token`` alongside a client-credentials access token. Honoring it means that
+        once the refresh token expires — it has its own, shorter lifetime — every call fails with
+        ``invalid_grant`` and the session never falls back to re-fetching with the client secret,
+        wedging the provider until the process restarts. For ``client_credentials`` we therefore
+        strip any ``refresh_token`` so authlib always re-fetches a brand-new token on expiry.
+
+        Must be called while holding ``self._lock``.
+        """
+        if self._grant_type != "client_credentials":
+            return
+        token = self._session.token  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        if token and token.get("refresh_token"):  # pyright: ignore[reportUnknownMemberType]
+            token.pop("refresh_token", None)  # pyright: ignore[reportUnknownMemberType]
 
     def _on_token_update(self, _new_token: dict[str, object], **_kwargs: object) -> None:
         """Callback invoked by authlib after a token refresh/re-fetch."""

--- a/tests/bfabric/oauth/test_credential_provider.py
+++ b/tests/bfabric/oauth/test_credential_provider.py
@@ -110,6 +110,70 @@ class TestClientCredentials:
         assert len(fetch_calls) == 1
 
 
+class TestClientCredentialsRefreshTokenStripping:
+    """A client_credentials provider must never honor a refresh_token returned by the AS.
+
+    authlib's ensure_active_token() prefers the refresh-token grant whenever the token dict
+    has a refresh_token, regardless of grant type. If the B-Fabric token endpoint returns one
+    alongside a client_credentials access token, honoring it wedges the session with
+    invalid_grant once that refresh token expires (it never falls back to re-fetching). So the
+    provider strips it for client_credentials.
+    """
+
+    def test_refresh_token_stripped_after_initial_fetch(self, provider, mock_oauth2_session):
+        def do_fetch(*args, **kwargs):
+            mock_oauth2_session.token = {
+                "access_token": "jwt123",
+                "refresh_token": "should_be_dropped",
+                "expires_at": time.time() + 3600,
+            }
+
+        mock_oauth2_session.fetch_token.side_effect = do_fetch
+
+        provider.get_auth()
+
+        # The refresh_token must be gone so authlib re-fetches (not refreshes) on next expiry.
+        assert "refresh_token" not in mock_oauth2_session.token
+
+    def test_refresh_token_stripped_before_ensure_active(self, provider, mock_oauth2_session):
+        """An existing token carrying a refresh_token has it stripped before ensure_active_token."""
+        mock_oauth2_session.token = {
+            "access_token": "existing",
+            "refresh_token": "stale_rt",
+            "expires_at": time.time() + 3600,
+        }
+        seen = {}
+
+        def record(*args, **kwargs):
+            seen["had_refresh_token"] = "refresh_token" in mock_oauth2_session.token
+
+        mock_oauth2_session.ensure_active_token.side_effect = record
+
+        provider.get_auth()
+
+        mock_oauth2_session.ensure_active_token.assert_called_once()
+        assert seen["had_refresh_token"] is False
+
+    def test_refresh_token_preserved_for_refresh_grant(self, mock_oauth2_session):
+        """The refresh_token grant must KEEP its refresh_token (only client_credentials strips)."""
+        mock_oauth2_session.token = {
+            "access_token": "jwt",
+            "refresh_token": "keep_me",
+            "expires_at": time.time() + 3600,
+        }
+        prov = OAuthCredentialProvider(
+            client_id="app-id",
+            client_secret="",
+            token_url="https://example.com/rest/oauth/token",
+            grant_type="refresh_token",
+            token={"access_token": "jwt", "refresh_token": "keep_me", "expires_at": time.time() + 3600},
+        )
+
+        prov.get_auth()
+
+        assert mock_oauth2_session.token.get("refresh_token") == "keep_me"
+
+
 class TestRefreshToken:
     def test_seeded_token_with_refresh(self, mock_oauth2_session):
         """When a token dict with refresh_token is provided, it's seeded into the session."""


### PR DESCRIPTION
## Problem

A `client_credentials` OAuth provider (`Bfabric.connect_oauth`) gets permanently wedged ~24h after process start, with every B-Fabric API call failing:

```
invalid_grant: Refresh token is invalid, expired, or revoked
```

Retries don't help — the failure is not transient. Restarting the workers fixes it temporarily, then it recurs once the refresh-token lifetime elapses again.

## Root cause

authlib's `OAuth2Client.ensure_active_token()` checks for a `refresh_token` **before** the `client_credentials` branch, regardless of the configured grant type:

```python
# authlib/oauth2/client.py
refresh_token = token.get("refresh_token")
url = self.metadata.get("token_endpoint")
if refresh_token and url:
    self.refresh_token(url, refresh_token=refresh_token)   # taken
    return True
elif self.metadata.get("grant_type") == "client_credentials":
    self.fetch_token(url, grant_type="client_credentials")  # never reached
```

Some B-Fabric token endpoints return a `refresh_token` alongside a `client_credentials` access token (the AS client even has a configurable refresh-token lifetime, e.g. 86400s). authlib stores it, and on access-token expiry prefers the **refresh** grant over a clean re-fetch. Once the refresh token outlives its (shorter) lifetime, the refresh fails with `invalid_grant` and authlib never falls back to re-fetching with the client secret — so the session is stuck until restart.

This was observed in production on the Trace Storage TUS Service: a worker running for >24h, then every hook call failing `invalid_grant`.

## Fix

For `client_credentials` providers, strip any `refresh_token` from the session token — after the initial fetch and before each expiry check — so authlib always takes the `fetch_token(grant_type="client_credentials")` path on expiry. The `refresh_token` grant path is unaffected (it keeps its refresh token).

## Tests

Added `TestClientCredentialsRefreshTokenStripping`:
- refresh_token stripped after the initial fetch
- refresh_token stripped before `ensure_active_token` on an existing token
- refresh_token **preserved** for the `refresh_token` grant (no regression)

All 100 `tests/bfabric/oauth/` tests pass.

## Relationship to the AS-side fix

The root cause also lives in the B-Fabric auth server: per RFC 6749 §4.4.3, a `client_credentials` grant **SHOULD NOT** return a `refresh_token`. That is being fixed in parallel on the AS so newly issued client-credentials tokens no longer carry one.

This client-side PR is kept regardless, as defense in depth:

- **Old/cached tokens** already issued still carry a `refresh_token` and would stay wedged until this lands — the AS fix only affects newly issued tokens.
- **Other / not-yet-updated AS deployments** (staging, older prod, customer installs) keep the client robust.
- **Correct client posture** — the client shouldn't rely on every AS being spec-perfect; authlib preferring `refresh_token` over the configured grant is its own latent quirk this neutralizes.

The two fixes are complementary: the AS fix removes the cause, this removes the failure mode.