### PR TITLE
fix(app-runner): pin app environment to Python 3.13 (#494)

### DIFF
--- a/.basedpyright/baseline.bfabric_app_runner.json
+++ b/.basedpyright/baseline.bfabric_app_runner.json
@@ -1242,14 +1242,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnusedCallResult",
                 "range": {
                     "startColumn": 0,

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -11,10 +11,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Added `runtime-evaluated-base-classes` to the ruff `flake8-type-checking` config (matching `bfabric`), listing `pydantic.BaseModel` and `FromConfigFile`, so `TC001`/`TC002`/`TC003` no longer suggest moving imports used only in pydantic model field annotations into `if TYPE_CHECKING:` blocks. Removed the now-unnecessary per-line `# noqa: TC00x` workarounds and the blanket `cli/**`/`specs/**` per-file-ignores this uncovered.
+- `CommandPythonEnv.python_version` now defaults to `"3.13"` instead of `None`. This fixes a `uv venv -p None` failure for app definitions that omit `python_version`, and pins the app environment to the tested interpreter.
 
 ### Fixed
 
 - `_register_workflow_step` now raises a clear error when the configured workflow template step is missing or has no workflow template, instead of crashing with an `AttributeError` on `None` (missing template) or logging-and-skipping (missing step). Both cases abort output registration before the workunit is finalized to `available`, so the misconfiguration surfaces instead of leaving a finalized workunit with no workflow-step linkage.
+- The SLURM integration wrapper now launches `bfabric-app-runner` with `uv run -p 3.13` (previously the launch was unpinned, only the version-detection helper was pinned). This prevents the runner from floating onto an untested Python such as a prerelease 3.14, where pydantic raised `TypeError: _eval_type() got an unexpected keyword argument 'prefer_fwd_module'` ([#494](https://github.com/fgcz/bfabricPy/issues/494)).
 
 ## \[0.6.1\] - 2026-06-11
 

--- a/bfabric_app_runner/src/bfabric_app_runner/bfabric_integration/wrapper/wrap_app_yaml_template.bash.mako
+++ b/bfabric_app_runner/src/bfabric_app_runner/bfabric_integration/wrapper/wrap_app_yaml_template.bash.mako
@@ -1,7 +1,7 @@
 # shellcheck disable=SC2016,SC2154
 # Determine app runner version
 get_app_runner_version() {
-    uv run -p 3.13 --with "pyyaml==6.0.2" python - "$1" <<'EOF'
+    uv run -p ${python_version} --with "pyyaml==6.0.2" python - "$1" <<'EOF'
 import yaml
 import sys
 import re
@@ -17,5 +17,5 @@ EOF
 app_runner_version=$(get_app_runner_version "${app_yaml_path}")
 
 # Run
-uv run --with "$app_runner_version" bfabric-app-runner \
+uv run -p ${python_version} --with "$app_runner_version" bfabric-app-runner \
     run workunit --app-definition '${app_yaml_path}' --scratch-root '${scratch_root}' --workunit-ref '${workunit_id}'

--- a/bfabric_app_runner/src/bfabric_app_runner/bfabric_integration/wrapper/wrap_app_yaml_template.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/bfabric_integration/wrapper/wrap_app_yaml_template.py
@@ -16,6 +16,11 @@ class WrapAppYamlTemplate:
         workunit_id: int
         app_yaml_path: str
         scratch_root: Path
+        python_version: str = "3.13"
+        """Python version the app_runner itself is launched with (independent of the app's venv).
+
+        Pinned so the runner does not float onto an untested interpreter. See issue #494.
+        """
 
         @classmethod
         def extract_workunit(cls, workunit: Workunit, scratch_root: Path) -> WrapAppYamlTemplate.Params:

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/commands_spec.py
@@ -77,8 +77,8 @@ class CommandPythonEnv(BaseModel):
     command: str
     """The command to run, will be split by `shlex.split` and is not an actual shell script."""
 
-    python_version: str | None = None
-    """The Python version to use."""
+    python_version: str = "3.13"
+    """The Python version to use for the environment (passed to `uv venv -p`)."""
 
     local_extra_deps: list[Path] = []
     """Additional dependencies to install into the environment.

--- a/tests/bfabric_app_runner/bfabric_integration/wrapper/test_wrap_app_yaml_template.py
+++ b/tests/bfabric_app_runner/bfabric_integration/wrapper/test_wrap_app_yaml_template.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from bfabric_app_runner.bfabric_integration.wrapper.wrap_app_yaml_template import WrapAppYamlTemplate
+
+
+def _render(**overrides: object) -> str:
+    params = WrapAppYamlTemplate.Params(
+        workunit_id=123,
+        app_yaml_path="/path/to/app.yml",
+        scratch_root=Path("/scratch"),
+        **overrides,
+    )
+    template = WrapAppYamlTemplate(params=params, path=WrapAppYamlTemplate.default_path())
+    return template.render_string()
+
+
+class TestWrapAppYamlTemplate:
+    def test_default_python_version_is_3_13(self):
+        """Params defaults the runner's interpreter to the blessed 3.13."""
+        assert (
+            WrapAppYamlTemplate.Params(
+                workunit_id=1, app_yaml_path="/x/app.yml", scratch_root=Path("/scratch")
+            ).python_version
+            == "3.13"
+        )
+
+    def test_runner_launch_is_pinned(self):
+        """Regression guard for #494: the runner launch must pin the interpreter.
+
+        Previously `uv run --with "$app_runner_version" bfabric-app-runner` had no `-p`,
+        so it floated onto whatever Python uv found (e.g. a prerelease 3.14 where pydantic
+        crashed). It must launch via `uv run -p 3.13 --with`.
+        """
+        script = _render()
+        assert 'uv run -p 3.13 --with "$app_runner_version" bfabric-app-runner' in script
+
+    def test_both_uv_run_invocations_are_pinned(self):
+        """Neither uv run invocation may float the interpreter.
+
+        The exact count is asserted so the guard fails if an invocation is dropped or an
+        unpinned one is reintroduced, not just when an existing line stays pinned.
+        """
+        script = _render()
+        uv_run_lines = [line for line in script.splitlines() if "uv run" in line]
+        assert len(uv_run_lines) == 2, f"expected exactly two `uv run` invocations, got {uv_run_lines!r}"
+        for line in uv_run_lines:
+            assert "-p 3.13" in line, f"unpinned uv run invocation: {line!r}"
+
+    def test_python_version_override_propagates(self):
+        """An explicit python_version flows into every uv run invocation."""
+        script = _render(python_version="3.12")
+        uv_run_lines = [line for line in script.splitlines() if "uv run" in line]
+        assert uv_run_lines
+        for line in uv_run_lines:
+            assert "-p 3.12" in line
+        assert "-p 3.13" not in script

--- a/tests/bfabric_app_runner/commands/test_command_python_env.py
+++ b/tests/bfabric_app_runner/commands/test_command_python_env.py
@@ -40,6 +40,27 @@ def sample_command():
     )
 
 
+class TestCommandPythonEnvDefaults:
+    """Tests for CommandPythonEnv spec defaults."""
+
+    def test_python_version_defaults_to_3_13(self):
+        """When omitted (e.g. ScaffoldDIA app.yml), python_version defaults to the tested 3.13.
+
+        Previously it defaulted to None and was passed verbatim to `uv venv -p None`.
+        """
+        command = CommandPythonEnv(pylock=Path("/test/requirements.txt"), command="my_script.py")
+        assert command.python_version == "3.13"
+
+    def test_provision_uses_default_python_version(self, temp_env_path, mock_uv, mock_execute_command_exec):
+        """Provisioning a command without an explicit python_version pins -p 3.13."""
+        temp_env_path.mkdir(parents=True, exist_ok=True)
+        command = CommandPythonEnv(pylock=Path("/test/requirements.txt"), command="my_script.py")
+        PythonEnvironment(temp_env_path, command).provision()
+
+        venv_call = mock_execute_command_exec.call_args_list[0][0][0]
+        assert "uv venv -p 3.13" in venv_call.command
+
+
 class TestPythonEnvironment:
     """Tests for the PythonEnvironment class."""
 


### PR DESCRIPTION
App definitions that omit `python_version` ran on an unpinned interpreter, so the
runner could land on an untested Python — e.g. a prerelease 3.14, where the pinned
pydantic raises `TypeError: _eval_type() got an unexpected keyword argument
'prefer_fwd_module'` at import. Two launch paths were unpinned; this pins both to a
tested default.

- `CommandPythonEnv.python_version` now defaults to `"3.13"` instead of `None`. The old
  default flowed straight into `uv venv -p None`; the new default also lets the field
  narrow from `str | None` to `str`.
- The SLURM integration wrapper's `bfabric-app-runner` launch is now
  `uv run -p ${python_version}` (previously only the version-detection helper was
  pinned). The version is a new overridable `Params.python_version` field defaulting to
  `"3.13"`.

Verified: app_runner test suite passes (36 incl. new regression guards), basedpyright clean.

Closes #494

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.