### PR TITLE
fix(app-runner): harden scp/rsync movers against command injection

### DIFF
--- a/.basedpyright/baseline.bfabric_app_runner.json
+++ b/.basedpyright/baseline.bfabric_app_runner.json
@@ -3094,14 +3094,6 @@
             {
                 "code": "reportUnusedCallResult",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnusedCallResult",
-                "range": {
                     "startColumn": 4,
                     "endColumn": 35,
                     "lineCount": 1

--- a/bfabric_app_runner/src/bfabric_app_runner/inputs/prepare/prepare_resolved_file.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/inputs/prepare/prepare_resolved_file.py
@@ -49,7 +49,8 @@ def _operation_copy_rsync(source: FileSourceSsh | FileSourceLocal, output_path: 
             source_str = str(Path(local).resolve())
         case FileSourceSsh(ssh=FileSourceSshValue(host=host, path=path)):
             source_str = f"{ssh_user}@{host}:{path}" if ssh_user else f"{host}:{path}"
-    cmd = ["rsync", "-rltvP", source_str, str(output_path)]
+    # "--" terminates option parsing so a source/dest beginning with "-" can't be read as an rsync flag.
+    cmd = ["rsync", "-rltvP", "--", source_str, str(output_path)]
     logger.info(shlex.join(cmd))
     result = subprocess.run(cmd, check=False)
     return result.returncode == 0
@@ -141,13 +142,17 @@ def _operation_copy_cp(source: FileSourceLocal, output_path: Path) -> bool:
 
 
 def _operation_link_symbolic(source: FileSourceLocal, output_path: Path) -> bool:
-    # the link is created relative to the output file, so it should be more portable across apptainer images etc
-    source_path = Path(source.local).resolve().relative_to(output_path.resolve().parent, walk_up=True)
+    # the link is created relative to the output file, so it should be more portable across apptainer images etc.
+    # Relativize against output_path's own directory -- NOT output_path.resolve().parent, which would follow an
+    # already present link to the source and yield the wrong (source-relative) target.
+    source_abs = Path(source.local).resolve()
+    source_path = source_abs.relative_to(output_path.parent.resolve(), walk_up=True)
 
     # if the file exists, and only if it is a link as well
     if output_path.is_symlink():
-        # check if it points to the same file, in which case we don't need to do anything
-        if output_path.resolve() == source_path.resolve():
+        # Compare the link's real target to the source (both absolute). Resolving the *relative* target went
+        # via the process CWD, so a correct link was only recognized when we happened to run from its own dir.
+        if output_path.resolve() == source_abs:
             logger.info("Link already exists and points to the correct file")
             return True
         else:

--- a/bfabric_app_runner/src/bfabric_app_runner/util/scp.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/util/scp.py
@@ -29,12 +29,21 @@ def scp(source: str | Path, target: str | Path, *, user: str | None = None, mkdi
     elif user and target_remote:
         target = f"{user}@{target}"
 
+    # scp/ssh parse a leading "-" as an option, so an endpoint like "-oProxyCommand=..." would smuggle
+    # arbitrary options (and thus local command execution) into the invocation. A real path or
+    # ``[user@]host`` never starts with "-", so reject it rather than let it reach the command line.
+    _reject_option_like(source, role="scp source")
+    _reject_option_like(target, role="scp target")
+
     if mkdir:
         if target_remote:
             host, path = target.split(":", 1)
-            parent_path = Path(path).parent
-            logger.debug(f"ssh {host} mkdir -p {parent_path}")
-            subprocess.run(["ssh", host, "mkdir", "-p", parent_path], check=True)
+            # ssh joins its trailing args and runs them through the remote *shell*, so the remote path
+            # must be quoted -- otherwise a path containing shell metacharacters would execute arbitrary
+            # commands on the host.
+            quoted_parent = shlex.quote(str(Path(path).parent))
+            logger.debug(f"ssh {host} mkdir -p {quoted_parent}")
+            _ = subprocess.run(["ssh", host, "mkdir", "-p", quoted_parent], check=True)
         else:
             parent_path = Path(target).parent
             parent_path.mkdir(parents=True, exist_ok=True)
@@ -42,6 +51,12 @@ def scp(source: str | Path, target: str | Path, *, user: str | None = None, mkdi
     cmd = ["scp", source, target]
     logger.info(shlex.join(cmd))
     subprocess.run(cmd, check=True)
+
+
+def _reject_option_like(value: str, *, role: str) -> None:
+    """Reject an scp/ssh endpoint that would be misread as a command-line option (a leading ``-``)."""
+    if value.startswith("-"):
+        raise ValueError(f"{role} must not start with '-': {value!r}")
 
 
 def _is_remote(path: str | Path) -> bool:

--- a/tests/bfabric_app_runner/inputs/prepare/test_prepare_resolved_file.py
+++ b/tests/bfabric_app_runner/inputs/prepare/test_prepare_resolved_file.py
@@ -1,5 +1,6 @@
 import contextlib
 import hashlib
+import os
 from pathlib import Path
 from shutil import SameFileError
 from subprocess import CalledProcessError
@@ -358,8 +359,8 @@ def test_operation_copy_rsync_local(mock_subprocess, logot: Logot):
     source = FileSourceLocal(local="/source.txt")
     mock_subprocess.return_value.returncode = 0
     result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
-    mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "/source.txt", "mock_output.txt"], check=False)
-    logot.assert_logged(logged.info("rsync -rltvP /source.txt mock_output.txt"))
+    mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "--", "/source.txt", "mock_output.txt"], check=False)
+    logot.assert_logged(logged.info("rsync -rltvP -- /source.txt mock_output.txt"))
     assert result
 
 
@@ -367,8 +368,10 @@ def test_operation_copy_rsync_ssh_default(mock_subprocess, logot: Logot):
     source = FileSourceSsh(ssh=FileSourceSshValue(host="host", path="/source.txt"))
     mock_subprocess.return_value.returncode = 0
     result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user=None)
