### PR TITLE
fix(ci): show ✅ instead of ❌ for removed TODOs in PR comment

### DIFF
--- a/.github/actions/todo-diff/check_todos.py
+++ b/.github/actions/todo-diff/check_todos.py
@@ -156,7 +156,7 @@ def generate_summary(changes: Dict) -> str:
     if added_count > 0:
         parts.append(f"➕ {added_count} \"TODO\"{'s' if added_count != 1 else ''} added")
     if removed_count > 0:
-        parts.append(f"❌ {removed_count} \"TODO\"{'s' if removed_count != 1 else ''} removed")
+        parts.append(f"✅ {removed_count} \"TODO\"{'s' if removed_count != 1 else ''} removed")
     if modified_count > 0:
         parts.append(f"📝 {modified_count} \"TODO\"{'s' if modified_count != 1 else ''} modified")
 

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -94,7 +94,7 @@ jobs:
             }
 
             if (details.removed && details.removed.length > 0) {
-              commentBody += `### ❌ Removed "TODO"s (${details.removed.length})\n`;
+              commentBody += `### ✅ Removed "TODO"s (${details.removed.length})\n`;
               for (const todo of details.removed) {
                 commentBody += `- \`${todo.file_path}:${todo.line_number}\`: ${todo.content}\n`;
               }


### PR DESCRIPTION
The `todo-diff` action posts a PR comment listing TODO changes between base and head. Removed TODOs were rendered with ❌, which reads as an error — but removing a TODO means a task got resolved. This swaps the removed marker to ✅ in both the summary line (`check_todos.py`) and the comment's *Removed* section heading (`run_unit_tests.yml`).

Added (➕) and modified (📝) markers, and the comment header (📝), are unchanged. The header is left intact deliberately so the existing-comment lookup still matches and updates in place.