### PR TITLE
feat(transfer): transport-agnostic byte movers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,10 @@ Each package's docs live alongside its source. Skim the index when working in a 
 - Tests use the pytest-mock `mocker` fixture for **all** mocking — do not `import unittest.mock`.
   Use `mocker.patch(...)`, `mocker.patch.object(...)`, `mocker.patch.dict(...)`, `mocker.MagicMock()`,
   `mocker.Mock()`, `mocker.mock_open(...)`, etc. (`pytest-mock` is a test dependency in every package.)
+- Group related tests in a file with plain `class TestXyz:` blocks — do **not** use `# --- section ---`
+  comment banners as separators. A bare class (no base) is all pytest needs; move fixtures used by only
+  one group inside its class so their scope matches the grouping. Keep each method name specific enough to
+  read on its own (drop a prefix only when the class already conveys it).
 - Ruff linting is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores)
 - Line length: 120 (ruff and black)
 - Do not restate a parameter's default value in its docstring when the signature already shows it (e.g. `client_id: str = DEFAULT_CLIENT_ID`). Writing `(default "CLI")` in the `:param:` line just duplicates the signature and drifts out of sync when the default changes. Keep notes that explain what a value *means* (e.g. `(``0`` = auto-assign)`), not ones that merely repeat it. This also applies to class/model docstrings that restate a field's default shown a few lines below (prefer "see `field_name`" over repeating the literal value). Note the common case where the signature default is a sentinel like `None` but the docstring explains what it resolves to at runtime (e.g. `max_results: int | None = 100` documented as `` (``None`` for all) ``, or `path: Path | None = None` documented as `` (``None`` writes to ``./output.yml``) ``) — that is the *meaning* case, not the restatement case, and should be kept; phrase it as "``None`` does/means X", not "(default: X)", so it isn't mistaken for a literal restatement.

--- a/bfabric/pyproject.toml
+++ b/bfabric/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+transfer = ["tuspy>=1.0,<2"]
 dev = [
     "bfabric[doc,test]",
     "black",
@@ -53,7 +54,7 @@ doc = [
     "sphinx-autobuild>=2024.10.3",
     "linkify-it-py",
 ]
-test = ["pytest>=8", "pytest-mock>=3.15", "logot[pytest,loguru]>=1.5.1", "coverage>=7.10.0", "pytest-asyncio>=1.2.0", "dirty-equals>=0.10.0", "pytest-random-order>=1.1.0"]
+test = ["bfabric[transfer]", "pytest>=8", "pytest-mock>=3.15", "logot[pytest,loguru]>=1.5.1", "coverage>=7.10.0", "pytest-asyncio>=1.2.0", "dirty-equals>=0.10.0", "pytest-random-order>=1.1.0"]
 typing = ["mypy", "types-requests", "lxml-stubs", "types-python-dateutil", "types-PyYAML"]
 
 [project.urls]

--- a/bfabric/src/bfabric/transfer/__init__.py
+++ b/bfabric/src/bfabric/transfer/__init__.py
@@ -1,0 +1,57 @@
+"""The B-Fabric transfer layer: transport-agnostic byte movers.
+
+This first slice ships only the generic movers (:mod:`bfabric.transfer._generic`) -- transport-only
+source/sink value objects, ``Credentials``, ``fetch_to_path`` (download) and ``send_to_sink``
+(upload, tus behind the ``[transfer]`` extra). They know nothing about B-Fabric and are re-exported
+here for convenience. The B-Fabric domain binding (the ``/rest/upload/*`` client, token acquisition,
+Resource -> source mapping) lands in a follow-up and will extend these exports.
+
+Importing this module is plain core (httpx only); actually transferring over tus needs the
+``bfabric[transfer]`` extra, and is dispatched lazily by ``send_to_sink``.
+"""
+
+from __future__ import annotations
+
+from bfabric.transfer._generic import (
+    Credentials,
+    FileInfo,
+    TransferError,
+    TransferSink,
+    TransferSinkLocal,
+    TransferSinkScp,
+    TransferSinkTus,
+    TransferSource,
+    TransferSourceHttp,
+    TransferSourceLocal,
+    TransferSourceSsh,
+    UploadOutcome,
+    collect_file_infos,
+    compute_file_info,
+    fetch_to_path,
+    md5_checksum,
+    resolve_paths,
+    scp,
+    send_to_sink,
+)
+
+__all__ = [
+    "Credentials",
+    "FileInfo",
+    "TransferError",
+    "TransferSink",
+    "TransferSinkLocal",
+    "TransferSinkScp",
+    "TransferSinkTus",
+    "TransferSource",
+    "TransferSourceHttp",
+    "TransferSourceLocal",
+    "TransferSourceSsh",
+    "UploadOutcome",
+    "collect_file_infos",
+    "compute_file_info",
+    "fetch_to_path",
+    "md5_checksum",
+    "resolve_paths",
+    "scp",
+    "send_to_sink",
+]

--- a/bfabric/src/bfabric/transfer/_generic/__init__.py
+++ b/bfabric/src/bfabric/transfer/_generic/__init__.py
@@ -1,0 +1,58 @@
+"""Transport-agnostic file movers for B-Fabric resource I/O.
+
+This package moves bytes given a transport-only source/sink description plus credentials. It knows
+nothing about B-Fabric: the domain binding (Resource -> source/sink, token acquisition) lives in
+core ``bfabric.transfer``. Base install needs only ``httpx``; the tus resumable-upload mover is
+gated behind the ``[tus]`` extra and is imported lazily, so a download-only consumer never pulls
+``tuspy``.
+"""
+
+from __future__ import annotations
+
+from bfabric.transfer._generic._upload_types import UploadOutcome
+from bfabric.transfer._generic.checksums import (
+    FileInfo,
+    collect_file_infos,
+    compute_file_info,
+    md5_checksum,
+    resolve_paths,
+)
+from bfabric.transfer._generic.credentials import Credentials
+from bfabric.transfer._generic.errors import TransferError
+from bfabric.transfer._generic.fetch import fetch_to_path
+from bfabric.transfer._generic.scp import scp
+from bfabric.transfer._generic.send import send_to_sink
+from bfabric.transfer._generic.sinks import (
+    TransferSink,
+    TransferSinkLocal,
+    TransferSinkScp,
+    TransferSinkTus,
+)
+from bfabric.transfer._generic.sources import (
+    TransferSource,
+    TransferSourceHttp,
+    TransferSourceLocal,
+    TransferSourceSsh,
+)
+
+__all__ = [
+    "Credentials",
+    "FileInfo",
+    "TransferError",
+    "TransferSink",
+    "TransferSinkLocal",
+    "TransferSinkScp",
+    "TransferSinkTus",
+    "TransferSource",
+    "TransferSourceHttp",
+    "TransferSourceLocal",
+    "TransferSourceSsh",
+    "UploadOutcome",
+    "collect_file_infos",
+    "compute_file_info",
+    "fetch_to_path",
+    "md5_checksum",
+    "resolve_paths",
+    "scp",
+    "send_to_sink",
+]

--- a/bfabric/src/bfabric/transfer/_generic/__init__.py
+++ b/bfabric/src/bfabric/transfer/_generic/__init__.py
@@ -3,7 +3,7 @@
 This package moves bytes given a transport-only source/sink description plus credentials. It knows
 nothing about B-Fabric: the domain binding (Resource -> source/sink, token acquisition) lives in
 core ``bfabric.transfer``. Base install needs only ``httpx``; the tus resumable-upload mover is
-gated behind the ``[tus]`` extra and is imported lazily, so a download-only consumer never pulls
+gated behind the ``[transfer]`` extra and is imported lazily, so a download-only consumer never pulls
 ``tuspy``.
 """
 

--- a/bfabric/src/bfabric/transfer/_generic/_tus_mover.py
+++ b/bfabric/src/bfabric/transfer/_generic/_tus_mover.py
@@ -1,0 +1,165 @@
+# tusclient (the ``tuspy`` package) ships no type information and is an OPTIONAL dependency (the
+# ``[tus]`` extra), so it is unresolved when this package is typechecked without the extra. Disable
+# the unknown-type family for this thin wrapper module only, rather than threading casts through
+# every tuspy call.
+# pyright: reportMissingImports=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
+"""The tus resumable-upload mover.
+
+Isolated in its own module because it is the ONLY place that imports ``tusclient`` (from the ``tuspy``
+package, installed via the ``[tus]`` extra). Neither ``bfabric.transfer._generic.__init__`` nor
+``bfabric.transfer._generic.send`` import this module at top level -- ``send_to_sink`` imports it lazily, only
+when a tus sink is actually dispatched -- so a download-only / query install never pulls ``tuspy``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+from tusclient.client import TusClient
+
+from bfabric.transfer._generic._upload_types import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_RETRIES,
+    DEFAULT_RETRY_DELAY,
+    ProgressCallback,
+    UploadOutcome,
+    UrlCallback,
+)
+from bfabric.transfer._generic.errors import TransferError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# RFC 6454 defines an origin using the scheme's default port when the URL omits one, so
+# https://h and https://h:443 are the same origin. urlsplit().port is None in the implicit
+# case, so compare an *effective* port to avoid spuriously rejecting a legitimate resume URL.
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _same_origin(a: str, b: str) -> bool:
+    """True if two URLs share scheme, host, and effective port (the scheme default if unspecified)."""
+    ua, ub = urlsplit(a), urlsplit(b)
+    pa = ua.port or _DEFAULT_PORTS.get(ua.scheme)
+    pb = ub.port or _DEFAULT_PORTS.get(ub.scheme)
+    return (ua.scheme, ua.hostname, pa) == (ub.scheme, ub.hostname, pb)
+
+
+def upload_file(
+    tus_endpoint: str,
+    token: str,
+    file_path: Path,
+    metadata: dict[str, str],
+    *,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    on_progress: ProgressCallback | None = None,
+    resume_url: str | None = None,
+    on_url: UrlCallback | None = None,
+    retries: int = DEFAULT_RETRIES,
+    retry_delay: int = DEFAULT_RETRY_DELAY,
+) -> UploadOutcome:
+    """Upload a single file using the tus protocol.
+
+    Args:
+        tus_endpoint: Base tus endpoint used to create a new upload.
+        token: Bearer token for the Authorization header (the short-lived tus upload token).
+        file_path: Local file to upload.
+        metadata: tus metadata sent with the creation request.
+        chunk_size: Bytes per PATCH request.
+        on_progress: Called after each chunk with (bytes_done, total).
+        resume_url: If given, resume a previously-started upload at this URL
+            instead of creating a new one.
+        on_url: Called once with the server-side upload URL as soon as it is
+            known -- including when a fresh upload's first chunk fails after the
+            creation request already registered the upload -- so the caller can
+            always persist a URL to resume from.
+        retries: Per-chunk retry attempts for transient network errors
+            (tuspy resumes from the server offset on each retry).
+        retry_delay: Seconds between retries.
+
+    Returns:
+        UploadOutcome on success. A transfer failure raises TransferError.
+
+    Raises:
+        ValueError: if ``resume_url`` does not share the origin (scheme/host/
+            port) of ``tus_endpoint`` -- we refuse to send the bearer token to
+            an unexpected host.
+    """
+    if resume_url is not None and not _same_origin(resume_url, tus_endpoint):
+        raise ValueError(
+            f"resume_url origin {urlsplit(resume_url).netloc!r} does not match "
+            f"tus_endpoint origin {urlsplit(tus_endpoint).netloc!r}; refusing to "
+            f"send the upload token to it."
+        )
+
+    client = TusClient(tus_endpoint)
+    client.set_headers({"Authorization": f"Bearer {token}"})
+
+    file_size = file_path.stat().st_size
+    uploader = client.uploader(
+        file_path=str(file_path),
+        chunk_size=chunk_size,
+        metadata=metadata,
+        retries=retries,
+        retry_delay=retry_delay,
+    )
+
+    start_offset = 0
+    url_reported = False
+
+    def _report_url(url: str | None) -> None:
+        nonlocal url_reported
+        if not url_reported and url:
+            url_reported = True
+            if on_url is not None:
+                on_url(url)
+
+    if resume_url is not None:
+        # Resume: point at the existing upload and sync the local offset to
+        # what the server already has. tuspy's set_url() does NOT sync the
+        # uploader's offset, so without this the next PATCH is built from
+        # offset 0 and the server rejects it with 409 (offset conflict).
+        uploader.set_url(resume_url)
+        try:
+            # get_offset() issues a HEAD to the resume URL; a stale/unreachable
+            # URL raises tuspy's TusCommunicationError, which is not a
+            # TransferError -- wrap it so callers can catch TransferError.
+            start_offset = uploader.get_offset()
+        except Exception as exc:
+            raise TransferError(f"failed to query resume offset for {file_path.name} from {resume_url}: {exc}") from exc
+        uploader.offset = start_offset
+        _report_url(resume_url)
+
+    if file_size == 0:
+        # tus still needs the creation request for a fresh empty file; a
+        # resumed empty upload was already created, so skip it (and avoid a
+        # second on_url call).
+        if resume_url is None:
+            uploader.upload()
+            _report_url(uploader.url)
+        if on_progress is not None:
+            on_progress(0, 0)
+        return UploadOutcome(bytes_uploaded=0, final_offset=0, upload_url=uploader.url or resume_url)
+
+    if resume_url is not None and on_progress is not None:
+        # Report the server-retained offset as the starting point.
+        on_progress(start_offset, file_size)
+
+    while uploader.offset < file_size:
+        try:
+            uploader.upload_chunk()
+        except Exception as exc:
+            raise TransferError(f"tus transfer failed for {file_path.name}: {exc}") from exc
+        finally:
+            # The creation POST sets uploader.url before the data PATCH, so the
+            # URL exists even if the chunk failed -- report it either way.
+            _report_url(uploader.url)
+        if on_progress is not None:
+            on_progress(uploader.offset, file_size)
+
+    return UploadOutcome(
+        bytes_uploaded=uploader.offset - start_offset,
+        final_offset=uploader.offset,
+        upload_url=uploader.url,
+    )

--- a/bfabric/src/bfabric/transfer/_generic/_tus_mover.py
+++ b/bfabric/src/bfabric/transfer/_generic/_tus_mover.py
@@ -1,12 +1,12 @@
 # tusclient (the ``tuspy`` package) ships no type information and is an OPTIONAL dependency (the
-# ``[tus]`` extra), so it is unresolved when this package is typechecked without the extra. Disable
+# ``[transfer]`` extra), so it is unresolved when this package is typechecked without the extra. Disable
 # the unknown-type family for this thin wrapper module only, rather than threading casts through
 # every tuspy call.
 # pyright: reportMissingImports=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
 """The tus resumable-upload mover.
 
 Isolated in its own module because it is the ONLY place that imports ``tusclient`` (from the ``tuspy``
-package, installed via the ``[tus]`` extra). Neither ``bfabric.transfer._generic.__init__`` nor
+package, installed via the ``[transfer]`` extra). Neither ``bfabric.transfer._generic.__init__`` nor
 ``bfabric.transfer._generic.send`` import this module at top level -- ``send_to_sink`` imports it lazily, only
 when a tus sink is actually dispatched -- so a download-only / query install never pulls ``tuspy``.
 """

--- a/bfabric/src/bfabric/transfer/_generic/_upload_types.py
+++ b/bfabric/src/bfabric/transfer/_generic/_upload_types.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+ProgressCallback = Callable[[int, int], None]
+"""Called with (bytes_done, total) after each chunk. bytes_done is absolute."""
+
+UrlCallback = Callable[[str], None]
+"""Called once with the server-side upload URL as soon as it is known."""
+
+DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024
+DEFAULT_RETRIES = 3
+DEFAULT_RETRY_DELAY = 5
+
+
+@dataclass
+class UploadOutcome:
+    """Result of a single successful file transfer to a sink.
+
+    ``bytes_uploaded`` is the number of bytes actually sent during *this* call, whereas
+    ``final_offset`` is the absolute offset confirmed on the server (the total size now stored). For a
+    fresh upload the two are equal; for a resumed tus upload ``final_offset`` also counts the bytes a
+    previous session already delivered, so ``final_offset >= bytes_uploaded``. For non-resumable sinks
+    (local/scp) both equal the file size.
+
+    ``upload_url`` is the server-side (resumable) upload URL for a tus transfer; persist it (via the
+    ``on_url`` callback, which fires as soon as the URL exists -- even if the transfer then fails) to
+    resume a later interrupted transfer via ``send_to_sink(..., resume_url=...)``. It is ``None`` for
+    non-resumable sinks (local/scp). A failed transfer raises
+    :class:`~bfabric.transfer._generic.errors.TransferError` rather than returning.
+    """
+
+    bytes_uploaded: int
+    final_offset: int
+    upload_url: str | None
+
+
+# These types are deliberately kept in a module that does NOT import ``tusclient``, so that
+# ``bfabric.transfer._generic.__init__`` and ``bfabric.transfer._generic.send`` can re-export ``UploadOutcome`` without
+# dragging ``tuspy`` into a download-only / query install.