-    mock_subprocess.assert_called_once_with(["rsync", "-rltvP", "host:/source.txt", "mock_output.txt"], check=False)
-    logot.assert_logged(logged.info("rsync -rltvP host:/source.txt mock_output.txt"))
+    mock_subprocess.assert_called_once_with(
+        ["rsync", "-rltvP", "--", "host:/source.txt", "mock_output.txt"], check=False
+    )
+    logot.assert_logged(logged.info("rsync -rltvP -- host:/source.txt mock_output.txt"))
     assert result
 
 
@@ -377,9 +380,9 @@ def test_operation_copy_rsync_ssh_custom_user(mock_subprocess, logot: Logot):
     mock_subprocess.return_value.returncode = 0
     result = _operation_copy_rsync(source=source, output_path=Path("mock_output.txt"), ssh_user="user")
     mock_subprocess.assert_called_once_with(
-        ["rsync", "-rltvP", "user@host:/source.txt", "mock_output.txt"], check=False
+        ["rsync", "-rltvP", "--", "user@host:/source.txt", "mock_output.txt"], check=False
     )
-    logot.assert_logged(logged.info("rsync -rltvP user@host:/source.txt mock_output.txt"))
+    logot.assert_logged(logged.info("rsync -rltvP -- user@host:/source.txt mock_output.txt"))
     assert result
 
 
