### PR TITLE
fix(ruff): stop TCH from moving pydantic BaseModel field imports into TYPE_CHECKING

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -16,6 +16,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ### Changed
 
 - Removed dead `if <required relationship> is None` guards (in `Workunit.store_output_folder` and `WorkunitExecutionDefinition.from_workunit`) that could never fire — a missing required relationship already raises `ValueError("Field '<name>' is required")` from the descriptor.
+- Added `runtime-evaluated-base-classes = ["pydantic.BaseModel"]` to the ruff `flake8-type-checking` config, so `TC001`/`TC002`/`TC003` no longer suggest moving imports used only in pydantic `BaseModel` field annotations into `if TYPE_CHECKING:` blocks (which would break at runtime, since pydantic resolves field annotations eagerly). Removed the now-unnecessary `# noqa: TC00x` workarounds this uncovered.
 
 ## \[1.20.0rc1\] - 2026-06-23
 

--- a/bfabric/pyproject.toml
+++ b/bfabric/pyproject.toml
@@ -77,6 +77,11 @@ target-version = "py311"
 select = ["ANN", "BLE", "D103", "E", "EXE", "F", "N", "PLW", "PTH", "SIM", "TCH", "UP", "W191"]
 ignore = ["ANN401"]
 
+[tool.ruff.lint.flake8-type-checking]
+# pydantic evaluates model field annotations at runtime, so imports used only in a BaseModel field
+# must stay at runtime -- don't let TCH suggest moving them into an `if TYPE_CHECKING:` block.
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
 [tool.ruff.lint.per-file-ignores]
 "**/bfabric_scripts/**" = ["ALL"]
 "**/wrapper_creator/**" = ["ALL"]

--- a/bfabric/src/bfabric/_oauth/url_token.py
+++ b/bfabric/src/bfabric/_oauth/url_token.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 import time
-from datetime import datetime  # noqa: TC003  # runtime import: pydantic resolves field annotations
+from datetime import datetime
 
 import httpx
 from joserfc import jwt as joserfc_jwt
@@ -89,5 +89,3 @@ def verify_jwt(base_url: str, token: str) -> dict[str, object]:
     claims_registry = joserfc_jwt.JWTClaimsRegistry(exp={"essential": True})
     claims_registry.validate(result.claims)
     return dict(result.claims)
-
-

--- a/bfabric/src/bfabric/config/config_data.py
+++ b/bfabric/src/bfabric/config/config_data.py
@@ -9,7 +9,7 @@ import yaml
 from loguru import logger
 from pydantic import BaseModel
 
-from bfabric.config import BfabricClientConfig, BfabricAuth  # noqa
+from bfabric.config import BfabricClientConfig, BfabricAuth
 from bfabric.config.config_file import ConfigFile
 
 

--- a/bfabric/src/bfabric/entities/core/entity_reader.py
+++ b/bfabric/src/bfabric/entities/core/entity_reader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable  # noqa
 from typing import TYPE_CHECKING, TypeGuard, TypeVar, cast
 
 from loguru import logger
@@ -12,7 +11,7 @@ from bfabric.entities.core.uri import EntityUri, GroupedUris
 from bfabric.experimental import MultiQuery
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
     from bfabric import Bfabric
     from bfabric.typing import ApiRequestObjectType, ApiResponseDataType, ApiResponseObjectType

--- a/bfabric/src/bfabric/experimental/webapp_integration_settings.py
+++ b/bfabric/src/bfabric/experimental/webapp_integration_settings.py
@@ -4,7 +4,7 @@ from typing import Protocol, Self, runtime_checkable
 
 from pydantic import BaseModel, model_validator
 
-from bfabric.config.bfabric_auth import BfabricAuth  # noqa
+from bfabric.config.bfabric_auth import BfabricAuth
 
 
 @runtime_checkable

--- a/bfabric/src/bfabric/experimental/workunit_definition.py
+++ b/bfabric/src/bfabric/experimental/workunit_definition.py
@@ -8,7 +8,7 @@ from loguru import logger
 from pydantic import BaseModel
 
 from bfabric.entities import Workunit
-from bfabric.utils.path_safe_name import PathSafeStr  # noqa: TC001
+from bfabric.utils.path_safe_name import PathSafeStr
 
 if TYPE_CHECKING:
     from bfabric import Bfabric

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `BfabricResourceSpec` gains an `access` field (`ssh`/`http`) selecting the transport used to stage a resource. `access: http` streams the file from the storage's HTTP endpoint instead of rsync/scp — portable, but requires an OAuth-backed client whose token carries the `containers` scope. The generic `file` spec also gained an HTTP source (`FileSourceHttp`), always fetched anonymously. See the input specification docs for details.
 
+### Changed
+
+- Added `runtime-evaluated-base-classes` to the ruff `flake8-type-checking` config (matching `bfabric`), listing `pydantic.BaseModel` and `FromConfigFile`, so `TC001`/`TC002`/`TC003` no longer suggest moving imports used only in pydantic model field annotations into `if TYPE_CHECKING:` blocks. Removed the now-unnecessary per-line `# noqa: TC00x` workarounds and the blanket `cli/**`/`specs/**` per-file-ignores this uncovered.
+
 ### Fixed
 
 - `_register_workflow_step` now raises a clear error when the configured workflow template step is missing or has no workflow template, instead of crashing with an `AttributeError` on `None` (missing template) or logging-and-skipping (missing step). Both cases abort output registration before the workunit is finalized to `available`, so the misconfiguration surfaces instead of leaving a finalized workunit with no workflow-step linkage.

