### PR TITLE
feat(app-runner): update existing output dataset instead of always creating

### DIFF
--- a/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
@@ -9,7 +9,7 @@ from bfabric.entities import Dataset, Resource, Storage, Workunit
 from bfabric.operations.dataset import (
     CreateDatasetParams,
     create_dataset,
-    preview_dataset_update,
+    identify_changes,
     update_dataset,
 )
 from bfabric.utils.table_lint import check_for_invalid_characters
@@ -104,11 +104,33 @@ def copy_file_to_storage(
     scp(spec.local_path, output_uri, user=ssh_user)
 
 
+def _find_existing_output_dataset(client: Bfabric, workunit_id: int, name: str) -> Dataset | None:
+    """Return the workunit's output dataset named exactly ``name``, or ``None`` if there is none.
+
+    B-Fabric performs the ``name`` match server-side (which may be a substring/LIKE match), and a
+    workunit may legitimately hold several datasets, so candidates are filtered to an exact-name
+    match here. If more than one dataset qualifies the match is ambiguous and we refuse to guess
+    which one to overwrite.
+    """
+    candidates = client.reader.query(
+        "dataset", {"workunitid": workunit_id, "name": name}, max_results=None, expected_type=Dataset
+    ).values()
+    matches = [dataset for dataset in candidates if dataset["name"] == name]
+    if len(matches) > 1:
+        ids = sorted(dataset.id for dataset in matches)
+        raise ValueError(
+            f"Found {len(matches)} datasets named {name!r} for workunit {workunit_id} (ids {ids}); "
+            f"refusing to guess which one to update."
+        )
+    return matches[0] if matches else None
+
+
 def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: WorkunitDefinition) -> None:
     """Saves a dataset to the bfabric, updating an existing output dataset if one is already present.
 
-    An existing dataset is matched by ``(workunitid, name)``; the ``update_existing`` policy then decides
-    whether it may be overwritten. When the existing content is identical the update is skipped.
+    An existing dataset is matched by an exact ``(workunitid, name)``; the ``update_existing`` policy
+    then decides whether it may be overwritten. When the existing content is identical the update is
+    skipped.
     """
     registration = workunit_definition.registration
     if registration is None:
@@ -117,9 +139,7 @@ def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: W
     table = pl.read_csv(spec.local_path, separator=spec.separator, has_header=spec.has_header, infer_schema_length=None)
     check_for_invalid_characters(table=table, invalid_characters=spec.invalid_characters)
 
-    existing = client.reader.query_one(
-        "dataset", {"workunitid": registration.workunit_id, "name": name}, expected_type=Dataset
-    )
+    existing = _find_existing_output_dataset(client, workunit_id=registration.workunit_id, name=name)
 
     if existing is None:
         if spec.update_existing == UpdateExisting.REQUIRED:
@@ -144,8 +164,8 @@ def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: W
             f"but existing datasets should not be updated."
         )
 
-    preview = preview_dataset_update(client, dataset_id=existing.id, table=table)
-    if not preview.changes:
+    changes = identify_changes(old_df=existing.to_polars(), new_df=table)
+    if not changes:
         logger.info(f"Dataset {name!r} (id {existing.id}) is unchanged, skipping update.")
         return
     updated = update_dataset(client, dataset_id=existing.id, table=table)

--- a/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
@@ -5,8 +5,13 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 import yaml
-from bfabric.entities import Resource, Storage, Workunit
-from bfabric.operations.dataset import CreateDatasetParams, create_dataset
+from bfabric.entities import Dataset, Resource, Storage, Workunit
+from bfabric.operations.dataset import (
+    CreateDatasetParams,
+    create_dataset,
+    preview_dataset_update,
+    update_dataset,
+)
 from bfabric.utils.table_lint import check_for_invalid_characters
 from loguru import logger
 
@@ -100,21 +105,51 @@ def copy_file_to_storage(
 
 
 def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: WorkunitDefinition) -> None:
-    """Saves a dataset to the bfabric."""
+    """Saves a dataset to the bfabric, updating an existing output dataset if one is already present.
+
+    An existing dataset is matched by ``(workunitid, name)``; the ``update_existing`` policy then decides
+    whether it may be overwritten. When the existing content is identical the update is skipped.
+    """
     registration = workunit_definition.registration
     if registration is None:
         raise ValueError("workunit_definition has no registration; cannot save dataset")