@@ -430,3 +433,27 @@ def test_operation_link_symbolic(mock_subprocess, logot: Logot, source_path, des
     mock_subprocess.assert_called_once_with(["ln", "-s", expected_target, str(dest)], check=False)
     logot.assert_logged(logged.info(f"ln -s {expected_target} {dest}"))
     assert result
+
+
+def test_operation_link_symbolic_recognizes_existing_correct_link(mock_subprocess, logot: Logot, tmp_path):
+    # An already-correct relative symlink must be recognized regardless of the process CWD. The check
+    # used to resolve the relative target against the CWD (and take output_path.resolve().parent, which
+    # follows the existing link), so a correct link was only recognized when run from its own directory
+    # and was otherwise needlessly torn down and recreated.
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    source_file = src_dir / "source.txt"
+    source_file.write_text("payload")
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+    output_path = dst_dir / "destination.txt"
+    # Pre-create exactly the relative link the operation itself would create.
+    output_path.symlink_to(os.path.relpath(source_file, dst_dir))
+
+    source = FileSourceLocal(local=str(source_file))
+    result = _operation_link_symbolic(source=source, output_path=output_path)
+
+    assert result is True
+    logot.assert_logged(logged.info("Link already exists and points to the correct file"))
+    # The link was already correct, so it must not be recreated.
+    mock_subprocess.assert_not_called()

--- a/tests/bfabric_app_runner/util/test_util_scp.py
+++ b/tests/bfabric_app_runner/util/test_util_scp.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from bfabric_app_runner.util.scp import scp
+
+
+@pytest.fixture
+def mock_subprocess(mocker):
+    return mocker.patch("subprocess.run")
+
+
+def test_scp_quotes_remote_mkdir_path(mocker, mock_subprocess):
+    # ssh runs its trailing args through the remote shell, so a directory containing shell
+    # metacharacters must be quoted -- otherwise it would execute arbitrary commands on the host.
+    scp(source="/local/file.txt", target="host:/remote/$(touch pwned)/file.txt")
+
+    ssh_call = mock_subprocess.call_args_list[0]
+    assert ssh_call == mocker.call(["ssh", "host", "mkdir", "-p", "'/remote/$(touch pwned)'"], check=True)
+
+
+def test_scp_rejects_option_like_target(mock_subprocess):
+    # A target beginning with '-' would be parsed by scp/ssh as an option (e.g. -oProxyCommand=...),
+    # smuggling local command execution into the invocation; reject it before it reaches the command line.
+    with pytest.raises(ValueError, match="must not start with '-'"):
+        scp(source="/local/file.txt", target="-oProxyCommand=touch pwned:/x")
+    mock_subprocess.assert_not_called()
+
+
+def test_scp_rejects_option_like_source(mock_subprocess):
+    with pytest.raises(ValueError, match="must not start with '-'"):
+        scp(source="-oProxyCommand=touch pwned:/x", target="/local/file.txt")
+    mock_subprocess.assert_not_called()


### PR DESCRIPTION
## Summary

Hardening fixes to the app-runner file movers (`util/scp.py`, `inputs/prepare/prepare_resolved_file.py`), surfaced while auditing the new transport-agnostic transfer layer (these are the same fixes applied there, ported back to their pre-existing app-runner counterparts).

- **scp — remote command injection**: `ssh <host> mkdir -p <path>` runs its trailing args through the remote *shell*, so a destination path containing shell metacharacters could execute arbitrary commands on the storage host. The path is now `shlex.quote`'d.
- **scp/rsync — option injection**: an endpoint beginning with `-` (e.g. `-oProxyCommand=…`) is parsed by scp/ssh as an option, enabling local command execution. `scp()` now rejects `-`-leading endpoints, and rsync terminates option parsing with `--`.
- **symlink — CWD-dependent "already correct" check**: the fast-path that skips recreating an existing correct relative symlink resolved the relative target against the process CWD (and derived its base from `output_path.resolve().parent`, which follows an existing link), so it only matched when run from the link's own directory and otherwise needlessly tore the link down and recreated it. It now compares the link's resolved target to the resolved source and relativizes against `output_path`'s own directory.

Each fix has a reproducing/regression test. Trust-model note: these movers are fed by binding-constructed source/sink values, so exploitability of the injection paths depends on whether attacker-influenced data reaches a host/path; hardened regardless as defense-in-depth.