--- a/bfabric_app_runner/pyproject.toml
+++ b/bfabric_app_runner/pyproject.toml
@@ -87,7 +87,9 @@ classmethod-decorators = [
     "pydantic.field_validator",
 ]
 
-[tool.ruff.lint.per-file-ignores]
-# This is needed because of false positives in cyclopts code
-"**/bfabric_app_runner/cli/**" = ["TCH001", "TCH002", "TCH003"]
-"**/bfabric_app_runner/specs/**" = ["TCH001", "TCH002", "TCH003"]
+[tool.ruff.lint.flake8-type-checking]
+# pydantic evaluates model field annotations at runtime, so imports used only in a BaseModel field
+# must stay at runtime -- don't let TC suggest moving them into an `if TYPE_CHECKING:` block.
+# FromConfigFile is listed explicitly because it subclasses BaseModel in another module, and ruff's
+# cross-module base-class resolution doesn't follow that chain on its own.
+runtime-evaluated-base-classes = ["pydantic.BaseModel", "bfabric_app_runner.actions.config_file.FromConfigFile"]

--- a/bfabric_app_runner/src/bfabric_app_runner/actions/types.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/actions/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from enum import Enum
-from pathlib import Path  # noqa
+from pathlib import Path
 from typing import Literal, Annotated
 
 from pydantic import Field

--- a/bfabric_app_runner/src/bfabric_app_runner/bfabric_integration/submitter/config/slurm_params.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/bfabric_integration/submitter/config/slurm_params.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import cast
-from pathlib import Path  # noqa: TC003
+from typing import TYPE_CHECKING, cast
+from pathlib import Path
 
 import yaml
 from pydantic import BaseModel, field_validator
 
-from bfabric.entities import Workunit  # noqa: TC002
 from bfabric.utils.path_safe_name import path_safe_name
 from bfabric_app_runner.bfabric_integration.submitter.config.slurm_workunit_params import (
-    SlurmWorkunitParams,  # noqa: TC001
-)  # noqa: TC001
+    SlurmWorkunitParams,
+)
 from bfabric_app_runner.specs.config_interpolation import VariablesApp, VariablesWorkunit, interpolate_config_strings
+
+if TYPE_CHECKING:
+    from bfabric.entities import Workunit
 
 
 class SlurmParameters(BaseModel):

--- a/bfabric_app_runner/src/bfabric_app_runner/inputs/resolve/resolved_inputs.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/inputs/resolve/resolved_inputs.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from collections import defaultdict
 from typing import Annotated, Literal, Self
 
-from bfabric_app_runner.specs.common_types import RelativeFilePath  # noqa: TC001
-from bfabric_app_runner.specs.inputs.file_spec import FileSourceSsh, FileSourceLocal, FileSourceHttp  # noqa: TC001
+from bfabric_app_runner.specs.common_types import RelativeFilePath
+from bfabric_app_runner.specs.inputs.file_spec import FileSourceSsh, FileSourceLocal, FileSourceHttp
 from pydantic import BaseModel, Field, model_validator
 
 

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/app_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/app_spec.py
@@ -6,7 +6,7 @@ from collections import Counter
 import yaml
 from pydantic import BaseModel, field_validator
 
-from bfabric_app_runner.specs.app.app_version import AppVersion, AppVersionMultiTemplate  # noqa: TCH001
+from bfabric_app_runner.specs.app.app_version import AppVersion, AppVersionMultiTemplate
 from bfabric_app_runner.specs.config_interpolation import VariablesApp
 
 if TYPE_CHECKING:

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/app_version.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/app_version.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from pydantic import BaseModel, field_validator
 
-from bfabric_app_runner.specs.app.commands_spec import CommandsSpec  # noqa: TCH001
+from bfabric_app_runner.specs.app.commands_spec import CommandsSpec
 from bfabric_app_runner.specs.config_interpolation import interpolate_config_strings, VariablesApp
 
 

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_annotation_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_annotation_spec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal, TYPE_CHECKING, Annotated
 
-from bfabric_app_runner.specs.common_types import RelativeFilePath  # noqa: TC001
+from bfabric_app_runner.specs.common_types import RelativeFilePath
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_dataset_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_dataset_spec.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from bfabric_app_runner.specs.common_types import RelativeFilePath  # noqa: TC001
+from bfabric_app_runner.specs.common_types import RelativeFilePath
 
 
 class BfabricDatasetSpec(BaseModel):

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_order_fasta_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_order_fasta_spec.py
@@ -3,7 +3,7 @@ from typing import Literal, TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
-from bfabric_app_runner.specs.common_types import RelativeFilePath  # noqa: TC001
+from bfabric_app_runner.specs.common_types import RelativeFilePath
 
 if TYPE_CHECKING:
     from bfabric import Bfabric

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_resource_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_resource_spec.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from bfabric_app_runner.specs.common_types import RelativeFilePath  # noqa: TC001
+from bfabric_app_runner.specs.common_types import RelativeFilePath
 
 
 class BfabricResourceSpec(BaseModel):

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/file_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/file_spec.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal, TYPE_CHECKING, Self
 
-from bfabric_app_runner.specs.common_types import RelativeFilePath, AbsoluteFilePath  # noqa: TC001
+from bfabric_app_runner.specs.common_types import RelativeFilePath, AbsoluteFilePath
 from pydantic import BaseModel, model_validator
 
 if TYPE_CHECKING:

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/outputs_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/outputs_spec.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import enum
-from pathlib import Path  # noqa: TCH003
+from pathlib import Path
 from typing import Literal, Annotated
 
 import yaml


### PR DESCRIPTION
Purely a code style issue which was discovered in a bigger PR so excluding it now for easier reviewing later.

🤖 Prepared with assistance from Claude Sonnet 5 via Claude Code.