--- a/bfabric/src/bfabric/transfer/_generic/checksums.py
+++ b/bfabric/src/bfabric/transfer/_generic/checksums.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def md5_checksum(path: Path) -> str:
+    """Returns the lowercase hex MD5 digest of the file at ``path``."""
+    with path.open("rb") as f:
+        return hashlib.file_digest(f, "md5").hexdigest()
+
+
+@dataclass
+class FileInfo:
+    name: str
+    md5: str
+    size: int
+    path: Path
+
+
+def resolve_paths(paths: list[Path]) -> list[Path]:
+    """Expand directories recursively into files, passing regular files through unchanged."""
+    result: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            result.extend(sorted(f for f in p.rglob("*") if f.is_file()))
+        else:
+            result.append(p)
+    return result
+
+
+def collect_file_infos(paths: list[Path]) -> list[FileInfo]:
+    """Expand any directories and compute a FileInfo for every resulting file.
+
+    Directories are expanded recursively, preserving the path relative to the
+    directory as the resource name (e.g. "subdir/file.txt"). Plain files keep
+    their basename. Raises ValueError if a directory contains no files.
+    """
+    infos: list[FileInfo] = []
+    for p in paths:
+        if p.is_dir():
+            expanded = resolve_paths([p])
+            if not expanded:
+                raise ValueError(f"Directory '{p}' contains no files.")
+            for ep in expanded:
+                infos.append(compute_file_info(ep, base_dir=p))
+        else:
+            infos.append(compute_file_info(p))
+    return infos
+
+
+def compute_file_info(path: Path, base_dir: Path | None = None) -> FileInfo:
+    """Compute MD5 checksum and size for a file.
+
+    When base_dir is provided, the file name is set to the path relative to base_dir
+    (e.g. "subdir/file.txt"). Otherwise, just the basename is used.
+    """
+    name = str(path.relative_to(base_dir)) if base_dir is not None else path.name
+    return FileInfo(
+        name=name,
+        md5=md5_checksum(path),
+        size=path.stat().st_size,
+        path=path,
+    )

--- a/bfabric/src/bfabric/transfer/_generic/credentials.py
+++ b/bfabric/src/bfabric/transfer/_generic/credentials.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pydantic import BaseModel
+
+
+class Credentials(BaseModel):
+    """Transport credentials for a transfer.
+
+    ``token_provider`` supplies the bearer token for authenticated HTTP transfers. It is invoked once
+    per request/retry rather than snapshotted, so a caller can hand back a live provider and let the
+    token be refreshed underneath -- a long transfer then survives a mid-batch token expiry. ``None``
+    means no bearer token is available (a transfer that requires one fails fast). ``ssh_user`` is the
+    remote user for the ssh/scp/rsync transports.
+    """
+
+    token_provider: Callable[[], str] | None = None
+    ssh_user: str | None = None

--- a/bfabric/src/bfabric/transfer/_generic/errors.py
+++ b/bfabric/src/bfabric/transfer/_generic/errors.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+class TransferError(RuntimeError):
+    """A file transfer (download or upload) failed.
+
+    Subclasses :class:`RuntimeError` to match bfabricPy's error convention (e.g. the ``use_client``
+    CLI decorator catches ``RuntimeError``), so callers integrating this package need not import a
+    bespoke base class to handle a failed transfer.
+    """

--- a/bfabric/src/bfabric/transfer/_generic/fetch.py
+++ b/bfabric/src/bfabric/transfer/_generic/fetch.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from shutil import SameFileError
+from subprocess import CalledProcessError
+from typing import TYPE_CHECKING
+
+import httpx
+from loguru import logger
+
+from bfabric.transfer._generic.checksums import md5_checksum
+from bfabric.transfer._generic.errors import TransferError
+from bfabric.transfer._generic.scp import scp
+from bfabric.transfer._generic.sources import (
+    TransferSource,
+    TransferSourceHttp,
+    TransferSourceLocal,
+    TransferSourceSsh,
+)
+
+if TYPE_CHECKING:
+    from bfabric.transfer._generic.credentials import Credentials
+
+
+def fetch_to_path(
+    source: TransferSource,
+    dest: Path,
+    creds: Credentials,
+    *,
+    checksum: str | None = None,
+    link_ok: bool = False,
+) -> None:
+    """Fetches ``source`` to ``dest`` using rsync/scp/cp/symlink or a streamed HTTP download.
+
+    The download is atomic and checksum-verified where the transport allows. ``link_ok`` permits
+    symlinking a local source in place of copying it. Raises :class:`TransferError` if the transfer
+    ultimately fails.
+
+    :param source: the file to fetch (a single transport-only source; candidate-list negotiation is
+        deferred).
+    :param dest: the full destination path (not a directory); parent directories are created.
+    :param creds: credentials used for the transfer (ssh user, and the bearer-token provider for
+        authenticated HTTP).
+    :param checksum: expected MD5 hex digest to verify an HTTP download against, if available.
+    :param link_ok: whether a local source may be symlinked instead of copied.
+    """
+    dest.parent.mkdir(exist_ok=True, parents=True)
+
+    if isinstance(source, TransferSourceHttp):
+        token = creds.token_provider() if creds.token_provider is not None else None
+        success = _operation_copy_http(source=source, output_path=dest, checksum=checksum, bearer_token=token)
+    elif not link_ok:
+        success = _operation_copy_rsync(source, dest, creds.ssh_user)
+        if not success:
+            success = _operation_copy(source, dest, creds.ssh_user)
+    else:
+        # A remote source must never reach the symlink branch, which assumes a local path; callers
+        # (and the binding) are expected to reject link_ok=True on a remote source before this point.
+        if not isinstance(source, TransferSourceLocal):
+            raise TransferError(f"Cannot link a non-local file: {source}")
+        success = _operation_link_symbolic(source, dest)
+
+    if not success:
+        raise TransferError(f"Failed to fetch file: {source}")
+
+
+def _operation_copy_rsync(
+    source: TransferSourceSsh | TransferSourceLocal, output_path: Path, ssh_user: str | None
+) -> bool:
+    match source:
+        case TransferSourceLocal(path=path):
+            source_str = str(Path(path).resolve())
+        case TransferSourceSsh(host=host, path=path):
+            source_str = f"{ssh_user}@{host}:{path}" if ssh_user else f"{host}:{path}"
+    cmd = ["rsync", "-rltvP", source_str, str(output_path)]
+    logger.info(shlex.join(cmd))
+    result = subprocess.run(cmd, check=False)
+    return result.returncode == 0
+
+
+def _operation_copy(source: TransferSourceSsh | TransferSourceLocal, output_path: Path, ssh_user: str | None) -> bool:
+    match source:
+        case TransferSourceLocal():
+            return _operation_copy_cp(source, output_path)
+        case TransferSourceSsh():
+            return _operation_copy_scp(source, output_path, ssh_user)
+
+
+def _operation_copy_http(
+    source: TransferSourceHttp, output_path: Path, checksum: str | None, bearer_token: str | None
+) -> bool:
+    """Streams a file from an HTTP(S) URL to ``output_path``, verifying the checksum when available."""
+    needs_auth = source.auth == "bfabric"
+
+    if needs_auth and not bearer_token:
+        raise TransferError(
+            "HTTP resource access requires an OAuth-backed client (e.g. Bfabric.connect_pkce / connect_oauth) "
+            "to provide a bearer token; the current credentials have none."
+        )
+
+    # Disable transport compression so the streamed bytes match the file the checksum was computed over.
+    headers = {"Accept-Encoding": "identity"}
+    # Only send the token for trusted, auth-required URLs; never leak it to arbitrary hosts.
+    if needs_auth and bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+
+    # Download to a temporary sibling and rename on success, so a mid-stream failure never leaves a
+    # truncated file at output_path.
+    tmp_path = output_path.with_name(f"{output_path.name}.part")
+    logger.info(f"GET {source.url} -> {output_path}")
+    try:
+        with httpx.stream("GET", source.url, headers=headers, follow_redirects=True) as response:
+            _ = response.raise_for_status()
+            with tmp_path.open("wb") as fh:
+                fh.writelines(response.iter_bytes())
+    except httpx.HTTPError as error:
+        tmp_path.unlink(missing_ok=True)
+        detail = ""
+        if isinstance(error, httpx.HTTPStatusError):
+            code = error.response.status_code
+            detail = f" (HTTP {code})"
+            if code in (401, 403) and needs_auth:
+                detail += "; the bearer token may be missing or lack the required 'containers' scope"
+        logger.error(f"HTTP download failed for {source.url}{detail}: {error}")
+        return False
+
+    _verify_checksum(tmp_path, checksum, output_path)
+    _ = tmp_path.replace(output_path)
+    return True
+
+
+def _verify_checksum(tmp_path: Path, expected: str | None, output_path: Path) -> None:
+    """Verifies ``tmp_path`` against ``expected``, raising on mismatch; warns and skips if none was provided."""
+    if expected is None:
+        logger.warning(f"No checksum available for {output_path}; skipping integrity verification.")
+        return
+    actual_checksum = md5_checksum(tmp_path)
+    if actual_checksum != expected:
+        tmp_path.unlink(missing_ok=True)
+        raise TransferError(
+            f"Checksum mismatch for {output_path} (expected {expected}, got {actual_checksum});"
+            " downloaded file is corrupt."
+        )
+
+
+def _operation_copy_scp(source: TransferSourceSsh, output_path: Path, ssh_user: str | None) -> bool:
+    try:
+        source_str = f"{source.host}:{source.path}"
+        scp(source=source_str, target=output_path, user=ssh_user)
+    except CalledProcessError:
+        return False
+    return True
+
+
+def _operation_copy_cp(source: TransferSourceLocal, output_path: Path) -> bool:
+    cmd = [str(Path(source.path).resolve()), str(output_path)]
+    logger.info(shlex.join(["cp", *cmd]))
+    try:
+        _ = shutil.copyfile(*cmd)
+    except (OSError, SameFileError):
+        return False
+    return True
+
+
+def _operation_link_symbolic(source: TransferSourceLocal, output_path: Path) -> bool:
+    # the link is created relative to the output file, so it should be more portable across apptainer images etc.
+    # os.path.relpath (rather than Path.relative_to(..., walk_up=True), which is 3.12+) keeps this working on
+    # the Python 3.11 the package supports while still walking up (emitting ``..``) when needed.
+    source_path = Path(os.path.relpath(Path(source.path).resolve(), output_path.resolve().parent))
+
+    # if the file exists, and only if it is a link as well
+    if output_path.is_symlink():
+        # check if it points to the same file, in which case we don't need to do anything
+        if output_path.resolve() == source_path.resolve():
+            logger.info("Link already exists and points to the correct file")
+            return True
+        else:
+            logger.info(f"rm {output_path}")
+            output_path.unlink()
+    elif output_path.exists():
+        raise TransferError(f"Output path already exists and is not a symlink: {output_path}")
+    cmd = ["ln", "-s", str(source_path), str(output_path)]
+    logger.info(shlex.join(cmd))
+    result = subprocess.run(cmd, check=False)
+    return result.returncode == 0

