### PR TITLE
feat(cli): add "auth default" to show/set the default config env

### DIFF
--- a/bfabric/src/bfabric/config/config_writer.py
+++ b/bfabric/src/bfabric/config/config_writer.py
@@ -129,6 +129,10 @@ def set_default_config(config_path: Path, env_name: str) -> None:
     # Enumerate the configured environments through the reader so the check matches how the
     # file will actually load back. ConfigFile's "before" validators mutate their input in
     # place, so always validate a deep copy and keep ``existing`` pristine for the write.
+    # This also doubles as the round-trip guard: since env_name is confirmed to be one of
+    # config_file_obj.environments, and environments are otherwise untouched below, setting
+    # GENERAL.default_config to env_name cannot fail ConfigFile's own default-config-must-exist
+    # validator -- so no second validation pass is needed after the mutation.
     config_file_obj = ConfigFile.model_validate(copy.deepcopy(existing))
     if env_name not in config_file_obj.environments:
         available = ", ".join(sorted(config_file_obj.environments)) or "(none)"
@@ -139,6 +143,4 @@ def set_default_config(config_path: Path, env_name: str) -> None:
         raise ValueError("Malformed config file: 'GENERAL' section is not a mapping.")
     general["default_config"] = env_name
 
-    # Guard the round-trip before touching disk, mirroring write_environment_to_config.
-    _ = ConfigFile.model_validate(copy.deepcopy(existing))
     _write_config_file(config_path, existing)

--- a/bfabric/src/bfabric/config/config_writer.py
+++ b/bfabric/src/bfabric/config/config_writer.py
@@ -6,16 +6,36 @@ existing config file will be lost when the file is rewritten.
 
 from __future__ import annotations
 
+import copy
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import yaml
 
