### PR TITLE
refactor(bfabric): basedpyright cleanup — drop stale baselines, fix hidden findings

### DIFF
--- a/.basedpyright/baseline.bfabric.json
+++ b/.basedpyright/baseline.bfabric.json
@@ -2354,22 +2354,6 @@
                     "endColumn": 16,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportExplicitAny",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
             }
         ],
         "./bfabric/src/bfabric/examples/compare_zeep_suds_pagination.py": [

--- a/.basedpyright/baseline.bfabric.json
+++ b/.basedpyright/baseline.bfabric.json
@@ -1048,14 +1048,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownMemberType",
                 "range": {
                     "startColumn": 12,
@@ -2376,62 +2368,6 @@
                 "range": {
                     "startColumn": 34,
                     "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 91,
                     "lineCount": 1
                 }
             }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ pytest tests/bfabric -k test_name      # single test
 ```bash
 nox -s basedpyright(bfabric)
 nox -s basedpyright(bfabric_scripts)
+nox -s basedpyright(bfabric_app_runner)
 ```
 
 ### Linting

--- a/bfabric/src/bfabric/bfabric.py
+++ b/bfabric/src/bfabric/bfabric.py
@@ -373,13 +373,13 @@ class Bfabric:
         :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
         :param pat: Personal Access Token (string or ``SecretStr``)
         """
-        from pydantic import SecretStr as _SecretStr
+        from pydantic import SecretStr
 
         from bfabric.config.bfabric_auth import OAUTH_LOGIN
 
         base_url = base_url.rstrip("/")
-        pat_value: str = pat.get_secret_value() if isinstance(pat, _SecretStr) else pat
-        auth = BfabricAuth(login=OAUTH_LOGIN, password=_SecretStr(pat_value))
+        pat_value: str = pat.get_secret_value() if isinstance(pat, SecretStr) else pat
+        auth = BfabricAuth(login=OAUTH_LOGIN, password=SecretStr(pat_value))
         config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
         config_data = ConfigData(client=config, auth=auth)
         return cls(config_data=config_data)

--- a/bfabric/src/bfabric/bfabric.py
+++ b/bfabric/src/bfabric/bfabric.py
@@ -29,8 +29,7 @@ from loguru import logger
 from rich.console import Console
 
 from bfabric._oauth._constants import DEFAULT_CLIENT_ID, DEFAULT_OAUTH_SCOPE
-
-from bfabric.config import BfabricAuth, BfabricClientConfig, DEFAULT_CONFIG_FILE
+from bfabric.config import DEFAULT_CONFIG_FILE, BfabricAuth, BfabricClientConfig
 from bfabric.config.bfabric_client_config import BfabricAPIEngineType
 from bfabric.config.config_data import ConfigData, load_config_data
 from bfabric.config.config_file import read_config_file
@@ -46,9 +45,9 @@ if TYPE_CHECKING:
 
     from pydantic import SecretStr
 
+    from bfabric._oauth.credential_provider import OAuthCredentialProvider
     from bfabric.entities.core.entity_reader import EntityReader
     from bfabric.experimental.webapp_integration_settings import TokenValidationSettingsProtocol
-    from bfabric._oauth.credential_provider import OAuthCredentialProvider
     from bfabric.typing import ApiRequestObjectType, ApiResponseObjectType
 
 
@@ -163,9 +162,6 @@ class Bfabric:
         )
         config, auth_config = get_system_auth(config_env=config_env, config_path=config_path)
         auth_used: BfabricAuth | None = auth_config if auth == "config" else auth
-        # TODO https://github.com/fgcz/bfabricPy/issues/164
-        # if engine is not None:
-        #    config = config.copy_with(engine=engine)
         return cls(ConfigData(client=config, auth=auth_used))
 
     @classmethod
@@ -382,8 +378,8 @@ class Bfabric:
         from bfabric.config.bfabric_auth import OAUTH_LOGIN
 
         base_url = base_url.rstrip("/")
-        pat_value = pat.get_secret_value() if isinstance(pat, _SecretStr) else pat
-        auth = BfabricAuth(login=OAUTH_LOGIN, password=pat_value)  # pyright: ignore[reportArgumentType]
+        pat_value: str = pat.get_secret_value() if isinstance(pat, _SecretStr) else pat
+        auth = BfabricAuth(login=OAUTH_LOGIN, password=_SecretStr(pat_value))
         config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
         config_data = ConfigData(client=config, auth=auth)
         return cls(config_data=config_data)

--- a/bfabric/src/bfabric/config/config_file.py
+++ b/bfabric/src/bfabric/config/config_file.py
@@ -6,11 +6,10 @@ from typing import Annotated, Any, Literal
 
 import yaml
 from loguru import logger
-from pydantic import BaseModel, Field, model_validator, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 
-from bfabric.config import BfabricAuth
-from bfabric.config import BfabricClientConfig
+from bfabric.config import BfabricAuth, BfabricClientConfig
 
 # Canonical default location of the bfabricPy config file. The tilde is kept unexpanded here;
 # callers expand it via Path.expanduser() at the point of use.

--- a/bfabric/src/bfabric/engine/engine_suds.py
+++ b/bfabric/src/bfabric/engine/engine_suds.py
@@ -112,7 +112,7 @@ class EngineSUDS:
             n_available_pages = response["numberofpages"]
         except AttributeError:
             n_available_pages = 0
-        errors = get_response_errors(response, endpoint=endpoint)
+        errors = get_response_errors(response, endpoint=endpoint)  # pyright: ignore[reportAny]
         if not hasattr(response, endpoint):
             return ResultContainer([], total_pages_api=0, errors=errors)
         # TODO up until here it's duplicated with engine_zeep

--- a/bfabric/src/bfabric/engine/engine_zeep.py
+++ b/bfabric/src/bfabric/engine/engine_zeep.py
@@ -150,7 +150,7 @@ class EngineZeep:
             n_available_pages = response["numberofpages"]
         except AttributeError:
             n_available_pages = 0
-        errors = get_response_errors(response, endpoint=endpoint)
+        errors = get_response_errors(response, endpoint=endpoint)  # pyright: ignore[reportAny]
         if not hasattr(response, endpoint):
             return ResultContainer([], total_pages_api=0, errors=errors)
         # TODO up until here it's duplicated with engine_suds

--- a/bfabric/src/bfabric/entities/application.py
+++ b/bfabric/src/bfabric/entities/application.py
@@ -27,10 +27,10 @@ class Application(Entity):
         Currently, in case of multiple technologies, the first one (alphabetically) is used.
         TODO this logic should probably be improved in the future
         """
-        technology = self.data_dict["technology"]
-        if not _is_technology_list(technology):
+        technology_raw = self.data_dict["technology"]
+        if not _is_technology_list(technology_raw):
             raise ValueError("Technology must be a list of strings")
-        technology = sorted(technology)[0]
+        technology = sorted(technology_raw)[0]
         return TypeAdapter(PathSafeStr).validate_python(technology)
 
 

--- a/bfabric/src/bfabric/entities/cache/_cache_stack.py
+++ b/bfabric/src/bfabric/entities/cache/_cache_stack.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from bfabric.entities.cache._entity_memory_cache import EntityMemoryCache
     from bfabric.entities.core.entity import Entity
     from bfabric.entities.core.uri import EntityUri
-    from bfabric.entities.cache._entity_memory_cache import EntityMemoryCache
-    from collections.abc import Iterable
 
 
 class CacheStack:
@@ -28,7 +30,7 @@ class CacheStack:
     def item_contains(self, uri: EntityUri) -> bool:
         return any(cache.contains(uri) for cache in reversed(self._stack))
 
-    def item_get(self, uri: EntityUri) -> Entity:
+    def item_get(self, uri: EntityUri) -> Entity | None:
         for cache in reversed(self._stack):
             entity = cache.get(uri)
             if entity is not None:

--- a/bfabric/src/bfabric/errors.py
+++ b/bfabric/src/bfabric/errors.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 
 class BfabricRequestError(RuntimeError):
@@ -88,20 +88,22 @@ class BfabricOAuthError(RuntimeError):
     """Raised when an OAuth operation fails (token exchange, device code flow, PKCE, etc.)."""
 
 
-def get_response_errors(response: Any, endpoint: str) -> list[BfabricRequestError]:
+def get_response_errors(response: object, endpoint: str) -> list[BfabricRequestError]:
     """
     :param response:  A raw response to a query from an underlying engine
     :param endpoint:  The target endpoint
     :return:          A list of errors for each query result, if that result failed
         Thus, a successful query would result in an empty list
     """
-    if getattr(response, "errorreport", None):  # pyright: ignore[reportAny]
-        return [BfabricRequestError(response.errorreport)]  # pyright: ignore[reportAny]
-    elif hasattr(response, endpoint):  # pyright: ignore[reportAny]
-        return [
-            BfabricRequestError(r.errorreport)  # pyright: ignore[reportAny]
-            for r in getattr(response, endpoint)  # pyright: ignore[reportAny]
-            if getattr(r, "errorreport", None)  # pyright: ignore[reportAny]
-        ]
-    else:
+    top_error = cast("str | None", getattr(response, "errorreport", None))
+    if top_error:
+        return [BfabricRequestError(top_error)]
+    if not hasattr(response, endpoint):
         return []
+    results = cast("list[object]", getattr(response, endpoint))
+    errors: list[BfabricRequestError] = []
+    for result in results:
+        message = cast("str | None", getattr(result, "errorreport", None))
+        if message:
+            errors.append(BfabricRequestError(message))
+    return errors

--- a/bfabric/src/bfabric/errors.py
+++ b/bfabric/src/bfabric/errors.py
@@ -88,7 +88,6 @@ class BfabricOAuthError(RuntimeError):
     """Raised when an OAuth operation fails (token exchange, device code flow, PKCE, etc.)."""
 
 
-# TODO: Also test for response-level errors
 def get_response_errors(response: Any, endpoint: str) -> list[BfabricRequestError]:
     """
     :param response:  A raw response to a query from an underlying engine
@@ -96,9 +95,13 @@ def get_response_errors(response: Any, endpoint: str) -> list[BfabricRequestErro
     :return:          A list of errors for each query result, if that result failed
         Thus, a successful query would result in an empty list
     """
-    if getattr(response, "errorreport", None):
-        return [BfabricRequestError(response.errorreport)]
-    elif endpoint in response:
-        return [BfabricRequestError(r.errorreport) for r in response[endpoint] if getattr(r, "errorreport", None)]
+    if getattr(response, "errorreport", None):  # pyright: ignore[reportAny]
+        return [BfabricRequestError(response.errorreport)]  # pyright: ignore[reportAny]
+    elif hasattr(response, endpoint):  # pyright: ignore[reportAny]
+        return [
+            BfabricRequestError(r.errorreport)  # pyright: ignore[reportAny]
+            for r in getattr(response, endpoint)  # pyright: ignore[reportAny]
+            if getattr(r, "errorreport", None)  # pyright: ignore[reportAny]
+        ]
     else:
         return []

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs_spec.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from typing import Annotated, TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
 from bfabric_app_runner.specs.inputs.bfabric_annotation_spec import BfabricAnnotationSpec
 from bfabric_app_runner.specs.inputs.bfabric_dataset_spec import BfabricDatasetSpec
 from bfabric_app_runner.specs.inputs.bfabric_order_fasta_spec import BfabricOrderFastaSpec
@@ -12,7 +14,6 @@ from bfabric_app_runner.specs.inputs.bfabric_resource_spec import BfabricResourc
 from bfabric_app_runner.specs.inputs.file_spec import FileSpec
 from bfabric_app_runner.specs.inputs.static_file_spec import StaticFileSpec
 from bfabric_app_runner.specs.inputs.static_yaml_spec import StaticYamlSpec
-from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/tests/bfabric/test_errors.py
+++ b/tests/bfabric/test_errors.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from bfabric.errors import BfabricTokenExpiredError, BfabricTokenInvalidError, BfabricTokenValidationFailedError
+from types import SimpleNamespace
+
+from bfabric.errors import (
+    BfabricRequestError,
+    BfabricTokenExpiredError,
+    BfabricTokenInvalidError,
+    BfabricTokenValidationFailedError,
+    get_response_errors,
+)
 
 
 def test_token_expired_error_is_a_validation_failed_error() -> None:
@@ -26,3 +34,109 @@ def test_subclasses_are_distinguishable_via_isinstance() -> None:
     assert not isinstance(expired, BfabricTokenInvalidError)
     assert isinstance(invalid, BfabricTokenInvalidError)
     assert not isinstance(invalid, BfabricTokenExpiredError)
+
+
+# ---- get_response_errors ----
+
+
+class TestGetResponseErrorsTopLevel:
+    """Branch: response has a top-level errorreport attribute."""
+
+    def test_returns_single_error_for_top_level_report(self) -> None:
+        response = SimpleNamespace(errorreport="something went wrong")
+        result = get_response_errors(response, "getDataset")
+
+        assert len(result) == 1
+        assert isinstance(result[0], BfabricRequestError)
+        assert result[0].message == "something went wrong"
+
+    def test_ignores_endpoint_when_top_level_error_present(self) -> None:
+        item = SimpleNamespace(errorreport="item error")
+        response = SimpleNamespace(errorreport="top", getDataset=[item])
+        result = get_response_errors(response, "getDataset")
+
+        assert len(result) == 1
+        assert result[0].message == "top"
+
+    def test_errorreport_empty_string_treated_as_no_error(self) -> None:
+        response = SimpleNamespace(errorreport="")
+        result = get_response_errors(response, "getDataset")
+
+        assert result == []
+
+
+class TestGetResponseErrorsEndpointLevel:
+    """Branch: response[endpoint] is a list of results that may have errorreport."""
+
+    def test_returns_empty_list_when_no_errors(self) -> None:
+        item1 = SimpleNamespace(name="ok1")
+        item2 = SimpleNamespace(name="ok2")
+        response = SimpleNamespace(getDataset=[item1, item2])
+        result = get_response_errors(response, "getDataset")
+
+        assert result == []
+
+    def test_returns_error_for_single_failed_item(self) -> None:
+        ok = SimpleNamespace(name="ok")
+        fail = SimpleNamespace(name="fail", errorreport="bad thing")
+        response = SimpleNamespace(getDataset=[ok, fail])
+        result = get_response_errors(response, "getDataset")
+
+        assert len(result) == 1
+        assert result[0].message == "bad thing"
+
+    def test_returns_error_for_all_failed_items(self) -> None:
+        fail1 = SimpleNamespace(errorreport="err1")
+        fail2 = SimpleNamespace(errorreport="err2")
+        response = SimpleNamespace(getDataset=[fail1, fail2])
+        result = get_response_errors(response, "getDataset")
+
+        assert len(result) == 2
+        assert result[0].message == "err1"
+        assert result[1].message == "err2"
+
+    def test_skips_items_without_errorreport(self) -> None:
+        ok1 = SimpleNamespace(name="a")
+        fail = SimpleNamespace(name="b", errorreport="fail")
+        ok2 = SimpleNamespace(name="c")
+        response = SimpleNamespace(getDataset=[ok1, fail, ok2])
+        result = get_response_errors(response, "getDataset")
+
+        assert len(result) == 1
+        assert result[0].message == "fail"
+
+    def test_errorreport_none_is_skipped(self) -> None:
+        item = SimpleNamespace(name="x", errorreport=None)
+        response = SimpleNamespace(getDataset=[item])
+        result = get_response_errors(response, "getDataset")
+
+        assert result == []
+
+    def test_wrong_endpoint_returns_empty(self) -> None:
+        item = SimpleNamespace(errorreport="err")
+        response = SimpleNamespace(getDataset=[item])
+        result = get_response_errors(response, "getSample")
+
+        assert result == []
+
+
+class TestGetResponseErrorsNoMatch:
+    """Branch: response has neither errorreport nor endpoint key."""
+
+    def test_miserable_dict_returns_empty(self) -> None:
+        response = {}
+        result = get_response_errors(response, "getDataset")
+
+        assert result == []
+
+    def test_dict_with_other_keys_returns_empty(self) -> None:
+        response = {"otherkey": "value"}
+        result = get_response_errors(response, "getDataset")
+
+        assert result == []
+
+    def test_response_with_no_endpoint_and_no_error(self) -> None:
+        response = SimpleNamespace(other="value")
+        result = get_response_errors(response, "getDataset")
+
+        assert result == []


### PR DESCRIPTION
Basedpyright cleanup: drops now-stale baseline suppressions and fixes the findings they were hiding, instead of leaving them grandfathered.