--- a/bfabric/src/bfabric/transfer/_generic/fetch.py
+++ b/bfabric/src/bfabric/transfer/_generic/fetch.py
@@ -76,7 +76,8 @@ def _operation_copy_rsync(
             source_str = str(Path(path).resolve())
         case TransferSourceSsh(host=host, path=path):
             source_str = f"{ssh_user}@{host}:{path}" if ssh_user else f"{host}:{path}"
-    cmd = ["rsync", "-rltvP", source_str, str(output_path)]
+    # "--" terminates option parsing so a source/dest beginning with "-" can't be read as an rsync flag.
+    cmd = ["rsync", "-rltvP", "--", source_str, str(output_path)]
     logger.info(shlex.join(cmd))
     result = subprocess.run(cmd, check=False)
     return result.returncode == 0
@@ -169,13 +170,17 @@ def _operation_copy_cp(source: TransferSourceLocal, output_path: Path) -> bool:
 def _operation_link_symbolic(source: TransferSourceLocal, output_path: Path) -> bool:
     # the link is created relative to the output file, so it should be more portable across apptainer images etc.
     # os.path.relpath (rather than Path.relative_to(..., walk_up=True), which is 3.12+) keeps this working on
-    # the Python 3.11 the package supports while still walking up (emitting ``..``) when needed.
-    source_path = Path(os.path.relpath(Path(source.path).resolve(), output_path.resolve().parent))
+    # the Python 3.11 the package supports while still walking up (emitting ``..``) when needed. Relativize
+    # against output_path's own directory -- NOT output_path.resolve().parent, which would follow an already
+    # present link to the source and yield the wrong (source-relative) target.
+    source_abs = Path(source.path).resolve()
+    source_path = Path(os.path.relpath(source_abs, output_path.parent.resolve()))
 
     # if the file exists, and only if it is a link as well
     if output_path.is_symlink():
-        # check if it points to the same file, in which case we don't need to do anything
-        if output_path.resolve() == source_path.resolve():
+        # Compare the link's real target to the source (both absolute). Resolving the *relative* target went
+        # via the process CWD, so a correct link was only recognized when we happened to run from its own dir.
+        if output_path.resolve() == source_abs:
             logger.info("Link already exists and points to the correct file")
             return True
         else:

--- a/bfabric/src/bfabric/transfer/_generic/fetch.py
+++ b/bfabric/src/bfabric/transfer/_generic/fetch.py
@@ -36,36 +36,52 @@ def fetch_to_path(
 ) -> None:
     """Fetches ``source`` to ``dest`` using rsync/scp/cp/symlink or a streamed HTTP download.
 
-    The download is atomic and checksum-verified where the transport allows. ``link_ok`` permits
-    symlinking a local source in place of copying it. Raises :class:`TransferError` if the transfer
-    ultimately fails.
+    The fetch is atomic and checksum-verified across all transports: every byte-copy transport writes
+    to a temporary sibling, is verified, then atomically replaces ``dest`` -- so a failed or corrupt
+    transfer never leaves a partial file behind. ``link_ok`` permits symlinking a local source in place
+    of copying it (the linked file is still verified when a checksum is given). Raises
+    :class:`TransferError` if the transfer ultimately fails or the checksum does not match.
 
     :param source: the file to fetch (a single transport-only source; candidate-list negotiation is
         deferred).
     :param dest: the full destination path (not a directory); parent directories are created.
     :param creds: credentials used for the transfer (ssh user, and the bearer-token provider for
         authenticated HTTP).
-    :param checksum: expected MD5 hex digest to verify an HTTP download against, if available.
+    :param checksum: expected MD5 hex digest to verify the fetched file against (all transports), if
+        available.
     :param link_ok: whether a local source may be symlinked instead of copied.
     """
     dest.parent.mkdir(exist_ok=True, parents=True)
 
-    if isinstance(source, TransferSourceHttp):
-        token = creds.token_provider() if creds.token_provider is not None else None
-        success = _operation_copy_http(source=source, output_path=dest, checksum=checksum, bearer_token=token)
-    elif not link_ok:
-        success = _operation_copy_rsync(source, dest, creds.ssh_user)
-        if not success:
-            success = _operation_copy(source, dest, creds.ssh_user)
-    else:
+    if link_ok:
         # A remote source must never reach the symlink branch, which assumes a local path; callers
         # (and the binding) are expected to reject link_ok=True on a remote source before this point.
         if not isinstance(source, TransferSourceLocal):
             raise TransferError(f"Cannot link a non-local file: {source}")
-        success = _operation_link_symbolic(source, dest)
+        if not _operation_link_symbolic(source, dest):
+            raise TransferError(f"Failed to fetch file: {source}")
+        # Verify through the link; a mismatch unlinks it (removing the link, not the source) and raises.
+        _verify_checksum(dest, checksum, dest)
+        return
+
+    # Every transport writes to a temporary sibling first, so verification runs before we publish and a
+    # failed/corrupt transfer never lands at dest. The temp lives in dest's directory so the rename stays
+    # on one filesystem (atomic).
+    tmp = dest.with_name(f"{dest.name}.part")
+    if isinstance(source, TransferSourceHttp):
+        token = creds.token_provider() if creds.token_provider is not None else None
+        success = _operation_copy_http(source=source, output_path=tmp, bearer_token=token)
+    else:
+        success = _operation_copy_rsync(source, tmp, creds.ssh_user)
+        if not success:
+            success = _operation_copy(source, tmp, creds.ssh_user)
 
     if not success:
+        tmp.unlink(missing_ok=True)
         raise TransferError(f"Failed to fetch file: {source}")
+
+    _verify_checksum(tmp, checksum, dest)  # unlinks tmp and raises on mismatch
+    _ = tmp.replace(dest)
 
 
 def _operation_copy_rsync(
@@ -91,10 +107,8 @@ def _operation_copy(source: TransferSourceSsh | TransferSourceLocal, output_path
             return _operation_copy_scp(source, output_path, ssh_user)
 
 
-def _operation_copy_http(
-    source: TransferSourceHttp, output_path: Path, checksum: str | None, bearer_token: str | None
-) -> bool:
-    """Streams a file from an HTTP(S) URL to ``output_path``, verifying the checksum when available."""
+def _operation_copy_http(source: TransferSourceHttp, output_path: Path, bearer_token: str | None) -> bool:
+    """Streams a file from an HTTP(S) URL to ``output_path`` (checksum verification is the caller's job)."""
     needs_auth = source.auth == "bfabric"
 
     if needs_auth and not bearer_token:
@@ -109,17 +123,15 @@ def _operation_copy_http(
     if needs_auth and bearer_token:
         headers["Authorization"] = f"Bearer {bearer_token}"
 
-    # Download to a temporary sibling and rename on success, so a mid-stream failure never leaves a
-    # truncated file at output_path.
-    tmp_path = output_path.with_name(f"{output_path.name}.part")
+    # output_path is fetch_to_path's temporary sibling; a mid-stream failure leaves a partial there that
+    # the caller cleans up, so dest is never touched.
     logger.info(f"GET {source.url} -> {output_path}")
     try:
         with httpx.stream("GET", source.url, headers=headers, follow_redirects=True) as response:
             _ = response.raise_for_status()
-            with tmp_path.open("wb") as fh:
+            with output_path.open("wb") as fh:
                 fh.writelines(response.iter_bytes())
     except httpx.HTTPError as error:
-        tmp_path.unlink(missing_ok=True)
         detail = ""
         if isinstance(error, httpx.HTTPStatusError):
             code = error.response.status_code
@@ -129,15 +141,14 @@ def _operation_copy_http(
         logger.error(f"HTTP download failed for {source.url}{detail}: {error}")
         return False
 
-    _verify_checksum(tmp_path, checksum, output_path)
-    _ = tmp_path.replace(output_path)
     return True
 
 
 def _verify_checksum(tmp_path: Path, expected: str | None, output_path: Path) -> None:
     """Verifies ``tmp_path`` against ``expected``, raising on mismatch; warns and skips if none was provided."""
     if expected is None:
-        logger.warning(f"No checksum available for {output_path}; skipping integrity verification.")
+        # Runs for every un-checksummed fetch of any transport, so keep it at debug to avoid per-file noise.
+        logger.debug(f"No checksum available for {output_path}; skipping integrity verification.")
         return
     actual_checksum = md5_checksum(tmp_path)
     if actual_checksum != expected:

--- a/bfabric/src/bfabric/transfer/_generic/scp.py
+++ b/bfabric/src/bfabric/transfer/_generic/scp.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+from loguru import logger
+
+
+def scp(source: str | Path, target: str | Path, *, user: str | None = None, mkdir: bool = True) -> None:
+    """Copies a file using scp from source to target.
+    Make sure that either the source or target specifies a host, otherwise you should just use shutil.copyfile.
+    Always specify the full path for the target, not just a directory.
+    """
+    source = str(source)
+    target = str(target)
+    source_remote = _is_remote(source)
+    target_remote = _is_remote(target)
+    if source_remote == target_remote:
+        msg = (
+            f"Either source or target should be remote, but not both. "
+            f"source_remote={repr(source_remote)} == target_remote={repr(target_remote)}"
+        )
+        raise ValueError(msg)
+    if target[-1] == "/":
+        raise ValueError(f"Target should be a file, not a directory: {target}")
+    if user and source_remote:
+        source = f"{user}@{source}"
+    elif user and target_remote:
+        target = f"{user}@{target}"
+
+    if mkdir:
+        if target_remote:
+            host, path = target.split(":", 1)
+            parent_path = Path(path).parent
+            logger.debug(f"ssh {host} mkdir -p {parent_path}")
+            _ = subprocess.run(["ssh", host, "mkdir", "-p", parent_path], check=True)
+        else:
+            parent_path = Path(target).parent
+            parent_path.mkdir(parents=True, exist_ok=True)
+
+    cmd = ["scp", source, target]
+    logger.info(shlex.join(cmd))
+    _ = subprocess.run(cmd, check=True)
+
+
+def _is_remote(path: str | Path) -> bool:
+    """True if ``path`` is an scp remote spec (``[user@]host:path``) rather than a local path.
+
+    Mirrors scp/rsync's own heuristic: a colon only introduces a host if it appears before the first
+    path separator, so a colon inside a local path (e.g. ``./weird:name``) stays local. A single
+    leading character before the colon is a Windows drive letter (``C:\\...``), not a hostname.
+    """
+    s = str(path)
+    colon = s.find(":")
+    if colon == -1:
+        return False
+    first_sep = min((i for i in (s.find("/"), s.find("\\")) if i != -1), default=len(s))
+    if colon > first_sep:
+        return False
+    return colon != 1

--- a/bfabric/src/bfabric/transfer/_generic/scp.py
+++ b/bfabric/src/bfabric/transfer/_generic/scp.py
@@ -29,12 +29,21 @@ def scp(source: str | Path, target: str | Path, *, user: str | None = None, mkdi
     elif user and target_remote:
         target = f"{user}@{target}"
 
+    # scp/ssh parse a leading "-" as an option, so an endpoint like "-oProxyCommand=..." would smuggle
+    # arbitrary options (and thus local command execution) into the invocation. A real path or
+    # ``[user@]host`` never starts with "-", so reject it rather than let it reach the command line.
+    _reject_option_like(source, role="scp source")
+    _reject_option_like(target, role="scp target")
+
     if mkdir:
         if target_remote:
             host, path = target.split(":", 1)
-            parent_path = Path(path).parent
-            logger.debug(f"ssh {host} mkdir -p {parent_path}")
-            _ = subprocess.run(["ssh", host, "mkdir", "-p", parent_path], check=True)
+            # ssh joins its trailing args and runs them through the remote *shell*, so the remote path
+            # must be quoted -- otherwise a path containing shell metacharacters would execute arbitrary
+            # commands on the host.
+            quoted_parent = shlex.quote(str(Path(path).parent))
+            logger.debug(f"ssh {host} mkdir -p {quoted_parent}")
+            _ = subprocess.run(["ssh", host, "mkdir", "-p", quoted_parent], check=True)
         else:
             parent_path = Path(target).parent
             parent_path.mkdir(parents=True, exist_ok=True)
@@ -42,6 +51,12 @@ def scp(source: str | Path, target: str | Path, *, user: str | None = None, mkdi
     cmd = ["scp", source, target]
     logger.info(shlex.join(cmd))
     _ = subprocess.run(cmd, check=True)
+
+
+def _reject_option_like(value: str, *, role: str) -> None:
+    """Reject an scp/ssh endpoint that would be misread as a command-line option (a leading ``-``)."""
+    if value.startswith("-"):
+        raise ValueError(f"{role} must not start with '-': {value!r}")
 
 
 def _is_remote(path: str | Path) -> bool:

--- a/bfabric/src/bfabric/transfer/_generic/send.py
+++ b/bfabric/src/bfabric/transfer/_generic/send.py
@@ -50,7 +50,7 @@ def send_to_sink(
 
             return upload_file(
                 sink.endpoint,
-                sink.token,
+                sink.token.get_secret_value(),
                 src,
                 sink.metadata,
                 on_progress=on_progress,

--- a/bfabric/src/bfabric/transfer/_generic/send.py
+++ b/bfabric/src/bfabric/transfer/_generic/send.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import shutil
+from subprocess import CalledProcessError
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from bfabric.transfer._generic._upload_types import ProgressCallback, UploadOutcome, UrlCallback
+from bfabric.transfer._generic.errors import TransferError
+from bfabric.transfer._generic.scp import scp
+from bfabric.transfer._generic.sinks import (
+    TransferSink,
+    TransferSinkLocal,
+    TransferSinkScp,
+    TransferSinkTus,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bfabric.transfer._generic.credentials import Credentials
+
+
+def send_to_sink(
+    sink: TransferSink,
+    src: Path,
+    creds: Credentials,
+    *,
+    on_progress: ProgressCallback | None = None,
+    resume_url: str | None = None,
+    on_url: UrlCallback | None = None,
+) -> UploadOutcome:
+    """Pushes the bytes of ``src`` to ``sink``.
+
+    A tus sink is resumable: capture its URL via ``on_url`` and pass it back as ``resume_url`` to
+    resume an interrupted transfer. scp and local copies are not resumable, so ``resume_url`` /
+    ``on_url`` are ignored for them and the returned ``UploadOutcome.upload_url`` is ``None``. Raises
+    :class:`~bfabric.transfer._generic.errors.TransferError` on failure.
+    """
+    match sink:
+        case TransferSinkLocal():
+            return _send_local(sink, src, on_progress)
+        case TransferSinkScp():
+            return _send_scp(sink, src, creds, on_progress)
+        case TransferSinkTus():
+            # Imported lazily (from the submodule, not the package namespace, to avoid an import
+            # cycle) so a download-only / query install never pulls tuspy -- see _tus_mover.
+            from bfabric.transfer._generic._tus_mover import upload_file
+
+            return upload_file(
+                sink.endpoint,
+                sink.token,
+                src,
+                sink.metadata,
+                on_progress=on_progress,
+                resume_url=resume_url,
+                on_url=on_url,
+            )
+
+
+def _send_local(sink: TransferSinkLocal, src: Path, on_progress: ProgressCallback | None) -> UploadOutcome:
+    size = src.stat().st_size
+    sink.path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(f"cp {src} {sink.path}")
+    try:
+        _ = shutil.copyfile(src, sink.path)
+    except OSError as exc:
+        raise TransferError(f"failed to copy {src} to {sink.path}: {exc}") from exc
+    if on_progress is not None:
+        on_progress(size, size)
+    return UploadOutcome(bytes_uploaded=size, final_offset=size, upload_url=None)
+
+
+def _send_scp(
+    sink: TransferSinkScp, src: Path, creds: Credentials, on_progress: ProgressCallback | None
+) -> UploadOutcome:
+    size = src.stat().st_size
+    target = f"{sink.host}:{sink.path}"
+    try:
+        scp(source=src, target=target, user=creds.ssh_user)
+    except CalledProcessError as exc:
+        raise TransferError(f"scp of {src} to {target} failed: {exc}") from exc
+    if on_progress is not None:
+        on_progress(size, size)
+    return UploadOutcome(bytes_uploaded=size, final_offset=size, upload_url=None)

--- a/bfabric/src/bfabric/transfer/_generic/send.py
+++ b/bfabric/src/bfabric/transfer/_generic/send.py
@@ -44,9 +44,16 @@ def send_to_sink(
         case TransferSinkScp():
             return _send_scp(sink, src, creds, on_progress)
         case TransferSinkTus():
-            # Imported lazily (from the submodule, not the package namespace, to avoid an import
-            # cycle) so a download-only / query install never pulls tuspy -- see _tus_mover.
-            from bfabric.transfer._generic._tus_mover import upload_file
+            # tuspy is optional (the bfabric[transfer] extra). _tus_mover imports tusclient at module
+            # top, so it is imported here -- only when a tus sink is actually dispatched -- keeping a
+            # base / download-only / query install free of tuspy. A missing extra surfaces as a clear
+            # TransferError rather than a bare ModuleNotFoundError.
+            try:
+                from bfabric.transfer._generic._tus_mover import upload_file
+            except ImportError as exc:
+                raise TransferError(
+                    "tus uploads require the optional 'tuspy' dependency; install bfabric[transfer]."
+                ) from exc
 
             return upload_file(
                 sink.endpoint,

--- a/bfabric/src/bfabric/transfer/_generic/sinks.py
+++ b/bfabric/src/bfabric/transfer/_generic/sinks.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TransferSinkLocal(BaseModel):
+    """A destination on the local filesystem."""
+
+    type: Literal["local"] = "local"
+    path: Path
+
+
+class TransferSinkScp(BaseModel):
+    """A destination on a remote host reachable over scp."""
+
+    type: Literal["scp"] = "scp"
+    host: str
+    path: str
+
+
+class TransferSinkTus(BaseModel):
+    """A tus resumable-upload destination.
+
+    ``endpoint``, ``metadata`` and ``token`` are all resolved by the binding (from the
+    ``/rest/upload/initiate`` and create-resources calls) before this sink exists, so the mover stays
+    domain-free. The tus transfer authenticates with ``token`` -- a short-lived, single-mint tus
+    upload token whose ``authorization_details`` claim carries the storage path -- NOT the access
+    token in :class:`~bfabric.transfer._generic.credentials.Credentials`.
+    """
+
+    type: Literal["tus"] = "tus"
+    endpoint: str
+    metadata: dict[str, str]
+    token: str
+
+
+TransferSink = Annotated[
+    TransferSinkLocal | TransferSinkScp | TransferSinkTus,
+    Field(discriminator="type"),
+]
+"""A transport-only sink description, built in code by a binding (never parsed from YAML)."""

--- a/bfabric/src/bfabric/transfer/_generic/sinks.py
+++ b/bfabric/src/bfabric/transfer/_generic/sinks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 
 class TransferSinkLocal(BaseModel):
@@ -34,7 +34,7 @@ class TransferSinkTus(BaseModel):
     type: Literal["tus"] = "tus"
     endpoint: str
     metadata: dict[str, str]
-    token: str
+    token: SecretStr
 
 
 TransferSink = Annotated[

--- a/bfabric/src/bfabric/transfer/_generic/sources.py
+++ b/bfabric/src/bfabric/transfer/_generic/sources.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+
+class TransferSourceLocal(BaseModel):
+    """A file on the local filesystem."""
+
+    type: Literal["local"] = "local"
+    path: Path
+
+
+class TransferSourceSsh(BaseModel):
+    """A file on a remote host reachable over ssh/rsync/scp."""
+
+    type: Literal["ssh"] = "ssh"
+    host: str
+    path: str
+
+
+class TransferSourceHttp(BaseModel):
+    """A file reachable over HTTP(S) as a whole-file stream.
+
+    ``auth`` selects the credential scheme used for the download; it stays an enum (rather than a
+    bool) so further schemes can be added without a contract change. ``None`` downloads anonymously;
+    ``"bfabric"`` sends the access token from :class:`~bfabric.transfer._generic.credentials.Credentials` as a
+    bearer token, and only to this URL.
+    """
+
+    type: Literal["http"] = "http"
+    url: str
+    auth: Literal["bfabric"] | None = None
+
+
+TransferSource = Annotated[
+    TransferSourceLocal | TransferSourceSsh | TransferSourceHttp,
+    Field(discriminator="type"),
+]
+"""A transport-only source description, built in code by a binding (never parsed from YAML)."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ addopts = "--random-order"
 logot_capturer = "logot.loguru.LoguruCapturer"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = [
+    "slow: marks tests as slow (e.g. spawns a subprocess); deselect with '-m \"not slow\"'",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "**/bfabric_scripts/**" = ["ALL"]

--- a/tests/bfabric/transfer/generic/test_checksums.py
+++ b/tests/bfabric/transfer/generic/test_checksums.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from bfabric.transfer._generic.checksums import (
+    collect_file_infos,
+    compute_file_info,
+    md5_checksum,
+    resolve_paths,
+)
+
+
+def test_md5_checksum(tmp_path: Path) -> None:
+    f = tmp_path / "data.bin"
+    content = b"some bytes to hash"
+    f.write_bytes(content)
+
+    assert md5_checksum(f) == hashlib.md5(content).hexdigest()
+
+
+def test_compute_file_info_basename(tmp_path: Path) -> None:
+    f = tmp_path / "hello.txt"
+    content = b"hello world"
+    f.write_bytes(content)
+
+    fi = compute_file_info(f)
+
+    assert fi.name == "hello.txt"
+    assert fi.size == len(content)
+    assert fi.md5 == hashlib.md5(content).hexdigest()
+    assert fi.path == f
+
+
+def test_compute_file_info_relative_name_with_base_dir(tmp_path: Path) -> None:
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    f = sub / "file.txt"
+    f.write_bytes(b"x")
+
+    fi = compute_file_info(f, base_dir=tmp_path)
+
+    assert fi.name == "sub/file.txt"
+
+
+def test_resolve_paths_expands_directories_recursively(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_bytes(b"a")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.txt").write_bytes(b"b")
+
+    resolved = resolve_paths([tmp_path])
+
+    names = sorted(p.name for p in resolved)
+    assert names == ["a.txt", "b.txt"]
+
+
+def test_resolve_paths_passes_files_through(tmp_path: Path) -> None:
+    f = tmp_path / "a.txt"
+    f.write_bytes(b"a")
+
+    assert resolve_paths([f]) == [f]
+
+
+def test_collect_file_infos_expands_dirs_and_keeps_files(tmp_path: Path) -> None:
+    (tmp_path / "top.txt").write_bytes(b"t")
+    d = tmp_path / "d"
+    d.mkdir()
+    (d / "inner.txt").write_bytes(b"i")
+
+    infos = collect_file_infos([tmp_path / "top.txt", d])
+
+    # Directory expanded (relative name), plain file kept by basename.
+    assert sorted(i.name for i in infos) == ["inner.txt", "top.txt"]
+
+
+def test_collect_file_infos_empty_dir_raises(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+
+    with pytest.raises(ValueError):
+        collect_file_infos([empty])

--- a/tests/bfabric/transfer/generic/test_checksums.py
+++ b/tests/bfabric/transfer/generic/test_checksums.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 from pathlib import Path
 
 import pytest
@@ -15,22 +14,22 @@ from bfabric.transfer._generic.checksums import (
 
 def test_md5_checksum(tmp_path: Path) -> None:
     f = tmp_path / "data.bin"
-    content = b"some bytes to hash"
-    f.write_bytes(content)
+    f.write_bytes(b"some bytes to hash")
 
-    assert md5_checksum(f) == hashlib.md5(content).hexdigest()
+    # Literal md5 of b"some bytes to hash" -- an independent oracle, not a re-run of the code.
+    assert md5_checksum(f) == "03d01978f780dc8c34c0e279df48a8ce"
 
 
 def test_compute_file_info_basename(tmp_path: Path) -> None:
     f = tmp_path / "hello.txt"
-    content = b"hello world"
-    f.write_bytes(content)
+    f.write_bytes(b"hello world")
 
     fi = compute_file_info(f)
 
     assert fi.name == "hello.txt"
-    assert fi.size == len(content)
-    assert fi.md5 == hashlib.md5(content).hexdigest()
+    assert fi.size == 11
+    # Literal md5 of b"hello world".
+    assert fi.md5 == "5eb63bbbe01eeed093cb22bb8f5acdc3"
     assert fi.path == f
 
 

--- a/tests/bfabric/transfer/generic/test_fetch.py
+++ b/tests/bfabric/transfer/generic/test_fetch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import os
 from pathlib import Path
 from shutil import SameFileError
 from subprocess import CalledProcessError
@@ -220,16 +221,20 @@ class TestCopyOperations:
         source = TransferSourceLocal(path=Path("/source.txt"))
         mock_subprocess.return_value.returncode = 0
         result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
-        mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "/source.txt", "mock_output.txt"], check=False)
-        logot.assert_logged(logged.info("rsync -rltvP /source.txt mock_output.txt"))
+        mock_subprocess.assert_called_once_with(
+            ["rsync", "-rltvP", "--", "/source.txt", "mock_output.txt"], check=False
+        )
+        logot.assert_logged(logged.info("rsync -rltvP -- /source.txt mock_output.txt"))
         assert result
 
     def test_operation_copy_rsync_ssh_default(self, mock_subprocess, logot: Logot):
         source = TransferSourceSsh(host="host", path="/source.txt")
         mock_subprocess.return_value.returncode = 0
         result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
-        mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "host:/source.txt", "mock_output.txt"], check=False)
-        logot.assert_logged(logged.info("rsync -rltvP host:/source.txt mock_output.txt"))
+        mock_subprocess.assert_called_once_with(
+            ["rsync", "-rltvP", "--", "host:/source.txt", "mock_output.txt"], check=False
+        )
+        logot.assert_logged(logged.info("rsync -rltvP -- host:/source.txt mock_output.txt"))
         assert result
 
     def test_operation_copy_rsync_ssh_custom_user(self, mock_subprocess, logot: Logot):
@@ -237,9 +242,9 @@ class TestCopyOperations:
         mock_subprocess.return_value.returncode = 0
         result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
         mock_subprocess.assert_called_once_with(
-            ["rsync", "-rltvP", "user@host:/source.txt", "mock_output.txt"], check=False
+            ["rsync", "-rltvP", "--", "user@host:/source.txt", "mock_output.txt"], check=False
         )
-        logot.assert_logged(logged.info("rsync -rltvP user@host:/source.txt mock_output.txt"))
+        logot.assert_logged(logged.info("rsync -rltvP -- user@host:/source.txt mock_output.txt"))
         assert result
 
     def test_operation_copy_scp(self, mock_scp):
@@ -285,6 +290,29 @@ class TestCopyOperations:
         mock_subprocess.assert_called_once_with(["ln", "-s", expected_target, str(dest)], check=False)
         logot.assert_logged(logged.info(f"ln -s {expected_target} {dest}"))
         assert result
+
+    def test_operation_link_symbolic_recognizes_existing_correct_link(self, mock_subprocess, logot: Logot, tmp_path):
+        # An already-correct relative symlink must be recognized regardless of the process CWD. The check
+        # used to resolve the relative target against the CWD (and take output_path.resolve().parent, which
+        # follows the existing link), so a correct link was only recognized when run from its own directory
+        # and was otherwise needlessly torn down and recreated.
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        source_file = src_dir / "source.txt"
+        source_file.write_text("payload")
+        dst_dir = tmp_path / "dst"
+        dst_dir.mkdir()
+        output_path = dst_dir / "destination.txt"
+        # Pre-create exactly the relative link the operation itself would create.
+        output_path.symlink_to(os.path.relpath(source_file, dst_dir))
+
+        source = TransferSourceLocal(path=source_file)
+        result = _operation_link_symbolic(source=source, output_path=output_path)
+
+        assert result is True
+        logot.assert_logged(logged.info("Link already exists and points to the correct file"))
+        # The link was already correct, so it must not be recreated.
+        mock_subprocess.assert_not_called()
 
 
 class TestFetchToPathDispatch:

--- a/tests/bfabric/transfer/generic/test_fetch.py
+++ b/tests/bfabric/transfer/generic/test_fetch.py
@@ -27,368 +27,338 @@ from bfabric.transfer._generic.sources import (
     TransferSourceSsh,
 )
 
-# --- HTTP operation -------------------------------------------------------------------------------
+
+class TestOperationCopyHttp:
+    @pytest.fixture
+    def mock_http_stream(self, mocker):
+        """Patches httpx.stream to yield a response with the given body; returns (patch, set_body)."""
+
+        def _make(body: bytes = b"hello world", raise_error: BaseException | None = None):
+            response = mocker.MagicMock()
+            response.iter_bytes.return_value = [body]
+            response.raise_for_status.side_effect = raise_error
+            cm = mocker.MagicMock()
+            cm.__enter__.return_value = response
+            cm.__exit__.return_value = False
+            return mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", return_value=cm)
+
+        return _make
+
+    def test_anonymous_success(self, mock_http_stream, tmp_path):
+        stream = mock_http_stream(body=b"payload")
+        output_path = tmp_path / "out.txt"
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+        result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+
+        assert result is True
+        assert output_path.read_bytes() == b"payload"
+        # No Authorization header for anonymous downloads.
+        headers = stream.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+        assert stream.call_args.kwargs["follow_redirects"] is True
+
+    def test_sends_bearer_when_required(self, mock_http_stream, tmp_path):
+        stream = mock_http_stream(body=b"payload")
+        output_path = tmp_path / "out.txt"
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+
+        result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
+
+        assert result is True
+        headers = stream.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer jwt-token"
+
+    def test_require_auth_without_token_raises(self, tmp_path):
+        output_path = tmp_path / "out.txt"
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+
+        with pytest.raises(TransferError, match="OAuth-backed client"):
+            _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+
+    def test_does_not_send_token_when_not_required(self, mock_http_stream, tmp_path):
+        stream = mock_http_stream(body=b"payload")
+        output_path = tmp_path / "out.txt"
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+        _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
+
+        # Even if a token is available, an anonymous (auth=None) URL must not receive it.
+        headers = stream.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
+    def test_http_error_returns_false(self, mock_http_stream, tmp_path):
+        mock_http_stream(body=b"", raise_error=httpx.HTTPError("403 Forbidden"))
+        output_path = tmp_path / "out.txt"
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+        result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+
+        assert result is False
+
+    def test_checksum_ok(self, mock_http_stream, tmp_path):
+        body = b"payload"
+        checksum = hashlib.md5(body).hexdigest()
+        mock_http_stream(body=body)
+        output_path = tmp_path / "out.txt"
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+        assert (
+            _operation_copy_http(source=source, output_path=output_path, checksum=checksum, bearer_token=None) is True
+        )
+
+    def test_checksum_mismatch_raises(self, mock_http_stream, tmp_path):
+        mock_http_stream(body=b"payload")
+        output_path = tmp_path / "out.txt"
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+        with pytest.raises(TransferError, match="Checksum mismatch"):
+            _operation_copy_http(source=source, output_path=output_path, checksum="deadbeef", bearer_token=None)
 
 
-@pytest.fixture
-def mock_http_stream(mocker):
-    """Patches httpx.stream to yield a response with the given body; returns (patch, set_body)."""
+class TestVerifyChecksum:
+    def test_ok(self, tmp_path):
+        tmp_file = tmp_path / "download.part"
+        tmp_file.write_bytes(b"payload")
+        checksum = hashlib.md5(b"payload").hexdigest()
 
-    def _make(body: bytes = b"hello world", raise_error: BaseException | None = None):
-        response = mocker.MagicMock()
-        response.iter_bytes.return_value = [body]
-        response.raise_for_status.side_effect = raise_error
-        cm = mocker.MagicMock()
-        cm.__enter__.return_value = response
-        cm.__exit__.return_value = False
-        return mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", return_value=cm)
+        _verify_checksum(tmp_file, checksum, tmp_path / "out.txt")  # does not raise
+        assert tmp_file.exists()
 
-    return _make
+    def test_mismatch_raises(self, tmp_path):
+        tmp_file = tmp_path / "download.part"
+        tmp_file.write_bytes(b"payload")
 
+        with pytest.raises(TransferError, match="Checksum mismatch"):
+            _verify_checksum(tmp_file, "deadbeef", tmp_path / "out.txt")
 
-def test_operation_copy_http_anonymous_success(mock_http_stream, tmp_path):
-    stream = mock_http_stream(body=b"payload")
-    output_path = tmp_path / "out.txt"
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+        assert not tmp_file.exists()
 
-    result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+    def test_none_skips_and_warns(self, tmp_path, logot: Logot):
+        tmp_file = tmp_path / "download.part"
+        tmp_file.write_bytes(b"payload")
+        output_path = tmp_path / "out.txt"
 
-    assert result is True
-    assert output_path.read_bytes() == b"payload"
-    # No Authorization header for anonymous downloads.
-    headers = stream.call_args.kwargs["headers"]
-    assert "Authorization" not in headers
-    assert stream.call_args.kwargs["follow_redirects"] is True
+        _verify_checksum(tmp_file, None, output_path)
 
-
-def test_operation_copy_http_sends_bearer_when_required(mock_http_stream, tmp_path):
-    stream = mock_http_stream(body=b"payload")
-    output_path = tmp_path / "out.txt"
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
-
-    result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
-
-    assert result is True
-    headers = stream.call_args.kwargs["headers"]
-    assert headers["Authorization"] == "Bearer jwt-token"
+        logot.assert_logged(
+            logged.warning(f"No checksum available for {output_path}; skipping integrity verification.")
+        )
 
 
-def test_operation_copy_http_require_auth_without_token_raises(tmp_path):
-    output_path = tmp_path / "out.txt"
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+class TestHttpRedirectTrustBoundary:
+    @staticmethod
+    def _patch_redirecting_stream(mocker, redirect_to: str) -> dict[str, httpx.Headers]:
+        """Patches httpx.stream so a GET to ``/file`` 302-redirects to ``redirect_to``.
 
-    with pytest.raises(TransferError, match="OAuth-backed client"):
-        _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+        Routes the download through a real httpx client backed by MockTransport, so httpx's own
+        cross-origin ``Authorization``-stripping is actually exercised. Returns a per-host record of the
+        request headers seen by the transport.
+        """
+        seen: dict[str, httpx.Headers] = {}
 
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen[request.url.host] = request.headers
+            if request.url.path == "/file":
+                return httpx.Response(302, headers={"Location": redirect_to})
+            return httpx.Response(200, content=b"payload")
 
-def test_operation_copy_http_does_not_send_token_when_not_required(mock_http_stream, tmp_path):
-    stream = mock_http_stream(body=b"payload")
-    output_path = tmp_path / "out.txt"
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+        transport = httpx.MockTransport(handler)
 
-    _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
+        @contextlib.contextmanager
+        def fake_stream(method, url, *, headers=None, follow_redirects=False, **kwargs):
+            with httpx.Client(transport=transport, follow_redirects=follow_redirects) as client:
+                with client.stream(method, url, headers=headers) as response:
+                    yield response
 
-    # Even if a token is available, an anonymous (auth=None) URL must not receive it.
-    headers = stream.call_args.kwargs["headers"]
-    assert "Authorization" not in headers
+        mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", side_effect=fake_stream)
+        return seen
 
+    def test_strips_auth_on_cross_origin_redirect(self, mocker, tmp_path):
+        # The trust boundary relies on httpx dropping Authorization when a storage URL redirects off-origin
+        # (e.g. to a presigned CDN link); guard that behavior so an httpx upgrade cannot silently break it.
+        seen = self._patch_redirecting_stream(mocker, redirect_to="https://cdn.example/redirected")
+        source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
 
-def test_operation_copy_http_http_error_returns_false(mock_http_stream, tmp_path):
-    mock_http_stream(body=b"", raise_error=httpx.HTTPError("403 Forbidden"))
-    output_path = tmp_path / "out.txt"
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+        result = _operation_copy_http(
+            source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
+        )
 
-    result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+        assert result is True
+        assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
+        assert "authorization" not in seen["cdn.example"]
 
-    assert result is False
+    def test_keeps_auth_on_same_origin_redirect(self, mocker, tmp_path):
+        # A same-origin redirect must still carry the token, otherwise legitimate storage redirects break.
+        seen = self._patch_redirecting_stream(mocker, redirect_to="https://storage.example/redirected")
+        source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
 
+        result = _operation_copy_http(
+            source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
+        )
 
-def test_operation_copy_http_checksum_ok(mock_http_stream, tmp_path):
-    body = b"payload"
-    checksum = hashlib.md5(body).hexdigest()
-    mock_http_stream(body=body)
-    output_path = tmp_path / "out.txt"
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
-
-    assert _operation_copy_http(source=source, output_path=output_path, checksum=checksum, bearer_token=None) is True
-
-
-def test_operation_copy_http_checksum_mismatch_raises(mock_http_stream, tmp_path):
-    mock_http_stream(body=b"payload")
-    output_path = tmp_path / "out.txt"
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
-
-    with pytest.raises(TransferError, match="Checksum mismatch"):
-        _operation_copy_http(source=source, output_path=output_path, checksum="deadbeef", bearer_token=None)
-
-
-# --- checksum verification ------------------------------------------------------------------------
-
-
-def test_verify_checksum_ok(tmp_path):
-    tmp_file = tmp_path / "download.part"
-    tmp_file.write_bytes(b"payload")
-    checksum = hashlib.md5(b"payload").hexdigest()
-
-    _verify_checksum(tmp_file, checksum, tmp_path / "out.txt")  # does not raise
-    assert tmp_file.exists()
+        assert result is True
+        assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
 
 
-def test_verify_checksum_mismatch_raises(tmp_path):
-    tmp_file = tmp_path / "download.part"
-    tmp_file.write_bytes(b"payload")
+class TestCopyOperations:
+    """rsync / scp / cp / symlink operations."""
 
-    with pytest.raises(TransferError, match="Checksum mismatch"):
-        _verify_checksum(tmp_file, "deadbeef", tmp_path / "out.txt")
+    @pytest.fixture
+    def mock_subprocess(self, mocker):
+        return mocker.patch("subprocess.run")
 
-    assert not tmp_file.exists()
+    @pytest.fixture
+    def mock_shutil_copyfile(self, mocker):
+        return mocker.patch("shutil.copyfile")
 
+    @pytest.fixture
+    def mock_scp(self, mocker):
+        return mocker.patch("bfabric.transfer._generic.fetch.scp")
 
-def test_verify_checksum_none_skips_and_warns(tmp_path, logot: Logot):
-    tmp_file = tmp_path / "download.part"
-    tmp_file.write_bytes(b"payload")
-    output_path = tmp_path / "out.txt"
+    def test_operation_copy_rsync_local(self, mock_subprocess, logot: Logot):
+        source = TransferSourceLocal(path=Path("/source.txt"))
+        mock_subprocess.return_value.returncode = 0
+        result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
+        mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "/source.txt", "mock_output.txt"], check=False)
+        logot.assert_logged(logged.info("rsync -rltvP /source.txt mock_output.txt"))
+        assert result
 
-    _verify_checksum(tmp_file, None, output_path)
+    def test_operation_copy_rsync_ssh_default(self, mock_subprocess, logot: Logot):
+        source = TransferSourceSsh(host="host", path="/source.txt")
+        mock_subprocess.return_value.returncode = 0
+        result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
+        mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "host:/source.txt", "mock_output.txt"], check=False)
+        logot.assert_logged(logged.info("rsync -rltvP host:/source.txt mock_output.txt"))
+        assert result
 
-    logot.assert_logged(logged.warning(f"No checksum available for {output_path}; skipping integrity verification."))
+    def test_operation_copy_rsync_ssh_custom_user(self, mock_subprocess, logot: Logot):
+        source = TransferSourceSsh(host="host", path="/source.txt")
+        mock_subprocess.return_value.returncode = 0
+        result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
+        mock_subprocess.assert_called_once_with(
+            ["rsync", "-rltvP", "user@host:/source.txt", "mock_output.txt"], check=False
+        )
+        logot.assert_logged(logged.info("rsync -rltvP user@host:/source.txt mock_output.txt"))
+        assert result
 
+    def test_operation_copy_scp(self, mock_scp):
+        source = TransferSourceSsh(host="host", path="/source.txt")
+        result = _operation_copy_scp(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
+        mock_scp.assert_called_once_with(source="host:/source.txt", target=Path("mock_output.txt"), user="user")
+        assert result
 
-# --- redirect / trust-boundary behavior -----------------------------------------------------------
+    def test_operation_copy_scp_when_error(self, mock_scp):
+        mock_scp.side_effect = CalledProcessError(1, "scp")
+        source = TransferSourceSsh(host="host", path="/source.txt")
+        result = _operation_copy_scp(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
+        mock_scp.assert_called_once_with(source="host:/source.txt", target=Path("mock_output.txt"), user="user")
+        assert not result
 
+    def test_operation_copy_cp(self, mock_shutil_copyfile, logot: Logot):
+        source = TransferSourceLocal(path=Path("/source.txt"))
+        result = _operation_copy_cp(source=source, output_path=Path("mock_output.txt"))
+        mock_shutil_copyfile.assert_called_once_with("/source.txt", "mock_output.txt")
+        logot.assert_logged(logged.info("cp /source.txt mock_output.txt"))
+        assert result
 
-def _patch_redirecting_stream(mocker, redirect_to: str) -> dict[str, httpx.Headers]:
-    """Patches httpx.stream so a GET to ``/file`` 302-redirects to ``redirect_to``.
+    def test_operation_copy_cp_when_error(self, mock_shutil_copyfile, logot: Logot):
+        mock_shutil_copyfile.side_effect = SameFileError
+        source = TransferSourceLocal(path=Path("/source.txt"))
+        result = _operation_copy_cp(source=source, output_path=Path("mock_output.txt"))
+        mock_shutil_copyfile.assert_called_once_with("/source.txt", "mock_output.txt")
+        logot.assert_logged(logged.info("cp /source.txt mock_output.txt"))
+        assert not result
 
-    Routes the download through a real httpx client backed by MockTransport, so httpx's own
-    cross-origin ``Authorization``-stripping is actually exercised. Returns a per-host record of the
-    request headers seen by the transport.
-    """
-    seen: dict[str, httpx.Headers] = {}
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        seen[request.url.host] = request.headers
-        if request.url.path == "/file":
-            return httpx.Response(302, headers={"Location": redirect_to})
-        return httpx.Response(200, content=b"payload")
-
-    transport = httpx.MockTransport(handler)
-
-    @contextlib.contextmanager
-    def fake_stream(method, url, *, headers=None, follow_redirects=False, **kwargs):
-        with httpx.Client(transport=transport, follow_redirects=follow_redirects) as client:
-            with client.stream(method, url, headers=headers) as response:
-                yield response
-
-    mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", side_effect=fake_stream)
-    return seen
-
-
-def test_operation_copy_http_strips_auth_on_cross_origin_redirect(mocker, tmp_path):
-    # The trust boundary relies on httpx dropping Authorization when a storage URL redirects off-origin
-    # (e.g. to a presigned CDN link); guard that behavior so an httpx upgrade cannot silently break it.
-    seen = _patch_redirecting_stream(mocker, redirect_to="https://cdn.example/redirected")
-    source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
-
-    result = _operation_copy_http(
-        source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
+    @pytest.mark.parametrize(
+        "source_path,dest,expected_target",
+        [
+            ("/E/source.txt", "/E/dir/destination.txt", "../source.txt"),
+            ("/X/source.txt", "/E/dir/destination.txt", "../../X/source.txt"),
+            ("/work/source.txt", "/work/destination.txt", "source.txt"),
+        ],
     )
-
-    assert result is True
-    assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
-    assert "authorization" not in seen["cdn.example"]
-
-
-def test_operation_copy_http_keeps_auth_on_same_origin_redirect(mocker, tmp_path):
-    # A same-origin redirect must still carry the token, otherwise legitimate storage redirects break.
-    seen = _patch_redirecting_stream(mocker, redirect_to="https://storage.example/redirected")
-    source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
-
-    result = _operation_copy_http(
-        source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
-    )
-
-    assert result is True
-    assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
+    def test_operation_link_symbolic(self, mock_subprocess, logot: Logot, source_path, dest, expected_target):
+        source = TransferSourceLocal(path=Path(source_path))
+        mock_subprocess.return_value.returncode = 0
+        result = _operation_link_symbolic(source=source, output_path=Path(dest))
+        mock_subprocess.assert_called_once_with(["ln", "-s", expected_target, str(dest)], check=False)
+        logot.assert_logged(logged.info(f"ln -s {expected_target} {dest}"))
+        assert result
 
 
-# --- rsync / scp / cp / symlink operations --------------------------------------------------------
+class TestFetchToPathDispatch:
+    """fetch_to_path dispatch (new; the old dispatch tests stay in app-runner)."""
 
+    @pytest.fixture
+    def op_rsync(self, mocker):
+        return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_rsync", return_value=False)
 
-@pytest.fixture
-def mock_subprocess(mocker):
-    return mocker.patch("subprocess.run")
+    @pytest.fixture
+    def op_cp(self, mocker):
+        return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_cp", return_value=False)
 
+    @pytest.fixture
+    def op_scp(self, mocker):
+        return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_scp", return_value=False)
 
-@pytest.fixture
-def mock_shutil_copyfile(mocker):
-    return mocker.patch("shutil.copyfile")
+    @pytest.fixture
+    def op_link(self, mocker):
+        return mocker.patch("bfabric.transfer._generic.fetch._operation_link_symbolic", return_value=False)
 
+    def test_routes_http(self, mocker, tmp_path, op_rsync):
+        mock_http = mocker.patch("bfabric.transfer._generic.fetch._operation_copy_http", return_value=True)
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+        dest = tmp_path / "destination.txt"
 
-@pytest.fixture
-def mock_scp(mocker):
-    return mocker.patch("bfabric.transfer._generic.fetch.scp")
+        fetch_to_path(source, dest, Credentials(token_provider=lambda: "tok"))
 
+        mock_http.assert_called_once_with(source=source, output_path=dest, checksum=None, bearer_token="tok")
+        op_rsync.assert_not_called()
 
-def test_operation_copy_rsync_local(mock_subprocess, logot: Logot):
-    source = TransferSourceLocal(path=Path("/source.txt"))
-    mock_subprocess.return_value.returncode = 0
-    result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
-    mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "/source.txt", "mock_output.txt"], check=False)
-    logot.assert_logged(logged.info("rsync -rltvP /source.txt mock_output.txt"))
-    assert result
+    def test_local_falls_back_to_cp(self, op_rsync, op_cp, tmp_path):
+        op_rsync.return_value = False
+        op_cp.return_value = True
+        source = TransferSourceLocal(path=Path("/source.txt"))
+        dest = tmp_path / "destination.txt"
 
+        fetch_to_path(source, dest, Credentials())
 
-def test_operation_copy_rsync_ssh_default(mock_subprocess, logot: Logot):
-    source = TransferSourceSsh(host="host", path="/source.txt")
-    mock_subprocess.return_value.returncode = 0
-    result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
-    mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "host:/source.txt", "mock_output.txt"], check=False)
-    logot.assert_logged(logged.info("rsync -rltvP host:/source.txt mock_output.txt"))
-    assert result
+        op_rsync.assert_called_once_with(source, dest, None)
+        op_cp.assert_called_once_with(source, dest)
 
+    def test_ssh_falls_back_to_scp(self, op_rsync, op_scp, tmp_path):
+        op_rsync.return_value = False
+        op_scp.return_value = True
+        source = TransferSourceSsh(host="host", path="/source.txt")
+        dest = tmp_path / "destination.txt"
 
-def test_operation_copy_rsync_ssh_custom_user(mock_subprocess, logot: Logot):
-    source = TransferSourceSsh(host="host", path="/source.txt")
-    mock_subprocess.return_value.returncode = 0
-    result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
-    mock_subprocess.assert_called_once_with(
-        ["rsync", "-rltvP", "user@host:/source.txt", "mock_output.txt"], check=False
-    )
-    logot.assert_logged(logged.info("rsync -rltvP user@host:/source.txt mock_output.txt"))
-    assert result
+        fetch_to_path(source, dest, Credentials(ssh_user="user"))
 
+        op_rsync.assert_called_once_with(source, dest, "user")
+        op_scp.assert_called_once_with(source, dest, "user")
 
-def test_operation_copy_scp(mock_scp):
-    source = TransferSourceSsh(host="host", path="/source.txt")
-    result = _operation_copy_scp(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
-    mock_scp.assert_called_once_with(source="host:/source.txt", target=Path("mock_output.txt"), user="user")
-    assert result
+    def test_local_link(self, op_link, tmp_path):
+        op_link.return_value = True
+        source = TransferSourceLocal(path=Path("/source.txt"))
+        dest = tmp_path / "destination.txt"
 
-
-def test_operation_copy_scp_when_error(mock_scp):
-    mock_scp.side_effect = CalledProcessError(1, "scp")
-    source = TransferSourceSsh(host="host", path="/source.txt")
-    result = _operation_copy_scp(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
-    mock_scp.assert_called_once_with(source="host:/source.txt", target=Path("mock_output.txt"), user="user")
-    assert not result
-
-
-def test_operation_copy_cp(mock_shutil_copyfile, logot: Logot):
-    source = TransferSourceLocal(path=Path("/source.txt"))
-    result = _operation_copy_cp(source=source, output_path=Path("mock_output.txt"))
-    mock_shutil_copyfile.assert_called_once_with("/source.txt", "mock_output.txt")
-    logot.assert_logged(logged.info("cp /source.txt mock_output.txt"))
-    assert result
-
-
-def test_operation_copy_cp_when_error(mock_shutil_copyfile, logot: Logot):
-    mock_shutil_copyfile.side_effect = SameFileError
-    source = TransferSourceLocal(path=Path("/source.txt"))
-    result = _operation_copy_cp(source=source, output_path=Path("mock_output.txt"))
-    mock_shutil_copyfile.assert_called_once_with("/source.txt", "mock_output.txt")
-    logot.assert_logged(logged.info("cp /source.txt mock_output.txt"))
-    assert not result
-
-
-@pytest.mark.parametrize(
-    "source_path,dest,expected_target",
-    [
-        ("/E/source.txt", "/E/dir/destination.txt", "../source.txt"),
-        ("/X/source.txt", "/E/dir/destination.txt", "../../X/source.txt"),
-        ("/work/source.txt", "/work/destination.txt", "source.txt"),
-    ],
-)
-def test_operation_link_symbolic(mock_subprocess, logot: Logot, source_path, dest, expected_target):
-    source = TransferSourceLocal(path=Path(source_path))
-    mock_subprocess.return_value.returncode = 0
-    result = _operation_link_symbolic(source=source, output_path=Path(dest))
-    mock_subprocess.assert_called_once_with(["ln", "-s", expected_target, str(dest)], check=False)
-    logot.assert_logged(logged.info(f"ln -s {expected_target} {dest}"))
-    assert result
-
-
-# --- fetch_to_path dispatch (new; the old dispatch tests stay in app-runner) ----------------------
-
-
-@pytest.fixture
-def op_rsync(mocker):
-    return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_rsync", return_value=False)
-
-
-@pytest.fixture
-def op_cp(mocker):
-    return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_cp", return_value=False)
-
-
-@pytest.fixture
-def op_scp(mocker):
-    return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_scp", return_value=False)
-
-
-@pytest.fixture
-def op_link(mocker):
-    return mocker.patch("bfabric.transfer._generic.fetch._operation_link_symbolic", return_value=False)
-
-
-def test_fetch_to_path_routes_http(mocker, tmp_path, op_rsync):
-    mock_http = mocker.patch("bfabric.transfer._generic.fetch._operation_copy_http", return_value=True)
-    source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
-    dest = tmp_path / "destination.txt"
-
-    fetch_to_path(source, dest, Credentials(token_provider=lambda: "tok"))
-
-    mock_http.assert_called_once_with(source=source, output_path=dest, checksum=None, bearer_token="tok")
-    op_rsync.assert_not_called()
-
-
-def test_fetch_to_path_local_falls_back_to_cp(op_rsync, op_cp, tmp_path):
-    op_rsync.return_value = False
-    op_cp.return_value = True
-    source = TransferSourceLocal(path=Path("/source.txt"))
-    dest = tmp_path / "destination.txt"
-
-    fetch_to_path(source, dest, Credentials())
-
-    op_rsync.assert_called_once_with(source, dest, None)
-    op_cp.assert_called_once_with(source, dest)
-
-
-def test_fetch_to_path_ssh_falls_back_to_scp(op_rsync, op_scp, tmp_path):
-    op_rsync.return_value = False
-    op_scp.return_value = True
-    source = TransferSourceSsh(host="host", path="/source.txt")
-    dest = tmp_path / "destination.txt"
-
-    fetch_to_path(source, dest, Credentials(ssh_user="user"))
-
-    op_rsync.assert_called_once_with(source, dest, "user")
-    op_scp.assert_called_once_with(source, dest, "user")
-
-
-def test_fetch_to_path_local_link(op_link, tmp_path):
-    op_link.return_value = True
-    source = TransferSourceLocal(path=Path("/source.txt"))
-    dest = tmp_path / "destination.txt"
-
-    fetch_to_path(source, dest, Credentials(), link_ok=True)
-
-    op_link.assert_called_once_with(source, dest)
-
-
-def test_fetch_to_path_link_raises_for_non_local_source(tmp_path):
-    source = TransferSourceSsh(host="host", path="/source.txt")
-    dest = tmp_path / "destination.txt"
-
-    with pytest.raises(TransferError, match="Cannot link a non-local file"):
         fetch_to_path(source, dest, Credentials(), link_ok=True)
 
+        op_link.assert_called_once_with(source, dest)
 
-def test_fetch_to_path_raises_when_all_operations_fail(op_rsync, op_cp, tmp_path):
-    op_rsync.return_value = False
-    op_cp.return_value = False
-    source = TransferSourceLocal(path=Path("/source.txt"))
-    dest = tmp_path / "destination.txt"
+    def test_link_raises_for_non_local_source(self, tmp_path):
+        source = TransferSourceSsh(host="host", path="/source.txt")
+        dest = tmp_path / "destination.txt"
 
-    with pytest.raises(TransferError, match="Failed to fetch"):
-        fetch_to_path(source, dest, Credentials())
+        with pytest.raises(TransferError, match="Cannot link a non-local file"):
+            fetch_to_path(source, dest, Credentials(), link_ok=True)
+
+    def test_raises_when_all_operations_fail(self, op_rsync, op_cp, tmp_path):
+        op_rsync.return_value = False
+        op_cp.return_value = False
+        source = TransferSourceLocal(path=Path("/source.txt"))
+        dest = tmp_path / "destination.txt"
+
+        with pytest.raises(TransferError, match="Failed to fetch"):
+            fetch_to_path(source, dest, Credentials())

--- a/tests/bfabric/transfer/generic/test_fetch.py
+++ b/tests/bfabric/transfer/generic/test_fetch.py
@@ -29,28 +29,29 @@ from bfabric.transfer._generic.sources import (
 )
 
 
+@pytest.fixture
+def mock_http_stream(mocker):
+    """Patches httpx.stream to yield a response with the given body; returns the patch factory."""
+
+    def _make(body: bytes = b"hello world", raise_error: BaseException | None = None):
+        response = mocker.MagicMock()
+        response.iter_bytes.return_value = [body]
+        response.raise_for_status.side_effect = raise_error
+        cm = mocker.MagicMock()
+        cm.__enter__.return_value = response
+        cm.__exit__.return_value = False
+        return mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", return_value=cm)
+
+    return _make
+
+
 class TestOperationCopyHttp:
-    @pytest.fixture
-    def mock_http_stream(self, mocker):
-        """Patches httpx.stream to yield a response with the given body; returns (patch, set_body)."""
-
-        def _make(body: bytes = b"hello world", raise_error: BaseException | None = None):
-            response = mocker.MagicMock()
-            response.iter_bytes.return_value = [body]
-            response.raise_for_status.side_effect = raise_error
-            cm = mocker.MagicMock()
-            cm.__enter__.return_value = response
-            cm.__exit__.return_value = False
-            return mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", return_value=cm)
-
-        return _make
-
     def test_anonymous_success(self, mock_http_stream, tmp_path):
         stream = mock_http_stream(body=b"payload")
         output_path = tmp_path / "out.txt"
         source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
 
-        result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+        result = _operation_copy_http(source=source, output_path=output_path, bearer_token=None)
 
         assert result is True
         assert output_path.read_bytes() == b"payload"
@@ -64,7 +65,7 @@ class TestOperationCopyHttp:
         output_path = tmp_path / "out.txt"
         source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
 
-        result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
+        result = _operation_copy_http(source=source, output_path=output_path, bearer_token="jwt-token")
 
         assert result is True
         headers = stream.call_args.kwargs["headers"]
@@ -75,14 +76,14 @@ class TestOperationCopyHttp:
         source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
 
         with pytest.raises(TransferError, match="OAuth-backed client"):
-            _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+            _operation_copy_http(source=source, output_path=output_path, bearer_token=None)
 
     def test_does_not_send_token_when_not_required(self, mock_http_stream, tmp_path):
         stream = mock_http_stream(body=b"payload")
         output_path = tmp_path / "out.txt"
         source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
 
-        _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
+        _operation_copy_http(source=source, output_path=output_path, bearer_token="jwt-token")
 
         # Even if a token is available, an anonymous (auth=None) URL must not receive it.
         headers = stream.call_args.kwargs["headers"]
@@ -93,28 +94,9 @@ class TestOperationCopyHttp:
         output_path = tmp_path / "out.txt"
         source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
 
-        result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+        result = _operation_copy_http(source=source, output_path=output_path, bearer_token=None)
 
         assert result is False
-
-    def test_checksum_ok(self, mock_http_stream, tmp_path):
-        body = b"payload"
-        checksum = hashlib.md5(body).hexdigest()
-        mock_http_stream(body=body)
-        output_path = tmp_path / "out.txt"
-        source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
-
-        assert (
-            _operation_copy_http(source=source, output_path=output_path, checksum=checksum, bearer_token=None) is True
-        )
-
-    def test_checksum_mismatch_raises(self, mock_http_stream, tmp_path):
-        mock_http_stream(body=b"payload")
-        output_path = tmp_path / "out.txt"
-        source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
-
-        with pytest.raises(TransferError, match="Checksum mismatch"):
-            _operation_copy_http(source=source, output_path=output_path, checksum="deadbeef", bearer_token=None)
 
 
 class TestVerifyChecksum:
@@ -135,16 +117,14 @@ class TestVerifyChecksum:
 
         assert not tmp_file.exists()
 
-    def test_none_skips_and_warns(self, tmp_path, logot: Logot):
+    def test_none_skips_and_logs_debug(self, tmp_path, logot: Logot):
         tmp_file = tmp_path / "download.part"
         tmp_file.write_bytes(b"payload")
         output_path = tmp_path / "out.txt"
 
         _verify_checksum(tmp_file, None, output_path)
 
-        logot.assert_logged(
-            logged.warning(f"No checksum available for {output_path}; skipping integrity verification.")
-        )
+        logot.assert_logged(logged.debug(f"No checksum available for {output_path}; skipping integrity verification."))
 
 
 class TestHttpRedirectTrustBoundary:
@@ -181,9 +161,7 @@ class TestHttpRedirectTrustBoundary:
         seen = self._patch_redirecting_stream(mocker, redirect_to="https://cdn.example/redirected")
         source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
 
-        result = _operation_copy_http(
-            source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
-        )
+        result = _operation_copy_http(source=source, output_path=tmp_path / "out.txt", bearer_token="jwt-token")
 
         assert result is True
         assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
@@ -194,9 +172,7 @@ class TestHttpRedirectTrustBoundary:
         seen = self._patch_redirecting_stream(mocker, redirect_to="https://storage.example/redirected")
         source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
 
-        result = _operation_copy_http(
-            source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
-        )
+        result = _operation_copy_http(source=source, output_path=tmp_path / "out.txt", bearer_token="jwt-token")
 
         assert result is True
         assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
@@ -316,7 +292,7 @@ class TestCopyOperations:
 
 
 class TestFetchToPathDispatch:
-    """fetch_to_path dispatch (new; the old dispatch tests stay in app-runner)."""
+    """fetch_to_path transport dispatch (the old dispatch tests stay in app-runner)."""
 
     @pytest.fixture
     def op_rsync(self, mocker):
@@ -334,37 +310,53 @@ class TestFetchToPathDispatch:
     def op_link(self, mocker):
         return mocker.patch("bfabric.transfer._generic.fetch._operation_link_symbolic", return_value=False)
 
+    @staticmethod
+    def _writes(tmp: Path, body: bytes = b"data"):
+        """Returns an op stand-in that writes ``body`` to ``tmp`` and reports success."""
+
+        def _op(*args, **kwargs):
+            tmp.write_bytes(body)
+            return True
+
+        return _op
+
     def test_routes_http(self, mocker, tmp_path, op_rsync):
-        mock_http = mocker.patch("bfabric.transfer._generic.fetch._operation_copy_http", return_value=True)
-        source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
         dest = tmp_path / "destination.txt"
+        tmp = dest.with_name("destination.txt.part")
+        mock_http = mocker.patch("bfabric.transfer._generic.fetch._operation_copy_http", side_effect=self._writes(tmp))
+        source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
 
         fetch_to_path(source, dest, Credentials(token_provider=lambda: "tok"))
 
-        mock_http.assert_called_once_with(source=source, output_path=dest, checksum=None, bearer_token="tok")
+        mock_http.assert_called_once_with(source=source, output_path=tmp, bearer_token="tok")
         op_rsync.assert_not_called()
+        assert dest.exists()
 
     def test_local_falls_back_to_cp(self, op_rsync, op_cp, tmp_path):
-        op_rsync.return_value = False
-        op_cp.return_value = True
-        source = TransferSourceLocal(path=Path("/source.txt"))
         dest = tmp_path / "destination.txt"
+        tmp = dest.with_name("destination.txt.part")
+        op_rsync.return_value = False
+        op_cp.side_effect = self._writes(tmp)
+        source = TransferSourceLocal(path=Path("/source.txt"))
 
         fetch_to_path(source, dest, Credentials())
 
-        op_rsync.assert_called_once_with(source, dest, None)
-        op_cp.assert_called_once_with(source, dest)
+        op_rsync.assert_called_once_with(source, tmp, None)
+        op_cp.assert_called_once_with(source, tmp)
+        assert dest.exists()
 
     def test_ssh_falls_back_to_scp(self, op_rsync, op_scp, tmp_path):
-        op_rsync.return_value = False
-        op_scp.return_value = True
-        source = TransferSourceSsh(host="host", path="/source.txt")
         dest = tmp_path / "destination.txt"
+        tmp = dest.with_name("destination.txt.part")
+        op_rsync.return_value = False
+        op_scp.side_effect = self._writes(tmp)
+        source = TransferSourceSsh(host="host", path="/source.txt")
 
         fetch_to_path(source, dest, Credentials(ssh_user="user"))
 
-        op_rsync.assert_called_once_with(source, dest, "user")
-        op_scp.assert_called_once_with(source, dest, "user")
+        op_rsync.assert_called_once_with(source, tmp, "user")
+        op_scp.assert_called_once_with(source, tmp, "user")
+        assert dest.exists()
 
     def test_local_link(self, op_link, tmp_path):
         op_link.return_value = True
@@ -390,3 +382,101 @@ class TestFetchToPathDispatch:
 
         with pytest.raises(TransferError, match="Failed to fetch"):
             fetch_to_path(source, dest, Credentials())
+
+        assert not dest.exists()
+        assert not dest.with_name("destination.txt.part").exists()
+
+
+class TestFetchToPathChecksum:
+    """fetch_to_path verifies the checksum and atomically publishes on every transport."""
+
+    def test_cp_match_publishes(self, mocker, tmp_path):
+        # rsync fails so the real cp path runs, then the real verify + atomic rename.
+        mocker.patch("bfabric.transfer._generic.fetch._operation_copy_rsync", return_value=False)
+        src = tmp_path / "source.txt"
+        src.write_bytes(b"payload")
+        dest = tmp_path / "out" / "destination.txt"
+        source = TransferSourceLocal(path=src)
+
+        fetch_to_path(source, dest, Credentials(), checksum=hashlib.md5(b"payload").hexdigest())
+
+        assert dest.read_bytes() == b"payload"
+        assert not dest.with_name("destination.txt.part").exists()
+
+    def test_cp_mismatch_raises_and_cleans(self, mocker, tmp_path):
+        mocker.patch("bfabric.transfer._generic.fetch._operation_copy_rsync", return_value=False)
+        src = tmp_path / "source.txt"
+        src.write_bytes(b"payload")
+        dest = tmp_path / "out" / "destination.txt"
+        source = TransferSourceLocal(path=src)
+
+        with pytest.raises(TransferError, match="Checksum mismatch"):
+            fetch_to_path(source, dest, Credentials(), checksum="deadbeef")
+
+        assert not dest.exists()
+        assert not dest.with_name("destination.txt.part").exists()
+
+    def test_ssh_scp_mismatch_raises_and_cleans(self, mocker, tmp_path):
+        # rsync fails, scp "succeeds" (writes the temp), then verification rejects the bytes.
+        mocker.patch("bfabric.transfer._generic.fetch._operation_copy_rsync", return_value=False)
+
+        def _scp(source, output_path, ssh_user):
+            output_path.write_bytes(b"payload")
+            return True
+
+        mocker.patch("bfabric.transfer._generic.fetch._operation_copy_scp", side_effect=_scp)
+        dest = tmp_path / "destination.txt"
+        source = TransferSourceSsh(host="host", path="/f.txt")
+
+        with pytest.raises(TransferError, match="Checksum mismatch"):
+            fetch_to_path(source, dest, Credentials(ssh_user="user"), checksum="deadbeef")
+
+        assert not dest.exists()
+        assert not dest.with_name("destination.txt.part").exists()
+
+    def test_http_mismatch_raises_and_cleans(self, mock_http_stream, tmp_path):
+        mock_http_stream(body=b"payload")
+        dest = tmp_path / "destination.txt"
+        source = TransferSourceHttp(url="https://host/f.txt", auth=None)
+
+        with pytest.raises(TransferError, match="Checksum mismatch"):
+            fetch_to_path(source, dest, Credentials(), checksum="deadbeef")
+
+        assert not dest.exists()
+        assert not dest.with_name("destination.txt.part").exists()
+
+    def test_http_match_publishes(self, mock_http_stream, tmp_path):
+        body = b"payload"
+        mock_http_stream(body=body)
+        dest = tmp_path / "sub" / "destination.txt"
+        source = TransferSourceHttp(url="https://host/f.txt", auth=None)
+
+        fetch_to_path(source, dest, Credentials(), checksum=hashlib.md5(body).hexdigest())
+
+        assert dest.read_bytes() == body
+        assert not dest.with_name("destination.txt.part").exists()
+
+    def test_symlink_match_keeps_link(self, tmp_path):
+        src = tmp_path / "source.txt"
+        src.write_bytes(b"payload")
+        dest = tmp_path / "out" / "destination.txt"
+        source = TransferSourceLocal(path=src)
+
+        fetch_to_path(source, dest, Credentials(), checksum=hashlib.md5(b"payload").hexdigest(), link_ok=True)
+
+        assert dest.is_symlink()
+        assert dest.read_bytes() == b"payload"
+
+    def test_symlink_mismatch_removes_link_and_raises(self, tmp_path):
+        src = tmp_path / "source.txt"
+        src.write_bytes(b"payload")
+        dest = tmp_path / "out" / "destination.txt"
+        source = TransferSourceLocal(path=src)
+
+        with pytest.raises(TransferError, match="Checksum mismatch"):
+            fetch_to_path(source, dest, Credentials(), checksum="deadbeef", link_ok=True)
+
+        assert not dest.is_symlink()
+        assert not dest.exists()
+        # The verification failure must remove only the link, never the source file.
+        assert src.read_bytes() == b"payload"

--- a/tests/bfabric/transfer/generic/test_fetch.py
+++ b/tests/bfabric/transfer/generic/test_fetch.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+from pathlib import Path
+from shutil import SameFileError
+from subprocess import CalledProcessError
+
+import httpx
+import pytest
+from logot import Logot, logged
+
+from bfabric.transfer._generic.credentials import Credentials
+from bfabric.transfer._generic.errors import TransferError
+from bfabric.transfer._generic.fetch import (
+    _operation_copy_cp,
+    _operation_copy_http,
+    _operation_copy_rsync,
+    _operation_copy_scp,
+    _operation_link_symbolic,
+    _verify_checksum,
+    fetch_to_path,
+)
+from bfabric.transfer._generic.sources import (
+    TransferSourceHttp,
+    TransferSourceLocal,
+    TransferSourceSsh,
+)
+
+# --- HTTP operation -------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_http_stream(mocker):
+    """Patches httpx.stream to yield a response with the given body; returns (patch, set_body)."""
+
+    def _make(body: bytes = b"hello world", raise_error: BaseException | None = None):
+        response = mocker.MagicMock()
+        response.iter_bytes.return_value = [body]
+        response.raise_for_status.side_effect = raise_error
+        cm = mocker.MagicMock()
+        cm.__enter__.return_value = response
+        cm.__exit__.return_value = False
+        return mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", return_value=cm)
+
+    return _make
+
+
+def test_operation_copy_http_anonymous_success(mock_http_stream, tmp_path):
+    stream = mock_http_stream(body=b"payload")
+    output_path = tmp_path / "out.txt"
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+    result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+
+    assert result is True
+    assert output_path.read_bytes() == b"payload"
+    # No Authorization header for anonymous downloads.
+    headers = stream.call_args.kwargs["headers"]
+    assert "Authorization" not in headers
+    assert stream.call_args.kwargs["follow_redirects"] is True
+
+
+def test_operation_copy_http_sends_bearer_when_required(mock_http_stream, tmp_path):
+    stream = mock_http_stream(body=b"payload")
+    output_path = tmp_path / "out.txt"
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+
+    result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
+
+    assert result is True
+    headers = stream.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer jwt-token"
+
+
+def test_operation_copy_http_require_auth_without_token_raises(tmp_path):
+    output_path = tmp_path / "out.txt"
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+
+    with pytest.raises(TransferError, match="OAuth-backed client"):
+        _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+
+
+def test_operation_copy_http_does_not_send_token_when_not_required(mock_http_stream, tmp_path):
+    stream = mock_http_stream(body=b"payload")
+    output_path = tmp_path / "out.txt"
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+    _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token="jwt-token")
+
+    # Even if a token is available, an anonymous (auth=None) URL must not receive it.
+    headers = stream.call_args.kwargs["headers"]
+    assert "Authorization" not in headers
+
+
+def test_operation_copy_http_http_error_returns_false(mock_http_stream, tmp_path):
+    mock_http_stream(body=b"", raise_error=httpx.HTTPError("403 Forbidden"))
+    output_path = tmp_path / "out.txt"
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+    result = _operation_copy_http(source=source, output_path=output_path, checksum=None, bearer_token=None)
+
+    assert result is False
+
+
+def test_operation_copy_http_checksum_ok(mock_http_stream, tmp_path):
+    body = b"payload"
+    checksum = hashlib.md5(body).hexdigest()
+    mock_http_stream(body=body)
+    output_path = tmp_path / "out.txt"
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+    assert _operation_copy_http(source=source, output_path=output_path, checksum=checksum, bearer_token=None) is True
+
+
+def test_operation_copy_http_checksum_mismatch_raises(mock_http_stream, tmp_path):
+    mock_http_stream(body=b"payload")
+    output_path = tmp_path / "out.txt"
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth=None)
+
+    with pytest.raises(TransferError, match="Checksum mismatch"):
+        _operation_copy_http(source=source, output_path=output_path, checksum="deadbeef", bearer_token=None)
+
+
+# --- checksum verification ------------------------------------------------------------------------
+
+
+def test_verify_checksum_ok(tmp_path):
+    tmp_file = tmp_path / "download.part"
+    tmp_file.write_bytes(b"payload")
+    checksum = hashlib.md5(b"payload").hexdigest()
+
+    _verify_checksum(tmp_file, checksum, tmp_path / "out.txt")  # does not raise
+    assert tmp_file.exists()
+
+
+def test_verify_checksum_mismatch_raises(tmp_path):
+    tmp_file = tmp_path / "download.part"
+    tmp_file.write_bytes(b"payload")
+
+    with pytest.raises(TransferError, match="Checksum mismatch"):
+        _verify_checksum(tmp_file, "deadbeef", tmp_path / "out.txt")
+
+    assert not tmp_file.exists()
+
+
+def test_verify_checksum_none_skips_and_warns(tmp_path, logot: Logot):
+    tmp_file = tmp_path / "download.part"
+    tmp_file.write_bytes(b"payload")
+    output_path = tmp_path / "out.txt"
+
+    _verify_checksum(tmp_file, None, output_path)
+
+    logot.assert_logged(logged.warning(f"No checksum available for {output_path}; skipping integrity verification."))
+
+
+# --- redirect / trust-boundary behavior -----------------------------------------------------------
+
+
+def _patch_redirecting_stream(mocker, redirect_to: str) -> dict[str, httpx.Headers]:
+    """Patches httpx.stream so a GET to ``/file`` 302-redirects to ``redirect_to``.
+
+    Routes the download through a real httpx client backed by MockTransport, so httpx's own
+    cross-origin ``Authorization``-stripping is actually exercised. Returns a per-host record of the
+    request headers seen by the transport.
+    """
+    seen: dict[str, httpx.Headers] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen[request.url.host] = request.headers
+        if request.url.path == "/file":
+            return httpx.Response(302, headers={"Location": redirect_to})
+        return httpx.Response(200, content=b"payload")
+
+    transport = httpx.MockTransport(handler)
+
+    @contextlib.contextmanager
+    def fake_stream(method, url, *, headers=None, follow_redirects=False, **kwargs):
+        with httpx.Client(transport=transport, follow_redirects=follow_redirects) as client:
+            with client.stream(method, url, headers=headers) as response:
+                yield response
+
+    mocker.patch("bfabric.transfer._generic.fetch.httpx.stream", side_effect=fake_stream)
+    return seen
+
+
+def test_operation_copy_http_strips_auth_on_cross_origin_redirect(mocker, tmp_path):
+    # The trust boundary relies on httpx dropping Authorization when a storage URL redirects off-origin
+    # (e.g. to a presigned CDN link); guard that behavior so an httpx upgrade cannot silently break it.
+    seen = _patch_redirecting_stream(mocker, redirect_to="https://cdn.example/redirected")
+    source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
+
+    result = _operation_copy_http(
+        source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
+    )
+
+    assert result is True
+    assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
+    assert "authorization" not in seen["cdn.example"]
+
+
+def test_operation_copy_http_keeps_auth_on_same_origin_redirect(mocker, tmp_path):
+    # A same-origin redirect must still carry the token, otherwise legitimate storage redirects break.
+    seen = _patch_redirecting_stream(mocker, redirect_to="https://storage.example/redirected")
+    source = TransferSourceHttp(url="https://storage.example/file", auth="bfabric")
+
+    result = _operation_copy_http(
+        source=source, output_path=tmp_path / "out.txt", checksum=None, bearer_token="jwt-token"
+    )
+
+    assert result is True
+    assert seen["storage.example"]["Authorization"] == "Bearer jwt-token"
+
+
+# --- rsync / scp / cp / symlink operations --------------------------------------------------------
+
+
+@pytest.fixture
+def mock_subprocess(mocker):
+    return mocker.patch("subprocess.run")
+
+
+@pytest.fixture
+def mock_shutil_copyfile(mocker):
+    return mocker.patch("shutil.copyfile")
+
+
+@pytest.fixture
+def mock_scp(mocker):
+    return mocker.patch("bfabric.transfer._generic.fetch.scp")
+
+
+def test_operation_copy_rsync_local(mock_subprocess, logot: Logot):
+    source = TransferSourceLocal(path=Path("/source.txt"))
+    mock_subprocess.return_value.returncode = 0
+    result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
+    mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "/source.txt", "mock_output.txt"], check=False)
+    logot.assert_logged(logged.info("rsync -rltvP /source.txt mock_output.txt"))
+    assert result
+
+
+def test_operation_copy_rsync_ssh_default(mock_subprocess, logot: Logot):
+    source = TransferSourceSsh(host="host", path="/source.txt")
+    mock_subprocess.return_value.returncode = 0
+    result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
+    mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "host:/source.txt", "mock_output.txt"], check=False)
+    logot.assert_logged(logged.info("rsync -rltvP host:/source.txt mock_output.txt"))
+    assert result
+
+
+def test_operation_copy_rsync_ssh_custom_user(mock_subprocess, logot: Logot):
+    source = TransferSourceSsh(host="host", path="/source.txt")
+    mock_subprocess.return_value.returncode = 0
+    result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
+    mock_subprocess.assert_called_once_with(
+        ["rsync", "-rltvP", "user@host:/source.txt", "mock_output.txt"], check=False
+    )
+    logot.assert_logged(logged.info("rsync -rltvP user@host:/source.txt mock_output.txt"))
+    assert result
+
+
+def test_operation_copy_scp(mock_scp):
+    source = TransferSourceSsh(host="host", path="/source.txt")
+    result = _operation_copy_scp(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
+    mock_scp.assert_called_once_with(source="host:/source.txt", target=Path("mock_output.txt"), user="user")
+    assert result
+
+
+def test_operation_copy_scp_when_error(mock_scp):
+    mock_scp.side_effect = CalledProcessError(1, "scp")
+    source = TransferSourceSsh(host="host", path="/source.txt")
+    result = _operation_copy_scp(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
+    mock_scp.assert_called_once_with(source="host:/source.txt", target=Path("mock_output.txt"), user="user")
+    assert not result
+
+
+def test_operation_copy_cp(mock_shutil_copyfile, logot: Logot):
+    source = TransferSourceLocal(path=Path("/source.txt"))
+    result = _operation_copy_cp(source=source, output_path=Path("mock_output.txt"))
+    mock_shutil_copyfile.assert_called_once_with("/source.txt", "mock_output.txt")
+    logot.assert_logged(logged.info("cp /source.txt mock_output.txt"))
+    assert result
+
+
+def test_operation_copy_cp_when_error(mock_shutil_copyfile, logot: Logot):
+    mock_shutil_copyfile.side_effect = SameFileError
+    source = TransferSourceLocal(path=Path("/source.txt"))
+    result = _operation_copy_cp(source=source, output_path=Path("mock_output.txt"))
+    mock_shutil_copyfile.assert_called_once_with("/source.txt", "mock_output.txt")
+    logot.assert_logged(logged.info("cp /source.txt mock_output.txt"))
+    assert not result
+
+
+@pytest.mark.parametrize(
+    "source_path,dest,expected_target",
+    [
+        ("/E/source.txt", "/E/dir/destination.txt", "../source.txt"),
+        ("/X/source.txt", "/E/dir/destination.txt", "../../X/source.txt"),
+        ("/work/source.txt", "/work/destination.txt", "source.txt"),
+    ],
+)
+def test_operation_link_symbolic(mock_subprocess, logot: Logot, source_path, dest, expected_target):
+    source = TransferSourceLocal(path=Path(source_path))
+    mock_subprocess.return_value.returncode = 0
+    result = _operation_link_symbolic(source=source, output_path=Path(dest))
+    mock_subprocess.assert_called_once_with(["ln", "-s", expected_target, str(dest)], check=False)
+    logot.assert_logged(logged.info(f"ln -s {expected_target} {dest}"))
+    assert result
+
+
+# --- fetch_to_path dispatch (new; the old dispatch tests stay in app-runner) ----------------------
+
+
+@pytest.fixture
+def op_rsync(mocker):
+    return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_rsync", return_value=False)
+
+
+@pytest.fixture
+def op_cp(mocker):
+    return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_cp", return_value=False)
+
+
+@pytest.fixture
+def op_scp(mocker):
+    return mocker.patch("bfabric.transfer._generic.fetch._operation_copy_scp", return_value=False)
+
+
+@pytest.fixture
+def op_link(mocker):
+    return mocker.patch("bfabric.transfer._generic.fetch._operation_link_symbolic", return_value=False)
+
+
+def test_fetch_to_path_routes_http(mocker, tmp_path, op_rsync):
+    mock_http = mocker.patch("bfabric.transfer._generic.fetch._operation_copy_http", return_value=True)
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+    dest = tmp_path / "destination.txt"
+
+    fetch_to_path(source, dest, Credentials(token_provider=lambda: "tok"))
+
+    mock_http.assert_called_once_with(source=source, output_path=dest, checksum=None, bearer_token="tok")
+    op_rsync.assert_not_called()
+
+
+def test_fetch_to_path_local_falls_back_to_cp(op_rsync, op_cp, tmp_path):
+    op_rsync.return_value = False
+    op_cp.return_value = True
+    source = TransferSourceLocal(path=Path("/source.txt"))
+    dest = tmp_path / "destination.txt"
+
+    fetch_to_path(source, dest, Credentials())
+
+    op_rsync.assert_called_once_with(source, dest, None)
+    op_cp.assert_called_once_with(source, dest)
+
+
+def test_fetch_to_path_ssh_falls_back_to_scp(op_rsync, op_scp, tmp_path):
+    op_rsync.return_value = False
+    op_scp.return_value = True
+    source = TransferSourceSsh(host="host", path="/source.txt")
+    dest = tmp_path / "destination.txt"
+
+    fetch_to_path(source, dest, Credentials(ssh_user="user"))
+
+    op_rsync.assert_called_once_with(source, dest, "user")
+    op_scp.assert_called_once_with(source, dest, "user")
+
+
+def test_fetch_to_path_local_link(op_link, tmp_path):
+    op_link.return_value = True
+    source = TransferSourceLocal(path=Path("/source.txt"))
+    dest = tmp_path / "destination.txt"
+
+    fetch_to_path(source, dest, Credentials(), link_ok=True)
+
+    op_link.assert_called_once_with(source, dest)
+
+
+def test_fetch_to_path_link_raises_for_non_local_source(tmp_path):
+    source = TransferSourceSsh(host="host", path="/source.txt")
+    dest = tmp_path / "destination.txt"
+
+    with pytest.raises(TransferError, match="Cannot link a non-local file"):
+        fetch_to_path(source, dest, Credentials(), link_ok=True)
+
+
+def test_fetch_to_path_raises_when_all_operations_fail(op_rsync, op_cp, tmp_path):
+    op_rsync.return_value = False
+    op_cp.return_value = False
+    source = TransferSourceLocal(path=Path("/source.txt"))
+    dest = tmp_path / "destination.txt"
+
+    with pytest.raises(TransferError, match="Failed to fetch"):
+        fetch_to_path(source, dest, Credentials())

--- a/tests/bfabric/transfer/generic/test_generic_sources.py
+++ b/tests/bfabric/transfer/generic/test_generic_sources.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import TypeAdapter
+
+from bfabric.transfer._generic.sources import (
+    TransferSource,
+    TransferSourceHttp,
+    TransferSourceLocal,
+    TransferSourceSsh,
+)
+
+
+def test_local_construct_and_default_type():
+    source = TransferSourceLocal(path=Path("/data/file.txt"))
+    assert source.type == "local"
+    assert source.path == Path("/data/file.txt")
+
+
+def test_ssh_construct_and_default_type():
+    source = TransferSourceSsh(host="host", path="/data/file.txt")
+    assert source.type == "ssh"
+    assert source.host == "host"
+    assert source.path == "/data/file.txt"
+
+
+def test_http_construct_and_defaults():
+    source = TransferSourceHttp(url="https://host/data/f.txt")
+    assert source.type == "http"
+    assert source.url == "https://host/data/f.txt"
+    assert source.auth is None
+
+
+def test_http_auth_bfabric():
+    source = TransferSourceHttp(url="https://host/data/f.txt", auth="bfabric")
+    assert source.auth == "bfabric"
+
+
+def test_discriminated_union_validates_http():
+    source = TypeAdapter(TransferSource).validate_python({"type": "http", "url": "https://host/data/f.txt"})
+    assert isinstance(source, TransferSourceHttp)
+    assert source.url == "https://host/data/f.txt"
+
+
+def test_discriminated_union_validates_local():
+    source = TypeAdapter(TransferSource).validate_python({"type": "local", "path": "/data/file.txt"})
+    assert isinstance(source, TransferSourceLocal)
+    assert source.path == Path("/data/file.txt")
+
+
+def test_discriminated_union_validates_ssh():
+    source = TypeAdapter(TransferSource).validate_python({"type": "ssh", "host": "host", "path": "/data/file.txt"})
+    assert isinstance(source, TransferSourceSsh)
+    assert source.host == "host"
+    assert source.path == "/data/file.txt"

--- a/tests/bfabric/transfer/generic/test_scp.py
+++ b/tests/bfabric/transfer/generic/test_scp.py
@@ -48,9 +48,32 @@ def test_scp_upload_prepends_user_and_makes_remote_dir(mocker, mock_subprocess):
     scp(source="/local/file.txt", target="host:/remote/dir/file.txt", user="alice")
 
     assert mock_subprocess.call_args_list == [
-        mocker.call(["ssh", "alice@host", "mkdir", "-p", Path("/remote/dir")], check=True),
+        mocker.call(["ssh", "alice@host", "mkdir", "-p", "/remote/dir"], check=True),
         mocker.call(["scp", "/local/file.txt", "alice@host:/remote/dir/file.txt"], check=True),
     ]
+
+
+def test_scp_quotes_remote_mkdir_path(mocker, mock_subprocess):
+    # ssh runs its trailing args through the remote shell, so a directory containing shell
+    # metacharacters must be quoted -- otherwise it would execute arbitrary commands on the host.
+    scp(source="/local/file.txt", target="host:/remote/$(touch pwned)/file.txt")
+
+    ssh_call = mock_subprocess.call_args_list[0]
+    assert ssh_call == mocker.call(["ssh", "host", "mkdir", "-p", "'/remote/$(touch pwned)'"], check=True)
+
+
+def test_scp_rejects_option_like_target(mock_subprocess):
+    # A target beginning with '-' would be parsed by scp/ssh as an option (e.g. -oProxyCommand=...),
+    # smuggling local command execution into the invocation; reject it before it reaches the command line.
+    with pytest.raises(ValueError, match="must not start with '-'"):
+        scp(source="/local/file.txt", target="-oProxyCommand=touch pwned:/x")
+    mock_subprocess.assert_not_called()
+
+
+def test_scp_rejects_option_like_source(mock_subprocess):
+    with pytest.raises(ValueError, match="must not start with '-'"):
+        scp(source="-oProxyCommand=touch pwned:/x", target="/local/file.txt")
+    mock_subprocess.assert_not_called()
 
 
 def test_scp_download_prepends_user_and_makes_local_dir(mock_subprocess, tmp_path):

--- a/tests/bfabric/transfer/generic/test_scp.py
+++ b/tests/bfabric/transfer/generic/test_scp.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bfabric.transfer._generic.scp import _is_remote, scp
+
+
+@pytest.fixture
+def mock_subprocess(mocker):
+    return mocker.patch("subprocess.run")
+
+
+def test_is_remote():
+    assert _is_remote("host:/path") is True
+    assert _is_remote("user@host:/path") is True
+    assert _is_remote("host:relative/path") is True
+    assert _is_remote("/local/path") is False
+    assert _is_remote(Path("/local/path")) is False
+    # A Windows drive letter is a local path, not a host:path spec.
+    assert _is_remote("C:\\Users\\file.txt") is False
+    assert _is_remote("C:/Users/file.txt") is False
+    # A colon after the first path separator belongs to the local path, not a host.
+    assert _is_remote("./weird:name") is False
+
+
+def test_scp_rejects_both_remote(mock_subprocess):
+    with pytest.raises(ValueError, match="not both"):
+        scp(source="host1:/a", target="host2:/b")
+    mock_subprocess.assert_not_called()
+
+
+def test_scp_rejects_neither_remote(mock_subprocess):
+    with pytest.raises(ValueError, match="not both"):
+        scp(source="/a", target="/b")
+    mock_subprocess.assert_not_called()
+
+
+def test_scp_rejects_directory_target(mock_subprocess):
+    with pytest.raises(ValueError, match="not a directory"):
+        scp(source="host:/remote/file.txt", target="/local/dir/")
+    mock_subprocess.assert_not_called()
+
+
+def test_scp_upload_prepends_user_and_makes_remote_dir(mocker, mock_subprocess):
+    # remote target (upload): user@ is prepended to the target, and the remote parent is created via ssh.
+    scp(source="/local/file.txt", target="host:/remote/dir/file.txt", user="alice")
+
+    assert mock_subprocess.call_args_list == [
+        mocker.call(["ssh", "alice@host", "mkdir", "-p", Path("/remote/dir")], check=True),
+        mocker.call(["scp", "/local/file.txt", "alice@host:/remote/dir/file.txt"], check=True),
+    ]
+
+
+def test_scp_download_prepends_user_and_makes_local_dir(mock_subprocess, tmp_path):
+    # remote source (download): user@ is prepended to the source, and the local parent is created directly.
+    target = tmp_path / "sub" / "file.txt"
+    scp(source="host:/remote/file.txt", target=target, user="bob")
+
+    assert (tmp_path / "sub").is_dir()
+    mock_subprocess.assert_called_once_with(["scp", "bob@host:/remote/file.txt", str(target)], check=True)
+
+
+def test_scp_no_mkdir_skips_directory_creation(mock_subprocess, tmp_path):
+    target = tmp_path / "sub" / "file.txt"
+    scp(source="host:/remote/file.txt", target=target, mkdir=False)
+
+    assert not (tmp_path / "sub").exists()
+    mock_subprocess.assert_called_once_with(["scp", "host:/remote/file.txt", str(target)], check=True)

--- a/tests/bfabric/transfer/generic/test_send.py
+++ b/tests/bfabric/transfer/generic/test_send.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from subprocess import CalledProcessError
+
+import pytest
+from bfabric.transfer._generic import _tus_mover
+from bfabric.transfer._generic._upload_types import UploadOutcome
+from bfabric.transfer._generic.credentials import Credentials
+from bfabric.transfer._generic.errors import TransferError
+from bfabric.transfer._generic.send import send_to_sink
+from bfabric.transfer._generic.sinks import TransferSinkLocal, TransferSinkScp, TransferSinkTus
+
+
+def test_send_local_copies_file(tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    dest = tmp_path / "out" / "dest.bin"
+
+    outcome = send_to_sink(TransferSinkLocal(path=dest), src, Credentials())
+
+    assert dest.read_bytes() == b"payload"
+    assert outcome == UploadOutcome(bytes_uploaded=7, final_offset=7, upload_url=None)
+
+
+def test_send_local_reports_progress(tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    progress: list[tuple[int, int]] = []
+
+    send_to_sink(
+        TransferSinkLocal(path=tmp_path / "dest.bin"),
+        src,
+        Credentials(),
+        on_progress=lambda d, t: progress.append((d, t)),
+    )
+
+    assert progress == [(7, 7)]
+
+
+def test_send_scp_invokes_scp(mocker, tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    mock_scp = mocker.patch("bfabric.transfer._generic.send.scp")
+
+    outcome = send_to_sink(TransferSinkScp(host="storage", path="/data/dest.bin"), src, Credentials(ssh_user="bfabric"))
+
+    mock_scp.assert_called_once_with(source=src, target="storage:/data/dest.bin", user="bfabric")
+    assert outcome.upload_url is None
+    assert outcome.bytes_uploaded == 7
+
+
+def test_send_scp_error_wrapped(mocker, tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    mocker.patch("bfabric.transfer._generic.send.scp", side_effect=CalledProcessError(1, "scp"))
+
+    with pytest.raises(TransferError, match="scp of"):
+        send_to_sink(TransferSinkScp(host="storage", path="/data/dest.bin"), src, Credentials())
+
+
+def test_send_tus_delegates_to_mover(mocker, tmp_path):
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    sentinel = UploadOutcome(bytes_uploaded=7, final_offset=7, upload_url="https://tus/x")
+    mock_upload = mocker.patch.object(_tus_mover, "upload_file", return_value=sentinel)
+
+    sink = TransferSinkTus(endpoint="https://tus.example/", metadata={"resourceId": "1"}, token="tus-tok")
+    on_progress = mocker.Mock()
+    on_url = mocker.Mock()
+    outcome = send_to_sink(
+        sink, src, Credentials(), on_progress=on_progress, resume_url="https://tus.example/r", on_url=on_url
+    )
+
+    mock_upload.assert_called_once_with(
+        "https://tus.example/",
+        "tus-tok",
+        src,
+        {"resourceId": "1"},
+        on_progress=on_progress,
+        resume_url="https://tus.example/r",
+        on_url=on_url,
+    )
+    assert outcome is sentinel
+
+
+@pytest.mark.slow
+def test_importing_transfer_does_not_import_tuspy():
+    # The core lazy-import guarantee: a download-only / query consumer that merely imports the
+    # transfer facade (and its send module) must never pull tusclient/tuspy. Checked in a fresh
+    # interpreter so an earlier test that imported the tus mover cannot mask a regression.
+    code = (
+        "import sys; import bfabric.transfer; import bfabric.transfer._generic.send; "
+        "assert 'tusclient' not in sys.modules, sorted(m for m in sys.modules if 'tus' in m)"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/bfabric/transfer/generic/test_send.py
+++ b/tests/bfabric/transfer/generic/test_send.py
@@ -85,6 +85,19 @@ def test_send_tus_delegates_to_mover(mocker, tmp_path):
     assert outcome is sentinel
 
 
+def test_send_tus_missing_extra_raises_transfererror(mocker, tmp_path):
+    # A base install lacks tuspy, so importing the mover fails; the user should get a clear pointer
+    # to the extra, not a bare ModuleNotFoundError. Setting the module to None makes the lazy
+    # `from ..._tus_mover import upload_file` raise ImportError regardless of whether tuspy is present.
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    mocker.patch.dict(sys.modules, {"bfabric.transfer._generic._tus_mover": None})
+
+    sink = TransferSinkTus(endpoint="https://tus.example/", metadata={}, token="tus-tok")
+    with pytest.raises(TransferError, match=r"bfabric\[transfer\]"):
+        send_to_sink(sink, src, Credentials())
+
+
 @pytest.mark.slow
 def test_importing_transfer_does_not_import_tuspy():
     # The core lazy-import guarantee: a download-only / query consumer that merely imports the

--- a/tests/bfabric/transfer/generic/test_sinks.py
+++ b/tests/bfabric/transfer/generic/test_sinks.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from bfabric.transfer._generic.sinks import (
+    TransferSink,
+    TransferSinkLocal,
+    TransferSinkScp,
+    TransferSinkTus,
+)
+from pydantic import TypeAdapter
+
+_adapter = TypeAdapter(TransferSink)
+
+
+def test_sink_type_discriminators():
+    assert TransferSinkLocal(path=Path("/x")).type == "local"
+    assert TransferSinkScp(host="h", path="/x").type == "scp"
+    assert TransferSinkTus(endpoint="https://t/", metadata={}, token="tok").type == "tus"
+
+
+def test_sink_union_validates_from_dicts():
+    assert _adapter.validate_python({"type": "local", "path": "/x"}) == TransferSinkLocal(path=Path("/x"))
+    assert _adapter.validate_python({"type": "scp", "host": "h", "path": "/x"}) == TransferSinkScp(host="h", path="/x")
+    tus = _adapter.validate_python(
+        {"type": "tus", "endpoint": "https://t/", "metadata": {"resourceId": "1"}, "token": "tok"}
+    )
+    assert tus == TransferSinkTus(endpoint="https://t/", metadata={"resourceId": "1"}, token="tok")

--- a/tests/bfabric/transfer/generic/test_tus_mover.py
+++ b/tests/bfabric/transfer/generic/test_tus_mover.py
@@ -1,0 +1,220 @@
+"""Deterministic in-process port of the tus resume proof (was a live script, scripts/prove_tus_resume.py).
+
+Exercises upload_file's resume/offset-seeding, url-reporting and empty-file behavior against a fake
+tus uploader, with no real network and no time.sleep.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from bfabric.transfer._generic import _tus_mover
+from bfabric.transfer._generic._tus_mover import upload_file
+from bfabric.transfer._generic.errors import TransferError
+
+CREATED_URL = "https://tus.example/new-upload"
+
+
+class FakeUploader:
+    """Mimics the parts of tusclient's uploader that upload_file uses."""
+
+    def __init__(self, file_path: str, chunk_size: int, server_offset: int, fail_at_chunk: int | None) -> None:
+        self.file_size = os.path.getsize(file_path)
+        self.chunk_size = chunk_size
+        self.offset = 0
+        self.url: str | None = None
+        self._server_offset = server_offset
+        self._fail_at_chunk = fail_at_chunk
+        self._chunks_done = 0
+        self.set_url_calls: list[str] = []
+
+    def set_url(self, url: str) -> None:
+        self.url = url
+        self.set_url_calls.append(url)
+
+    def get_offset(self) -> int:
+        return self._server_offset
+
+    def upload_chunk(self) -> None:
+        # tuspy runs the creation POST (which sets self.url) before the data PATCH, so the URL exists
+        # even when the chunk then fails.
+        if self.url is None:
+            self.url = CREATED_URL
+        if self._fail_at_chunk is not None and self._chunks_done == self._fail_at_chunk:
+            raise ConnectionError("simulated network drop")
+        self.offset = min(self.offset + self.chunk_size, self.file_size)
+        self._chunks_done += 1
+
+    def upload(self) -> None:
+        if self.url is None:
+            self.url = CREATED_URL
+        self.offset = 0
+
+
+def _install_fake_tus(mocker, server_offset: int = 0, fail_at_chunk: int | None = None) -> dict:
+    captured: dict = {}
+
+    class _FakeTusClient:
+        def __init__(self, endpoint: str) -> None:
+            self.endpoint = endpoint
+
+        def set_headers(self, headers: dict) -> None:
+            captured["headers"] = headers
+
+        def uploader(self, file_path, chunk_size, metadata, retries=0, retry_delay=0):
+            up = FakeUploader(file_path, chunk_size, server_offset, fail_at_chunk)
+            captured["uploader"] = up
+            return up
+
+    mocker.patch.object(_tus_mover, "TusClient", _FakeTusClient)
+    return captured
+
+
+def _make_file(tmp_path: Path, size: int) -> Path:
+    f = tmp_path / "data.bin"
+    f.write_bytes(b"\x00" * size)
+    return f
+
+
+def test_fresh_upload_reports_created_url_and_completes(mocker, tmp_path):
+    _install_fake_tus(mocker)
+    f = _make_file(tmp_path, 20)
+
+    urls: list[str] = []
+    progress: list[tuple[int, int]] = []
+    outcome = upload_file(
+        "https://tus.example/",
+        "tok",
+        f,
+        {"resourceId": "1"},
+        chunk_size=4,
+        on_url=urls.append,
+        on_progress=lambda done, total: progress.append((done, total)),
+    )
+
+    assert outcome.final_offset == 20
+    assert outcome.bytes_uploaded == 20
+    assert outcome.upload_url == CREATED_URL
+    assert urls == [CREATED_URL]  # reported exactly once
+    assert progress[-1] == (20, 20)
+
+
+def test_resume_seeds_offset_from_server(mocker, tmp_path):
+    # Server already has 8 of 20 bytes.
+    captured = _install_fake_tus(mocker, server_offset=8)
+    f = _make_file(tmp_path, 20)
+
+    urls: list[str] = []
+    progress: list[tuple[int, int]] = []
+    resume_url = "https://tus.example/resume-here"
+    outcome = upload_file(
+        "https://tus.example/",
+        "tok",
+        f,
+        {"resourceId": "1"},
+        chunk_size=4,
+        resume_url=resume_url,
+        on_url=urls.append,
+        on_progress=lambda done, total: progress.append((done, total)),
+    )
+
+    fake = captured["uploader"]
+    # It pointed at the resume URL and seeded the local offset to the server's.
+    assert fake.set_url_calls == [resume_url]
+    assert progress[0] == (8, 20)  # first report is the seeded offset
+    # Only the 3 remaining chunks (8->12->16->20) are sent -- NOT all 5 from offset 0. This pins down
+    # the offset seeding: without it the uploader would re-send the 8 bytes the server already has.
+    assert fake._chunks_done == 3
+    assert outcome.final_offset == 20
+    assert outcome.bytes_uploaded == 12  # only the remaining bytes
+    assert outcome.upload_url == resume_url
+    assert urls == [resume_url]
+
+
+def test_resume_url_with_explicit_default_port_is_accepted(mocker, tmp_path):
+    # The server may hand back an absolute Location that spells out the default port (:443) while the
+    # endpoint omits it. That is the SAME origin per RFC 6454, so the resume must not be rejected.
+    captured = _install_fake_tus(mocker, server_offset=8)
+    f = _make_file(tmp_path, 20)
+
+    resume_url = "https://tus.example:443/resume-here"
+    outcome = upload_file(
+        "https://tus.example/",
+        "tok",
+        f,
+        {"resourceId": "1"},
+        chunk_size=4,
+        resume_url=resume_url,
+    )
+
+    fake = captured["uploader"]
+    assert fake.set_url_calls == [resume_url]  # accepted, not rejected as a foreign origin
+    assert outcome.final_offset == 20
+    assert outcome.bytes_uploaded == 12
+    assert outcome.upload_url == resume_url
+
+
+def test_resume_url_from_foreign_origin_is_rejected(mocker, tmp_path):
+    # A resume URL pointing at a different host must not receive the bearer token -- upload_file
+    # rejects it before contacting anything.
+    _install_fake_tus(mocker, server_offset=8)
+    f = _make_file(tmp_path, 20)
+
+    with pytest.raises(ValueError, match="origin"):
+        upload_file(
+            "https://tus.example/",
+            "tok",
+            f,
+            {"resourceId": "1"},
+            resume_url="https://evil.example/steal-my-token",
+        )
+
+
+def test_on_url_reported_even_when_first_chunk_fails(mocker, tmp_path):
+    # The creation POST succeeds (URL registered), then the first PATCH drops.
+    _install_fake_tus(mocker, fail_at_chunk=0)
+    f = _make_file(tmp_path, 20)
+
+    urls: list[str] = []
+    with pytest.raises(TransferError) as excinfo:
+        upload_file("https://tus.example/", "tok", f, {"resourceId": "1"}, chunk_size=4, on_url=urls.append)
+
+    # URL was surfaced despite the failure, so the caller can still resume.
+    assert urls == [CREATED_URL]
+    assert isinstance(excinfo.value.__cause__, ConnectionError)
+
+
+def test_zero_byte_resume_reports_url_once(mocker, tmp_path):
+    _install_fake_tus(mocker)
+    f = _make_file(tmp_path, 0)
+
+    urls: list[str] = []
+    resume_url = "https://tus.example/resume-empty"
+    outcome = upload_file(
+        "https://tus.example/", "tok", f, {"resourceId": "1"}, resume_url=resume_url, on_url=urls.append
+    )
+
+    assert urls == [resume_url]  # not fired a second time by the 0-byte branch
+    assert outcome.bytes_uploaded == 0
+    assert outcome.final_offset == 0
+
+
+def test_empty_file_fresh_creates_upload(mocker, tmp_path):
+    _install_fake_tus(mocker)
+    f = _make_file(tmp_path, 0)
+
+    urls: list[str] = []
+    outcome = upload_file("https://tus.example/", "tok", f, {"resourceId": "1"}, on_url=urls.append)
+
+    assert outcome.bytes_uploaded == 0
+    assert outcome.final_offset == 0
+    assert urls == [CREATED_URL]
+
+
+def test_bearer_token_set_on_client(mocker, tmp_path):
+    captured = _install_fake_tus(mocker)
+    f = _make_file(tmp_path, 4)
+    upload_file("https://tus.example/", "the-tus-token", f, {"resourceId": "1"}, chunk_size=4)
+    assert captured["headers"] == {"Authorization": "Bearer the-tus-token"}


### PR DESCRIPTION
Adds `bfabric.transfer._generic`: transport-agnostic byte movers with zero B-Fabric knowledge.

- source/sink value objects (local, SSH/scp, HTTP, tus)
- `fetch_to_path` (download) and `send_to_sink` (upload)
- checksums / `FileInfo`, `Credentials`
- the tus mover is gated behind the `[transfer]` extra and imported lazily, so download-only use never pulls `tuspy`

First of a 3-PR stack (split out of #536). The B-Fabric binding and the workunit-upload feature stack on top.
