### PR TITLE
fix(oauth): change default client_id to "CLI"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ Each package's docs live alongside its source. Skim the index when working in a 
   `mocker.Mock()`, `mocker.mock_open(...)`, etc. (`pytest-mock` is a test dependency in every package.)
 - Ruff linting is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores)
 - Line length: 120 (ruff and black)
+- Do not restate a parameter's default value in its docstring when the signature already shows it (e.g. `client_id: str = DEFAULT_CLIENT_ID`). Writing `(default "CLI")` in the `:param:` line just duplicates the signature and drifts out of sync when the default changes. Keep notes that explain what a value *means* (e.g. `(``0`` = auto-assign)`), not ones that merely repeat it.
 - basedpyright uses per-package baseline files at `.basedpyright/baseline.{package}.json` — **do not edit baseline files to silence new errors**; fix the code or add a targeted `# pyright: ignore[...]` comment on the offending line. Baselines only exist to grandfather in pre-existing errors.
 - Integration tests live in a separate repository
 - Use TDD: write a failing test first, verify it fails, then fix the code, then verify the test passes

--- a/bfabric/docs/design/oauth_integration.md
+++ b/bfabric/docs/design/oauth_integration.md
@@ -12,7 +12,7 @@ Private module under `bfabric/src/bfabric/_oauth/` implementing all OAuth primit
 
 | File | Purpose |
 |------|---------|
-| `_constants.py` | `DEFAULT_CLIENT_ID = "bfabric-cli"`, `DEFAULT_OAUTH_SCOPE = "api:read api:write"` |
+| `_constants.py` | `DEFAULT_CLIENT_ID = "CLI"`, `DEFAULT_OAUTH_SCOPE = "api:read api:write"` |
 | `credential_provider.py` | `OAuthCredentialProvider` — thread-safe token management with automatic refresh and disk caching. Supports both `client_credentials` and `refresh_token` grant types. |
 | `pkce.py` | `pkce_login()` — browser-based PKCE flow. Starts a local HTTP server, opens the browser, exchanges the authorization code for tokens. |
 | `device_code.py` | `device_code_login()` — RFC 8628 device authorization flow for headless environments. |