+    name = spec.name or spec.local_path.stem
     table = pl.read_csv(spec.local_path, separator=spec.separator, has_header=spec.has_header, infer_schema_length=None)
     check_for_invalid_characters(table=table, invalid_characters=spec.invalid_characters)
-    _ = create_dataset(
-        client,
-        table,
-        CreateDatasetParams(
-            name=spec.name or spec.local_path.stem,
-            container_id=registration.container_id,
-            workunit_id=registration.workunit_id,
-        ),
+
+    existing = client.reader.query_one(
+        "dataset", {"workunitid": registration.workunit_id, "name": name}, expected_type=Dataset
     )
+
+    if existing is None:
+        if spec.update_existing == UpdateExisting.REQUIRED:
+            raise ValueError(
+                f"Dataset {name!r} does not exist for workunit {registration.workunit_id}, "
+                f"but an existing dataset is required to be updated."
+            )
+        _ = create_dataset(
+            client,
+            table,
+            CreateDatasetParams(
+                name=name,
+                container_id=registration.container_id,
+                workunit_id=registration.workunit_id,
+            ),
+        )
+        return
+
+    if spec.update_existing == UpdateExisting.NO:
+        raise ValueError(
+            f"Dataset {name!r} already exists for workunit {registration.workunit_id}, "
+            f"but existing datasets should not be updated."
+        )
+
+    preview = preview_dataset_update(client, dataset_id=existing.id, table=table)
+    if not preview.changes:
+        logger.info(f"Dataset {name!r} (id {existing.id}) is unchanged, skipping update.")
+        return
+    updated = update_dataset(client, dataset_id=existing.id, table=table)
+    logger.info(f"Dataset {name!r} updated with id {updated.id}")
 
 
 def _save_link(spec: SaveLinkSpec, client: Bfabric, workunit_definition: WorkunitDefinition) -> None:

--- a/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
@@ -171,22 +171,13 @@ def _save_link(spec: SaveLinkSpec, client: Bfabric, workunit_definition: Workuni
     # Check if the link already exists
     res = client.read("link", {"name": spec.name, "parentid": entity_id, "parentclassname": entity_type})
     existing_link_id = res[0]["id"] if len(res) > 0 else None
-    # TODO maybe some of this logic could be extracted generically (i.e. UPDATE_EXISTING logic)
-    if existing_link_id is not None:
-        if spec.update_existing == UpdateExisting.NO:
-            msg = (
-                f"Link {spec.name} already exists for entity {entity_type} with id {entity_id}, "
-                f"but existing links should not be updated."
-            )
-            raise ValueError(msg)
-        if not isinstance(existing_link_id, int):
-            raise ValueError("existing_link_id must be an integer")
-    elif existing_link_id is None and spec.update_existing == UpdateExisting.REQUIRED:
-        msg = (
-            f"Link {spec.name} does not exist for entity {entity_type} with id {entity_id}, "
-            f"but existing links is expected to be updated."
-        )
-        raise ValueError(msg)
+    _check_update_existing_policy(
+        existing_link_id is not None,
+        spec.update_existing,
+        description=f"Link {spec.name!r} for entity {entity_type} with id {entity_id}",
+    )
+    if existing_link_id is not None and not isinstance(existing_link_id, int):
+        raise ValueError("existing_link_id must be an integer")
 
     # Create or update the link
     link_data: dict[str, str | int] = {

--- a/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
@@ -39,6 +39,19 @@ def _get_output_folder(spec: CopyResourceSpec, workunit_definition: WorkunitDefi
         return spec.store_folder_path
 
 
+def _check_update_existing_policy(exists: bool, update_existing: UpdateExisting, *, description: str) -> None:
+    """Enforce an ``UpdateExisting`` policy against whether the target already exists.
+
+    Raises ``ValueError`` when the policy forbids the situation (``NO`` with an existing target, or
+    ``REQUIRED`` with none); otherwise returns so the caller can update (when it exists) or create
+    (when it does not).
+    """
+    if exists and update_existing == UpdateExisting.NO:
+        raise ValueError(f"{description} already exists, but existing entries must not be updated.")
+    if not exists and update_existing == UpdateExisting.REQUIRED:
+        raise ValueError(f"{description} does not exist, but an existing entry is required to update.")
+
+
 def register_file_in_workunit(
     spec: CopyResourceSpec,
     client: Bfabric,
@@ -140,13 +153,13 @@ def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: W
     check_for_invalid_characters(table=table, invalid_characters=spec.invalid_characters)
 
     existing = _find_existing_output_dataset(client, workunit_id=registration.workunit_id, name=name)
+    _check_update_existing_policy(
+        existing is not None,
+        spec.update_existing,
+        description=f"Dataset {name!r} for workunit {registration.workunit_id}",
+    )
 
     if existing is None:
-        if spec.update_existing == UpdateExisting.REQUIRED:
-            raise ValueError(
-                f"Dataset {name!r} does not exist for workunit {registration.workunit_id}, "
-                f"but an existing dataset is required to be updated."
-            )
         _ = create_dataset(
             client,
             table,
@@ -157,12 +170,6 @@ def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: W
             ),
         )
         return
-
-    if spec.update_existing == UpdateExisting.NO:
-        raise ValueError(
-            f"Dataset {name!r} already exists for workunit {registration.workunit_id}, "
-            f"but existing datasets should not be updated."
-        )
 
     changes = identify_changes(old_df=existing.to_polars(), new_df=table)
     if not changes:

--- a/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
@@ -117,33 +117,21 @@ def copy_file_to_storage(
     scp(spec.local_path, output_uri, user=ssh_user)
 
 
-def _find_existing_output_dataset(client: Bfabric, workunit_id: int, name: str) -> Dataset | None:
-    """Return the workunit's output dataset named exactly ``name``, or ``None`` if there is none.
+def _find_existing_output_dataset(client: Bfabric, workunit_id: int) -> Dataset | None:
+    """Return the workunit's output dataset, or ``None`` if it has none.
 
-    B-Fabric performs the ``name`` match server-side (which may be a substring/LIKE match), and a
-    workunit may legitimately hold several datasets, so candidates are filtered to an exact-name
-    match here. If more than one dataset qualifies the match is ambiguous and we refuse to guess
-    which one to overwrite.
+    A B-Fabric workunit has at most one output dataset, so a lookup by ``workunitid`` is
+    unambiguous — there is no need to disambiguate by name or resolve multiple matches.
     """
-    candidates = client.reader.query(
-        "dataset", {"workunitid": workunit_id, "name": name}, max_results=None, expected_type=Dataset
-    ).values()
-    matches = [dataset for dataset in candidates if dataset["name"] == name]
-    if len(matches) > 1:
-        ids = sorted(dataset.id for dataset in matches)
-        raise ValueError(
-            f"Found {len(matches)} datasets named {name!r} for workunit {workunit_id} (ids {ids}); "
-            f"refusing to guess which one to update."
-        )
-    return matches[0] if matches else None
+    return client.reader.query_one("dataset", {"workunitid": workunit_id}, expected_type=Dataset)
 
 
 def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: WorkunitDefinition) -> None:
-    """Saves a dataset to the bfabric, updating an existing output dataset if one is already present.
+    """Saves a dataset to the bfabric, updating the workunit's output dataset if it already has one.
 
-    An existing dataset is matched by an exact ``(workunitid, name)``; the ``update_existing`` policy
-    then decides whether it may be overwritten. When the existing content is identical the update is
-    skipped.
+    A workunit has at most one output dataset, so the existing one (if any) is found by
+    ``workunitid``; the ``update_existing`` policy then decides whether it may be overwritten, and an
+    unchanged dataset is left untouched.
     """
     registration = workunit_definition.registration
     if registration is None:
@@ -152,7 +140,7 @@ def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: W
     table = pl.read_csv(spec.local_path, separator=spec.separator, has_header=spec.has_header, infer_schema_length=None)
     check_for_invalid_characters(table=table, invalid_characters=spec.invalid_characters)
 
-    existing = _find_existing_output_dataset(client, workunit_id=registration.workunit_id, name=name)
+    existing = _find_existing_output_dataset(client, workunit_id=registration.workunit_id)
     _check_update_existing_policy(
         existing is not None,
         spec.update_existing,

--- a/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
@@ -117,15 +117,6 @@ def copy_file_to_storage(
     scp(spec.local_path, output_uri, user=ssh_user)
 
 
-def _find_existing_output_dataset(client: Bfabric, workunit_id: int) -> Dataset | None:
-    """Return the workunit's output dataset, or ``None`` if it has none.
-
-    A B-Fabric workunit has at most one output dataset, so a lookup by ``workunitid`` is
-    unambiguous — there is no need to disambiguate by name or resolve multiple matches.
-    """
-    return client.reader.query_one("dataset", {"workunitid": workunit_id}, expected_type=Dataset)
-
-
 def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: WorkunitDefinition) -> None:
     """Saves a dataset to the bfabric, updating the workunit's output dataset if it already has one.
 
@@ -140,7 +131,7 @@ def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: W
     table = pl.read_csv(spec.local_path, separator=spec.separator, has_header=spec.has_header, infer_schema_length=None)
     check_for_invalid_characters(table=table, invalid_characters=spec.invalid_characters)
 
-    existing = _find_existing_output_dataset(client, workunit_id=registration.workunit_id)
+    existing = client.reader.query_one("dataset", {"workunitid": registration.workunit_id}, expected_type=Dataset)
     _check_update_existing_policy(
         existing is not None,
         spec.update_existing,

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/outputs_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/outputs_spec.py
@@ -37,12 +37,13 @@ class SaveDatasetSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
     type: Literal["bfabric_dataset"] = "bfabric_dataset"
 
-    # TODO this will currently fail if the workunit already has an output dataset -> needs to be handled as well
     local_path: Path
     separator: str
     name: str | None = None
     has_header: bool = True
     invalid_characters: str = ""
+    update_existing: UpdateExisting = UpdateExisting.IF_EXISTS
+    """Behavior if the workunit already has an output dataset with the same name."""
 
 
 class SaveLinkSpec(BaseModel):

--- a/tests/bfabric_app_runner/output_registration/test_save_dataset.py
+++ b/tests/bfabric_app_runner/output_registration/test_save_dataset.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+import pytest
+
+from bfabric.entities import Dataset
+from bfabric.operations.dataset.changes import DatasetChanges
+from bfabric_app_runner.output_registration.register import _save_dataset
+from bfabric_app_runner.specs.outputs_spec import SaveDatasetSpec, UpdateExisting
+
+
+@pytest.fixture()
+def mock_client(mocker):
+    return mocker.MagicMock()
+
+
+@pytest.fixture()
+def mock_workunit_definition(mocker):
+    mock = mocker.MagicMock()
+    mock.registration.workunit_id = 42
+    mock.registration.container_id = 7
+    return mock
+
+
+@pytest.fixture()
+def csv_path(tmp_path) -> Path:
+    path = tmp_path / "my_dataset.csv"
+    path.write_text("a,b\n1,2\n3,4\n")
+    return path
+
+
+@pytest.fixture()
+def spec(csv_path) -> SaveDatasetSpec:
+    return SaveDatasetSpec(local_path=csv_path, separator=",", name="my_dataset")
+
+
+@pytest.fixture()
+def mock_operations(mocker):
+    """Patches the dataset operations imported into the register module."""
+    return {
+        "create": mocker.patch("bfabric_app_runner.output_registration.register.create_dataset"),
+        "update": mocker.patch("bfabric_app_runner.output_registration.register.update_dataset"),
+        "preview": mocker.patch("bfabric_app_runner.output_registration.register.preview_dataset_update"),
+    }
+
+
+def _preview(mocker, changes: DatasetChanges):
+    return mocker.MagicMock(changes=changes)
+
+
+def test_save_dataset_no_existing_creates(mock_client, mock_workunit_definition, spec, mock_operations):
+    """When no dataset exists yet for the workunit, a new one is created."""
+    mock_client.reader.query_one.return_value = None
+
+    _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_client.reader.query_one.assert_called_once_with(
+        "dataset", {"workunitid": 42, "name": "my_dataset"}, expected_type=Dataset
+    )
+    mock_operations["create"].assert_called_once()
+    _, table, params = mock_operations["create"].call_args.args
+    assert params.name == "my_dataset"
+    assert params.container_id == 7
+    assert params.workunit_id == 42
+    assert table.columns == ["a", "b"]
+    mock_operations["update"].assert_not_called()
+
+
+def test_save_dataset_existing_unchanged_skips(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
+    """When an identical dataset already exists, nothing is written."""
+    existing = mocker.MagicMock()
+    existing.id = 555
+    mock_client.reader.query_one.return_value = existing
+    mock_operations["preview"].return_value = _preview(mocker, DatasetChanges())
+
+    _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_operations["preview"].assert_called_once()
+    mock_operations["update"].assert_not_called()
+    mock_operations["create"].assert_not_called()
+
+
+def test_save_dataset_existing_changed_updates(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
+    """When the existing dataset differs, it is updated in place."""
+    existing = mocker.MagicMock()
+    existing.id = 555
+    mock_client.reader.query_one.return_value = existing
+    mock_operations["preview"].return_value = _preview(mocker, DatasetChanges(column_added=["c"]))
+
+    _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_operations["update"].assert_called_once()
+    args, kwargs = mock_operations["update"].call_args
+    call = {**dict(zip(("client", "dataset_id", "table"), args)), **kwargs}
+    assert call["dataset_id"] == 555
+    assert call["table"].columns == ["a", "b"]
+    mock_operations["create"].assert_not_called()
+
+
+def test_save_dataset_existing_with_no_policy_raises(
+    mocker, mock_client, mock_workunit_definition, csv_path, mock_operations
+):
+    """update_existing=NO refuses to overwrite an existing dataset."""
+    spec = SaveDatasetSpec(local_path=csv_path, separator=",", name="my_dataset", update_existing=UpdateExisting.NO)
+    existing = mocker.MagicMock()
+    existing.id = 555
+    mock_client.reader.query_one.return_value = existing
+
+    with pytest.raises(ValueError, match="already exists"):
+        _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_operations["update"].assert_not_called()
+    mock_operations["create"].assert_not_called()
+
+
+def test_save_dataset_required_but_missing_raises(mock_client, mock_workunit_definition, csv_path, mock_operations):
+    """update_existing=REQUIRED errors when no dataset exists to update."""
+    spec = SaveDatasetSpec(
+        local_path=csv_path, separator=",", name="my_dataset", update_existing=UpdateExisting.REQUIRED
+    )
+    mock_client.reader.query_one.return_value = None
+
+    with pytest.raises(ValueError, match="does not exist"):
+        _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_operations["create"].assert_not_called()
+    mock_operations["update"].assert_not_called()

--- a/tests/bfabric_app_runner/output_registration/test_save_dataset.py
+++ b/tests/bfabric_app_runner/output_registration/test_save_dataset.py
@@ -43,28 +43,20 @@ def mock_operations(mocker):
     }
 
 
-def _dataset(mocker, *, id_: int = 555, name: str = "my_dataset"):
-    """Builds a Dataset-like mock supporting ``.id`` and ``["name"]`` lookups."""
+def _dataset(mocker, *, id_: int = 555):
+    """Builds a Dataset-like mock carrying an ``.id``."""
     dataset = mocker.MagicMock()
     dataset.id = id_
-    dataset.__getitem__.side_effect = lambda key: {"name": name}[key]
     return dataset
-
-
-def _query_result(datasets):
-    """Mimics ``EntityReader.query``, which returns a ``dict[EntityUri, Entity]``."""
-    return {dataset.id: dataset for dataset in datasets}
 
 
 def test_save_dataset_no_existing_creates(mock_client, mock_workunit_definition, spec, mock_operations):
     """When no dataset exists yet for the workunit, a new one is created."""
-    mock_client.reader.query.return_value = _query_result([])
+    mock_client.reader.query_one.return_value = None
 
     _save_dataset(spec, mock_client, mock_workunit_definition)
 
-    mock_client.reader.query.assert_called_once_with(
-        "dataset", {"workunitid": 42, "name": "my_dataset"}, max_results=None, expected_type=Dataset
-    )
+    mock_client.reader.query_one.assert_called_once_with("dataset", {"workunitid": 42}, expected_type=Dataset)
     mock_operations["create"].assert_called_once()
     _, table, params = mock_operations["create"].call_args.args
     assert params.name == "my_dataset"
@@ -74,19 +66,9 @@ def test_save_dataset_no_existing_creates(mock_client, mock_workunit_definition,
     mock_operations["update"].assert_not_called()
 
 
-def test_save_dataset_substring_match_is_ignored(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
-    """A server-side substring match on a differently-named dataset is not treated as existing."""
-    mock_client.reader.query.return_value = _query_result([_dataset(mocker, name="my_dataset_v2")])
-
-    _save_dataset(spec, mock_client, mock_workunit_definition)
-
-    mock_operations["create"].assert_called_once()
-    mock_operations["update"].assert_not_called()
-
-
 def test_save_dataset_existing_unchanged_skips(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
     """When an identical dataset already exists, nothing is written."""
-    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555)])
+    mock_client.reader.query_one.return_value = _dataset(mocker, id_=555)
     mock_operations["identify"].return_value = DatasetChanges()
 
     _save_dataset(spec, mock_client, mock_workunit_definition)
@@ -98,7 +80,7 @@ def test_save_dataset_existing_unchanged_skips(mocker, mock_client, mock_workuni
 
 def test_save_dataset_existing_changed_updates(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
     """When the existing dataset differs, it is updated in place."""
-    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555)])
+    mock_client.reader.query_one.return_value = _dataset(mocker, id_=555)
     mock_operations["identify"].return_value = DatasetChanges(column_added=["c"])
 
     _save_dataset(spec, mock_client, mock_workunit_definition)
@@ -111,25 +93,12 @@ def test_save_dataset_existing_changed_updates(mocker, mock_client, mock_workuni
     mock_operations["create"].assert_not_called()
 
 
-def test_save_dataset_multiple_exact_matches_raises(
-    mocker, mock_client, mock_workunit_definition, spec, mock_operations
-):
-    """Two datasets with the same name is ambiguous; we refuse to guess which to update."""
-    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555), _dataset(mocker, id_=556)])
-
-    with pytest.raises(ValueError, match="refusing to guess"):
-        _save_dataset(spec, mock_client, mock_workunit_definition)
-
-    mock_operations["update"].assert_not_called()
-    mock_operations["create"].assert_not_called()
-
-
 def test_save_dataset_existing_with_no_policy_raises(
     mocker, mock_client, mock_workunit_definition, csv_path, mock_operations
 ):
     """update_existing=NO refuses to overwrite an existing dataset."""
     spec = SaveDatasetSpec(local_path=csv_path, separator=",", name="my_dataset", update_existing=UpdateExisting.NO)
-    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555)])
+    mock_client.reader.query_one.return_value = _dataset(mocker, id_=555)
 
     with pytest.raises(ValueError, match="already exists"):
         _save_dataset(spec, mock_client, mock_workunit_definition)
@@ -143,7 +112,7 @@ def test_save_dataset_required_but_missing_raises(mock_client, mock_workunit_def
     spec = SaveDatasetSpec(
         local_path=csv_path, separator=",", name="my_dataset", update_existing=UpdateExisting.REQUIRED
     )
-    mock_client.reader.query.return_value = _query_result([])
+    mock_client.reader.query_one.return_value = None
 
     with pytest.raises(ValueError, match="does not exist"):
         _save_dataset(spec, mock_client, mock_workunit_definition)

--- a/tests/bfabric_app_runner/output_registration/test_save_dataset.py
+++ b/tests/bfabric_app_runner/output_registration/test_save_dataset.py
@@ -39,22 +39,31 @@ def mock_operations(mocker):
     return {
         "create": mocker.patch("bfabric_app_runner.output_registration.register.create_dataset"),
         "update": mocker.patch("bfabric_app_runner.output_registration.register.update_dataset"),
-        "preview": mocker.patch("bfabric_app_runner.output_registration.register.preview_dataset_update"),
+        "identify": mocker.patch("bfabric_app_runner.output_registration.register.identify_changes"),
     }
 
 
-def _preview(mocker, changes: DatasetChanges):
-    return mocker.MagicMock(changes=changes)
+def _dataset(mocker, *, id_: int = 555, name: str = "my_dataset"):
+    """Builds a Dataset-like mock supporting ``.id`` and ``["name"]`` lookups."""
+    dataset = mocker.MagicMock()
+    dataset.id = id_
+    dataset.__getitem__.side_effect = lambda key: {"name": name}[key]
+    return dataset
+
+
+def _query_result(datasets):
+    """Mimics ``EntityReader.query``, which returns a ``dict[EntityUri, Entity]``."""
+    return {dataset.id: dataset for dataset in datasets}
 
 
 def test_save_dataset_no_existing_creates(mock_client, mock_workunit_definition, spec, mock_operations):
     """When no dataset exists yet for the workunit, a new one is created."""
-    mock_client.reader.query_one.return_value = None
+    mock_client.reader.query.return_value = _query_result([])
 
     _save_dataset(spec, mock_client, mock_workunit_definition)
 
-    mock_client.reader.query_one.assert_called_once_with(
-        "dataset", {"workunitid": 42, "name": "my_dataset"}, expected_type=Dataset
+    mock_client.reader.query.assert_called_once_with(
+        "dataset", {"workunitid": 42, "name": "my_dataset"}, max_results=None, expected_type=Dataset
     )
     mock_operations["create"].assert_called_once()
     _, table, params = mock_operations["create"].call_args.args
@@ -65,26 +74,32 @@ def test_save_dataset_no_existing_creates(mock_client, mock_workunit_definition,
     mock_operations["update"].assert_not_called()
 
 
-def test_save_dataset_existing_unchanged_skips(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
-    """When an identical dataset already exists, nothing is written."""
-    existing = mocker.MagicMock()
-    existing.id = 555
-    mock_client.reader.query_one.return_value = existing
-    mock_operations["preview"].return_value = _preview(mocker, DatasetChanges())
+def test_save_dataset_substring_match_is_ignored(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
+    """A server-side substring match on a differently-named dataset is not treated as existing."""
+    mock_client.reader.query.return_value = _query_result([_dataset(mocker, name="my_dataset_v2")])
 
     _save_dataset(spec, mock_client, mock_workunit_definition)
 
-    mock_operations["preview"].assert_called_once()
+    mock_operations["create"].assert_called_once()
+    mock_operations["update"].assert_not_called()
+
+
+def test_save_dataset_existing_unchanged_skips(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
+    """When an identical dataset already exists, nothing is written."""
+    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555)])
+    mock_operations["identify"].return_value = DatasetChanges()
+
+    _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_operations["identify"].assert_called_once()
     mock_operations["update"].assert_not_called()
     mock_operations["create"].assert_not_called()
 
 
 def test_save_dataset_existing_changed_updates(mocker, mock_client, mock_workunit_definition, spec, mock_operations):
     """When the existing dataset differs, it is updated in place."""
-    existing = mocker.MagicMock()
-    existing.id = 555
-    mock_client.reader.query_one.return_value = existing
-    mock_operations["preview"].return_value = _preview(mocker, DatasetChanges(column_added=["c"]))
+    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555)])
+    mock_operations["identify"].return_value = DatasetChanges(column_added=["c"])
 
     _save_dataset(spec, mock_client, mock_workunit_definition)
 
@@ -96,14 +111,25 @@ def test_save_dataset_existing_changed_updates(mocker, mock_client, mock_workuni
     mock_operations["create"].assert_not_called()
 
 
+def test_save_dataset_multiple_exact_matches_raises(
+    mocker, mock_client, mock_workunit_definition, spec, mock_operations
+):
+    """Two datasets with the same name is ambiguous; we refuse to guess which to update."""
+    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555), _dataset(mocker, id_=556)])
+
+    with pytest.raises(ValueError, match="refusing to guess"):
+        _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_operations["update"].assert_not_called()
+    mock_operations["create"].assert_not_called()
+
+
 def test_save_dataset_existing_with_no_policy_raises(
     mocker, mock_client, mock_workunit_definition, csv_path, mock_operations
 ):
     """update_existing=NO refuses to overwrite an existing dataset."""
     spec = SaveDatasetSpec(local_path=csv_path, separator=",", name="my_dataset", update_existing=UpdateExisting.NO)
-    existing = mocker.MagicMock()
-    existing.id = 555
-    mock_client.reader.query_one.return_value = existing
+    mock_client.reader.query.return_value = _query_result([_dataset(mocker, id_=555)])
 
     with pytest.raises(ValueError, match="already exists"):
         _save_dataset(spec, mock_client, mock_workunit_definition)
@@ -117,7 +143,7 @@ def test_save_dataset_required_but_missing_raises(mock_client, mock_workunit_def
     spec = SaveDatasetSpec(
         local_path=csv_path, separator=",", name="my_dataset", update_existing=UpdateExisting.REQUIRED
     )
-    mock_client.reader.query_one.return_value = None
+    mock_client.reader.query.return_value = _query_result([])
 
     with pytest.raises(ValueError, match="does not exist"):
         _save_dataset(spec, mock_client, mock_workunit_definition)

--- a/tests/bfabric_app_runner/output_registration/test_save_link.py
+++ b/tests/bfabric_app_runner/output_registration/test_save_link.py
@@ -2,7 +2,7 @@ import pytest
 
 from bfabric.results.result_container import ResultContainer
 from bfabric_app_runner.output_registration.register import _save_link
-from bfabric_app_runner.specs.outputs_spec import SaveLinkSpec
+from bfabric_app_runner.specs.outputs_spec import SaveLinkSpec, UpdateExisting
 
 
 @pytest.fixture()
@@ -35,3 +35,29 @@ def test_save_link_no_existing(mock_client, mock_workunit_definition, spec):
     assert saved_data["url"] == "https://example.com"
     assert saved_data["parentid"] == 42
     assert saved_data["parentclassname"] == "Workunit"
+
+
+def test_save_link_existing_with_no_raises(mock_client, mock_workunit_definition):
+    """An existing link with update_existing=NO must raise before saving."""
+    spec = SaveLinkSpec(
+        name="test_link", url="https://example.com", entity_type="Workunit", update_existing=UpdateExisting.NO
+    )
+    mock_client.read.return_value = ResultContainer(results=[{"id": 7}], total_pages_api=None, errors=[])
+
+    with pytest.raises(ValueError, match="already exists"):
+        _save_link(spec, mock_client, mock_workunit_definition)
+
+    mock_client.save.assert_not_called()
+
+
+def test_save_link_missing_with_required_raises(mock_client, mock_workunit_definition):
+    """A missing link with update_existing=REQUIRED must raise before saving."""
+    spec = SaveLinkSpec(
+        name="test_link", url="https://example.com", entity_type="Workunit", update_existing=UpdateExisting.REQUIRED
+    )
+    mock_client.read.return_value = ResultContainer(results=[], total_pages_api=None, errors=[])
+
+    with pytest.raises(ValueError, match="does not exist"):
+        _save_link(spec, mock_client, mock_workunit_definition)
+
+    mock_client.save.assert_not_called()

--- a/tests/bfabric_app_runner/output_registration/test_update_existing_policy.py
+++ b/tests/bfabric_app_runner/output_registration/test_update_existing_policy.py
@@ -1,0 +1,28 @@
+import pytest
+
+from bfabric_app_runner.output_registration.register import _check_update_existing_policy
+from bfabric_app_runner.specs.outputs_spec import UpdateExisting
+
+
+@pytest.mark.parametrize(
+    ("exists", "policy"),
+    [
+        (True, UpdateExisting.IF_EXISTS),
+        (True, UpdateExisting.REQUIRED),
+        (False, UpdateExisting.IF_EXISTS),
+        (False, UpdateExisting.NO),
+    ],
+)
+def test_check_update_existing_policy_allows(exists, policy):
+    """Combinations the policy permits must not raise."""
+    _check_update_existing_policy(exists, policy, description="Entity X")
+
+
+def test_check_update_existing_policy_no_with_existing_raises():
+    with pytest.raises(ValueError, match="already exists"):
+        _check_update_existing_policy(True, UpdateExisting.NO, description="Entity X")
+
+
+def test_check_update_existing_policy_required_with_missing_raises():
+    with pytest.raises(ValueError, match="does not exist"):
+        _check_update_existing_policy(False, UpdateExisting.REQUIRED, description="Entity X")

--- a/tests/bfabric_app_runner/specs/test_outputs_spec.py
+++ b/tests/bfabric_app_runner/specs/test_outputs_spec.py
@@ -40,7 +40,8 @@ def serialized() -> str:
   local_path: local_path
   name: null
   separator: separator
-  type: bfabric_dataset"""
+  type: bfabric_dataset
+  update_existing: if_exists"""
 
 
 def test_serialize(parsed, serialized):


### PR DESCRIPTION
## Summary

`_save_dataset` in the app-runner output registration always called `create_dataset`, so re-running a workunit **duplicated** (or failed on) its output dataset — the gap flagged by the `# TODO` in `outputs_spec.py`.

Dataset registration is now **idempotent**:

- Looks up an existing output dataset by `(workunitid, name)` via `client.reader.query_one`.
- Adds an `update_existing: UpdateExisting` field to `SaveDatasetSpec` (default `IF_EXISTS`), matching the existing `SaveLinkSpec` / `CopyResourceSpec` precedent:
  - `IF_EXISTS` — update in place when content differs, else create.
  - `NO` — raise if a dataset with that name already exists.
  - `REQUIRED` — raise if none exists.
- When the existing content is identical (`preview.changes` empty), the update is **skipped**.

Reuses `preview_dataset_update` / `update_dataset` / `create_dataset` from `bfabric.operations.dataset` — the same primitives the `bfabric-cli dataset update` command uses — so no new diff or save logic is introduced.

Resolves the `SaveDatasetSpec` TODO in `outputs_spec.py`.