-from bfabric.config.config_file import EnvironmentConfig
+from bfabric.config.config_file import ConfigFile, EnvironmentConfig
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+
+def _write_config_file(config_path: Path, data: Mapping[str, object]) -> None:
+    """Serialize *data* to *config_path* as YAML with ``0o600`` permissions.
+
+    Centralizes the secret-safe write shared by every config mutation: creates parent
+    directories, dumps the mapping, and forces ``0o600`` even on a pre-existing file (whose
+    permissions ``os.open`` would otherwise leave untouched) so a secret never lands in a
+    group/world-readable file.
+    """
+    config_path = Path(config_path).expanduser()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = yaml.dump(data, default_flow_style=False, sort_keys=False).encode()
+    fd = os.open(str(config_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        _ = os.write(fd, serialized)
+    finally:
+        os.close(fd)
 
 
 def _validate_round_trip(env_name: str, env_data: Mapping[str, object]) -> None:
@@ -82,13 +102,43 @@ def write_environment_to_config(
 
     existing[env_name] = dict(env_data)
 
-    data = yaml.dump(existing, default_flow_style=False, sort_keys=False).encode()
-    fd = os.open(str(config_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        # The mode passed to os.open is only honored when the file is created; an existing
-        # config keeps its old (possibly group/world-readable) permissions. Tighten explicitly
-        # so a secret written here (e.g. a PAT) never lands in a readable file.
-        os.fchmod(fd, 0o600)
-        _ = os.write(fd, data)
-    finally:
-        os.close(fd)
+    _write_config_file(config_path, existing)
+
+
+def set_default_config(config_path: Path, env_name: str) -> None:
+    """Set ``GENERAL.default_config`` to an already-defined environment.
+
+    Unlike :func:`write_environment_to_config`, this only flips the default -- it never
+    creates or modifies an environment. Other environments and the general section are
+    preserved.
+
+    :param config_path: Path to the YAML config file (will be expanded).
+    :param env_name: Name of an existing environment to mark as default.
+    :raises FileNotFoundError: If the config file does not exist.
+    :raises ValueError: If *env_name* is not among the configured environments; the file is
+        left untouched in that case.
+    """
+    config_path = Path(config_path).expanduser()
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    loaded: object = yaml.safe_load(config_path.read_text())  # pyright: ignore[reportAny]
+    existing: dict[str, object]
+    existing = loaded if isinstance(loaded, dict) else {}  # pyright: ignore[reportUnknownVariableType]
+
+    # Enumerate the configured environments through the reader so the check matches how the
+    # file will actually load back. ConfigFile's "before" validators mutate their input in
+    # place, so always validate a deep copy and keep ``existing`` pristine for the write.
+    config_file_obj = ConfigFile.model_validate(copy.deepcopy(existing))
+    if env_name not in config_file_obj.environments:
+        available = ", ".join(sorted(config_file_obj.environments)) or "(none)"
+        raise ValueError(f"Environment {env_name!r} is not defined. Available environments: {available}")
+
+    general = existing.setdefault("GENERAL", {})
+    if not isinstance(general, dict):
+        raise ValueError("Malformed config file: 'GENERAL' section is not a mapping.")
+    general["default_config"] = env_name
+
+    # Guard the round-trip before touching disk, mirroring write_environment_to_config.
+    _ = ConfigFile.model_validate(copy.deepcopy(existing))
+    _write_config_file(config_path, existing)

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,6 +10,11 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 ## \[Unreleased\]
 
+### Added
+
+- `bfabric-cli auth default` — list the configured environments and show the current default.
+- `bfabric-cli auth default set [CONFIG_ENV]` — set the default environment, non-interactively when a value is passed or via an interactive picker when omitted.
+
 ## \[1.16.0rc1\] - 2026-06-23
 
 ### Added

--- a/bfabric_scripts/src/bfabric_scripts/cli/cli_auth.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/cli_auth.py
@@ -1,5 +1,6 @@
 import cyclopts
 
+from bfabric_scripts.cli.login.default_config import cmd_auth_default
 from bfabric_scripts.cli.login.device_code import cmd_login_device_code
 from bfabric_scripts.cli.login.logout import cmd_login_logout
 from bfabric_scripts.cli.login.pat import cmd_login_pat
@@ -16,3 +17,4 @@ _ = cmd_auth.command(cmd_login_register, name="register")
 _ = cmd_auth.command(cmd_login_register_webapp, name="register-webapp")
 _ = cmd_auth.command(cmd_login_status, name="status")
 _ = cmd_auth.command(cmd_login_logout, name="logout")
+_ = cmd_auth.command(cmd_auth_default, name="default")

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/default_config.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/default_config.py
@@ -1,0 +1,105 @@
+"""Commands to show and set the default configuration environment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+import yaml
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.text import Text
+
+from bfabric.config import DEFAULT_CONFIG_FILE
+from bfabric.config.config_file import ConfigFile
+from bfabric.config.config_writer import set_default_config
+
+cmd_auth_default = cyclopts.App(help="Show or set the default configuration environment.")
+
+
+def _environment_line(name: str, *, index: int | None, is_default: bool) -> Text:
+    """Render one environment row. Text (not markup) keeps names with "[" literal.
+
+    The current default is prefixed with a bold-green arrow so it stands out in a long list.
+    """
+    label = f"{index}. {name}" if index is not None else name
+    if is_default:
+        # Chained appends (each returns the Text) keep the whole row in one expression.
+        return Text("→ ", style="bold green").append(label, style="bold green").append("  (default)", style="green")
+    return Text(f"  {label}")
+
+
+def _prompt_for_environment(console: Console, names: list[str], default: str | None) -> str:
+    """Show a numbered menu of *names* and return the environment the user picks."""
+    console.print("Configuration environments:")
+    for index, name in enumerate(names, start=1):
+        console.print(_environment_line(name, index=index, is_default=name == default))
+    choices = [str(i) for i in range(1, len(names) + 1)]
+    # show_choices=False: the numbered menu above already lists the options, so the prompt stays
+    # short ("Select environment (3):") instead of repeating every name inline. Only offer a
+    # default when there is a current default to pre-select; otherwise the pick is required.
+    if default in names:
+        answer = Prompt.ask(
+            "Select environment", choices=choices, default=str(names.index(default) + 1), show_choices=False
+        )
+    else:
+        answer = Prompt.ask("Select environment", choices=choices, show_choices=False)
+    return names[int(answer) - 1]
+
+
+@cmd_auth_default.default
+def cmd_auth_default_show(
+    *,
+    config_file: Annotated[Path, cyclopts.Parameter(help="Path to the config file.")] = DEFAULT_CONFIG_FILE,
+) -> None:
+    """List configuration environments and show the current default."""
+    config_path = Path(config_file).expanduser()
+    if not config_path.is_file():
+        print(f"Config file not found: {config_path}")
+        return
+
+    config_file_obj = ConfigFile.model_validate(yaml.safe_load(config_path.read_text()))
+    names = list(config_file_obj.environments)
+    if not names:
+        print("No environments configured.")
+        return
+
+    default = config_file_obj.general.default_config
+    console = Console()
+    console.print("Configuration environments:")
+    for name in names:
+        console.print(_environment_line(name, index=None, is_default=name == default))
+    if default is None:
+        console.print("\nNo default configured.")
+
+
+@cmd_auth_default.command(name="set")
+def cmd_auth_default_set(
+    config_env: Annotated[
+        str | None, cyclopts.Parameter(help="Environment to set as default (prompted if omitted).")
+    ] = None,
+    *,
+    config_file: Annotated[Path, cyclopts.Parameter(help="Path to the config file.")] = DEFAULT_CONFIG_FILE,
+) -> None:
+    """Set the default configuration environment."""
+    config_path = Path(config_file).expanduser()
+    if not config_path.is_file():
+        print(f"Config file not found: {config_path}")
+        return
+
+    config_file_obj = ConfigFile.model_validate(yaml.safe_load(config_path.read_text()))
+    names = list(config_file_obj.environments)
+    if not names:
+        print("No environments configured.")
+        return
+
+    if config_env is None:
+        config_env = _prompt_for_environment(Console(), names, config_file_obj.general.default_config)
+
+    if config_env not in config_file_obj.environments:
+        print(f"Environment '{config_env}' not found. Available environments: {', '.join(names)}")
+        return
+
+    set_default_config(config_path, config_env)
+    print(f"Default environment set to '{config_env}'.")

--- a/tests/bfabric/config/test_config_writer.py
+++ b/tests/bfabric/config/test_config_writer.py
@@ -8,7 +8,7 @@ import yaml
 
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
 from bfabric.config.config_file import ConfigFile
-from bfabric.config.config_writer import write_environment_to_config
+from bfabric.config.config_writer import set_default_config, write_environment_to_config
 
 
 class TestWriteEnvironmentToConfig:
@@ -141,3 +141,55 @@ class TestRoundTrip:
         with pytest.raises(ValueError):
             write_environment_to_config(config_path, reserved, {"base_url": "https://example.com"}, set_default=True)
         assert not config_path.exists()
+
+
+class TestSetDefaultConfig:
+    @staticmethod
+    def _write_two_env_config(config_path):
+        config_path.write_text(
+            yaml.dump(
+                {
+                    "GENERAL": {"default_config": "PROD"},
+                    "PROD": {"base_url": "https://prod.example.com"},
+                    "TEST": {"base_url": "https://test.example.com"},
+                }
+            )
+        )
+
+    def test_sets_default_to_existing_env(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        self._write_two_env_config(config_path)
+        set_default_config(config_path, "TEST")
+        data = yaml.safe_load(config_path.read_text())
+        assert data["GENERAL"]["default_config"] == "TEST"
+
+    def test_preserves_other_environments(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        self._write_two_env_config(config_path)
+        set_default_config(config_path, "TEST")
+        data = yaml.safe_load(config_path.read_text())
+        assert data["PROD"]["base_url"] == "https://prod.example.com"
+        assert data["TEST"]["base_url"] == "https://test.example.com"
+
+    def test_raises_on_unknown_env_and_leaves_file_unchanged(self, tmp_path):
+        config_path = tmp_path / "config.yml"
+        self._write_two_env_config(config_path)
+        before = config_path.read_text()
+        with pytest.raises(ValueError):
+            set_default_config(config_path, "NOPE")
+        assert config_path.read_text() == before
+
+    def test_raises_on_missing_file(self, tmp_path):
+        config_path = tmp_path / "nonexistent.yml"
+        with pytest.raises(FileNotFoundError):
+            set_default_config(config_path, "PROD")
+
+    def test_tightens_permissions(self, tmp_path):
+        # Switching the default must not loosen an already-strict file, and should tighten a
+        # pre-existing group/world-readable one (a config may hold a PAT in another environment).
+        config_path = tmp_path / "config.yml"
+        self._write_two_env_config(config_path)
+        config_path.chmod(0o644)
+        set_default_config(config_path, "TEST")
+        mode = stat.S_IMODE(os.stat(config_path).st_mode)
+        assert mode == 0o600

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_default.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_default.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from bfabric_scripts.cli.login.default_config import cmd_auth_default_set, cmd_auth_default_show
+
+
+@pytest.fixture(autouse=True)
+def _clear_config_env(monkeypatch):
+    monkeypatch.delenv("BFABRICPY_CONFIG_ENV", raising=False)
+
+
+def _write_config(config_file, default="PROD"):
+    general = {"default_config": default} if default is not None else {}
+    config_file.write_text(
+        yaml.dump(
+            {
+                "GENERAL": general,
+                "PROD": {"base_url": "https://prod.example.com"},
+                "TEST": {"base_url": "https://test.example.com"},
+            }
+        )
+    )
+
+
+class TestCmdAuthDefaultShow:
+    def test_lists_environments_and_marks_default(self, tmp_path, capsys):
+        config_file = tmp_path / "config.yml"
+        _write_config(config_file, default="PROD")
+        cmd_auth_default_show(config_file=config_file)
+        output = capsys.readouterr().out
+        assert "PROD" in output
+        assert "TEST" in output
+        assert "(default)" in output
+        # The default env is marked prominently with an arrow.
+        assert "→ PROD" in output
+
+    def test_missing_config_file(self, tmp_path, capsys):
+        config_file = tmp_path / "nonexistent.yml"
+        cmd_auth_default_show(config_file=config_file)
+        assert "not found" in capsys.readouterr().out
+
+
+class TestCmdAuthDefaultSet:
+    def test_sets_default_non_interactively(self, tmp_path):
+        config_file = tmp_path / "config.yml"
+        _write_config(config_file, default="PROD")
+        cmd_auth_default_set("TEST", config_file=config_file)
+        data = yaml.safe_load(config_file.read_text())
+        assert data["GENERAL"]["default_config"] == "TEST"
+
+    def test_prompts_when_env_omitted(self, tmp_path, mocker, capsys):
+        config_file = tmp_path / "config.yml"
+        _write_config(config_file, default="PROD")
+        # The picker shows a numbered menu and asks for a number; env names are sorted
+        # (PROD=1, TEST=2), so choosing "2" selects TEST.
+        mocker.patch("bfabric_scripts.cli.login.default_config.Prompt.ask", return_value="2")
+        cmd_auth_default_set(config_file=config_file)
+        data = yaml.safe_load(config_file.read_text())
+        assert data["GENERAL"]["default_config"] == "TEST"
+        # The menu is printed with each environment on its own numbered line.
+        menu = capsys.readouterr().out
+        assert "1. PROD" in menu
+        assert "2. TEST" in menu
+
+    def test_unknown_env_errors_and_leaves_file_unchanged(self, tmp_path, capsys):
+        config_file = tmp_path / "config.yml"
+        _write_config(config_file, default="PROD")
+        before = config_file.read_text()
+        cmd_auth_default_set("NOPE", config_file=config_file)
+        output = capsys.readouterr().out
+        assert "NOPE" in output
+        assert config_file.read_text() == before
+
+    def test_missing_config_file(self, tmp_path, capsys):
+        config_file = tmp_path / "nonexistent.yml"
+        cmd_auth_default_set("PROD", config_file=config_file)
+        assert "not found" in capsys.readouterr().out


### PR DESCRIPTION
Adds a first-class way to see the configured environments and the current
default, and to switch the default among them — instead of hand-editing
~/.bfabricpy.yml.

- `bfabric-cli auth default` lists environments and marks the current default.
- `auth default set [CONFIG_ENV]` sets it — non-interactively when a value is
  passed, or via an interactive picker when omitted.
- New `set_default_config()` flips `GENERAL.default_config` without touching any
  environment, reusing the existing 0600 secret-safe write.

Testing: pytest (new tests + existing login suite), basedpyright and ruff clean,
and a manual end-to-end run of the new commands on a temp config.

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.