@@ -68,7 +68,7 @@ All auth commands use `--config-env` (consistent with API commands via `@use_cli
 PRODUCTION:
   base_url: "https://bfabric.example.com/bfabric"
   auth_method: "oauth"        # NEW — triggers OAuth flow in Bfabric.connect()
-  client_id: "bfabric-cli"    # NEW — optional, defaults to "bfabric-cli"
+  client_id: "CLI"    # NEW — optional, defaults to "CLI"
 ```
 
 ### New: `config_writer.py`
@@ -118,7 +118,7 @@ B-Fabric now enforces OAuth scopes at the API level:
 - `api:write` required for SOAP write operations
 - Additional scopes (e.g. `tus`, `download`) can be requested and are enforced by their respective endpoints
 
-The `bfabric-cli` default client is pre-registered with: `openid, profile, email, api:read, api:write, tus, download, offline_access`.
+The `CLI` default client is pre-registered with: `openid, profile, email, api:read, api:write, tus, download, offline_access`.
 
 ---
 

--- a/bfabric/src/bfabric/_oauth/_constants.py
+++ b/bfabric/src/bfabric/_oauth/_constants.py
@@ -1,4 +1,4 @@
 """Shared constants for the OAuth module."""
 
-DEFAULT_CLIENT_ID = "bfabric-cli"
+DEFAULT_CLIENT_ID = "CLI"
 DEFAULT_OAUTH_SCOPE = "api:read api:write openid profile email groups"

--- a/bfabric/src/bfabric/_oauth/device_code.py
+++ b/bfabric/src/bfabric/_oauth/device_code.py
@@ -149,7 +149,7 @@ def device_code_login(
     then polls until the user authorizes or the request times out.
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-    :param client_id: OAuth client ID (default ``"bfabric-cli"``)
+    :param client_id: OAuth client ID (default ``"CLI"``)
     :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param timeout: Seconds to wait for the user to authorize (default 600)
     :returns: Token dict with ``access_token``, ``refresh_token``, etc.

--- a/bfabric/src/bfabric/_oauth/device_code.py
+++ b/bfabric/src/bfabric/_oauth/device_code.py
@@ -149,9 +149,9 @@ def device_code_login(
     then polls until the user authorizes or the request times out.
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-    :param client_id: OAuth client ID (default ``"CLI"``)
-    :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
-    :param timeout: Seconds to wait for the user to authorize (default 600)
+    :param client_id: OAuth client ID
+    :param scope: OAuth scope
+    :param timeout: Seconds to wait for the user to authorize
     :returns: Token dict with ``access_token``, ``refresh_token``, etc.
     :raises RuntimeError: On timeout, expired token, or access denied
     """

--- a/bfabric/src/bfabric/_oauth/pkce.py
+++ b/bfabric/src/bfabric/_oauth/pkce.py
@@ -76,10 +76,7 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "text/html")
         self.end_headers()
-        _ = self.wfile.write(
-            b"<html><body><h1>Login successful</h1>"
-            b"<p>You can close this tab.</p></body></html>"
-        )
+        _ = self.wfile.write(b"<html><body><h1>Login successful</h1>" b"<p>You can close this tab.</p></body></html>")
 
         # Shut down the server from a daemon thread so this handler can return.
         threading.Thread(target=self.server.shutdown, daemon=True).start()
@@ -144,7 +141,7 @@ def pkce_login(
     exchanges the authorization code for tokens.
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-    :param client_id: OAuth client ID (default ``"bfabric-cli"``)
+    :param client_id: OAuth client ID (default ``"CLI"``)
     :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
     :param port: Local port for the callback server (``0`` = auto-assign)
     :param open_browser: Whether to open the authorization URL in the browser.
@@ -161,15 +158,17 @@ def pkce_login(
 
     server = _CallbackServer(port)
 
-    authorize_url = f"{base_url}/rest/oauth/authorize?" + urlencode({
-        "response_type": "code",
-        "client_id": client_id,
-        "redirect_uri": server.redirect_uri,
-        "code_challenge": challenge,
-        "code_challenge_method": "S256",
-        "state": state,
-        "scope": scope,
-    })
+    authorize_url = f"{base_url}/rest/oauth/authorize?" + urlencode(
+        {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": server.redirect_uri,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+            "scope": scope,
+        }
+    )
 
     # Try to open the browser; fall back to printing the URL.
     browser_opened = False

--- a/bfabric/src/bfabric/_oauth/pkce.py
+++ b/bfabric/src/bfabric/_oauth/pkce.py
@@ -141,8 +141,8 @@ def pkce_login(
     exchanges the authorization code for tokens.
 
     :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-    :param client_id: OAuth client ID (default ``"CLI"``)
-    :param scope: OAuth scope (default :data:`~bfabric._oauth.DEFAULT_OAUTH_SCOPE`)
+    :param client_id: OAuth client ID
+    :param scope: OAuth scope
     :param port: Local port for the callback server (``0`` = auto-assign)
     :param open_browser: Whether to open the authorization URL in the browser.
         If ``False`` (or if the browser fails to open), the URL is printed to stderr.

--- a/bfabric/src/bfabric/bfabric.py
+++ b/bfabric/src/bfabric/bfabric.py
@@ -278,7 +278,7 @@ class Bfabric:
         client uses :class:`OAuthCredentialProvider` for transparent refresh.
 
         :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-        :param client_id: OAuth client ID (default ``"bfabric-cli"``)
+        :param client_id: OAuth client ID (default ``"CLI"``)
         :param scope: OAuth scope (default ``"api:read api:write"``)
         :param port: Local port for the callback server (``0`` = auto-assign)
         :param open_browser: Whether to open the authorization URL in the browser
@@ -332,7 +332,7 @@ class Bfabric:
         where a localhost redirect is not feasible.
 
         :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-        :param client_id: OAuth client ID (default ``"bfabric-cli"``)
+        :param client_id: OAuth client ID (default ``"CLI"``)
         :param scope: OAuth scope (default ``"api:read api:write"``)
         :param timeout: Seconds to wait for the user to authorize (default 600)
         :param token_cache_path: Optional path to cache tokens on disk (survives restarts)

--- a/bfabric/src/bfabric/bfabric.py
+++ b/bfabric/src/bfabric/bfabric.py
@@ -278,8 +278,8 @@ class Bfabric:
         client uses :class:`OAuthCredentialProvider` for transparent refresh.
 
         :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-        :param client_id: OAuth client ID (default ``"CLI"``)
-        :param scope: OAuth scope (default ``"api:read api:write"``)
+        :param client_id: OAuth client ID
+        :param scope: OAuth scope
         :param port: Local port for the callback server (``0`` = auto-assign)
         :param open_browser: Whether to open the authorization URL in the browser
         :param timeout: Seconds to wait for the user to complete login
@@ -332,9 +332,9 @@ class Bfabric:
         where a localhost redirect is not feasible.
 
         :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
-        :param client_id: OAuth client ID (default ``"CLI"``)
-        :param scope: OAuth scope (default ``"api:read api:write"``)
-        :param timeout: Seconds to wait for the user to authorize (default 600)
+        :param client_id: OAuth client ID
+        :param scope: OAuth scope
+        :param timeout: Seconds to wait for the user to authorize
         :param token_cache_path: Optional path to cache tokens on disk (survives restarts)
         """
         from bfabric._oauth.credential_provider import OAuthCredentialProvider

--- a/tests/bfabric/oauth/test_device_code.py
+++ b/tests/bfabric/oauth/test_device_code.py
@@ -315,7 +315,7 @@ class TestDeviceCodeLogin:
 
         mock_request.assert_called_once_with(
             "https://example.com/bfabric",
-            client_id="bfabric-cli",
+            client_id="CLI",
             scope=DEFAULT_OAUTH_SCOPE,
         )
         assert mock_poll.call_args[0][0] == "https://example.com/bfabric"

--- a/tests/bfabric/test_bfabric.py
+++ b/tests/bfabric/test_bfabric.py
@@ -540,14 +540,14 @@ class TestConnectPkce:
 
         mock_pkce_login.assert_called_once_with(
             "https://example.com/bfabric",
-            client_id="bfabric-cli",
+            client_id="CLI",
             scope=DEFAULT_OAUTH_SCOPE,
             port=0,
             open_browser=True,
             timeout=120.0,
         )
         mock_provider_cls.assert_called_once_with(
-            client_id="bfabric-cli",
+            client_id="CLI",
             client_secret="",
             token_url="https://example.com/bfabric/rest/oauth/token",
             token=mock_pkce_login.return_value,
@@ -621,12 +621,12 @@ class TestConnectDeviceCode:
 
         mock_device_code_login.assert_called_once_with(
             "https://example.com/bfabric",
-            client_id="bfabric-cli",
+            client_id="CLI",
             scope=DEFAULT_OAUTH_SCOPE,
             timeout=600.0,
         )
         mock_provider_cls.assert_called_once_with(
-            client_id="bfabric-cli",
+            client_id="CLI",
             client_secret="",
             token_url="https://example.com/bfabric/rest/oauth/token",
             token=mock_device_code_login.return_value,


### PR DESCRIPTION
Changes the default OAuth `client_id` used by the interactive login flows (PKCE, device code) from `"bfabric-cli"` to `"CLI"`, matching the client identity now registered on the B-Fabric server.

The value lives in a single constant (`DEFAULT_CLIENT_ID` in `bfabric/_oauth/_constants.py`); all entry points (`connect_pkce`, `connect_device_code`, the `auth` CLI commands, config-based reconnection) already resolve through it. This PR updates that constant plus the docstrings, design doc, and tests that hardcode the literal.