### PR TITLE
feat(app-runner): log uv provisioning output at DEBUG instead of printing it

### DIFF
--- a/.basedpyright/baseline.bfabric_app_runner.json
+++ b/.basedpyright/baseline.bfabric_app_runner.json
@@ -1190,16 +1190,6 @@
                 }
             }
         ],
-        "./bfabric_app_runner/src/bfabric_app_runner/commands/command_exec.py": [
-            {
-                "code": "reportUnusedCallResult",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py": [
             {
                 "code": "reportUnannotatedClassAttribute",

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Added `runtime-evaluated-base-classes` to the ruff `flake8-type-checking` config (matching `bfabric`), listing `pydantic.BaseModel` and `FromConfigFile`, so `TC001`/`TC002`/`TC003` no longer suggest moving imports used only in pydantic model field annotations into `if TYPE_CHECKING:` blocks. Removed the now-unnecessary per-line `# noqa: TC00x` workarounds and the blanket `cli/**`/`specs/**` per-file-ignores this uncovered.
 - `CommandPythonEnv.python_version` now defaults to `"3.13"` instead of `None`. This fixes a `uv venv -p None` failure for app definitions that omit `python_version`, and pins the app environment to the tested interpreter.
+- Python-environment provisioning output (the `uv venv` / `uv pip install` diagnostics such as `Using Python … environment at`, `Resolved/Installed N packages`, `+ workflow==0.0`) is now captured and logged at DEBUG instead of printed directly, so a normal (INFO) run stays quiet while `--debug` still shows it, properly attributed through the logger. If a provisioning command fails, its full output is now logged at ERROR (previously it only appeared because stdio was inherited). The app's own command output continues to stream directly. `execute_command_exec` gains an opt-in `log_output_level` keyword for this.
 
 ### Fixed
 

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_exec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_exec.py
@@ -28,11 +28,34 @@ def _get_shell_env(
     return environ
 
 
-def execute_command_exec(command: CommandExec, *args: str, environ: dict[str, str] | None = None) -> None:
-    """Executes the command with the provided arguments."""
+def execute_command_exec(
+    command: CommandExec,
+    *args: str,
+    environ: dict[str, str] | None = None,
+    log_output_level: str | None = None,
+) -> None:
+    """Executes the command with the provided arguments.
+
+    :param log_output_level: when set (e.g. ``"DEBUG"``), the command's stdout/stderr is captured and
+        re-emitted through the logger at this level instead of inheriting the parent's streams. ``None``
+        inherits the parent's stdout/stderr so output is shown directly (the right choice for the app's own
+        output); a level is used for noisy provisioning steps whose output only matters when debugging.
+    """
     command_args = shlex.split(command.command) + list(args)
     shell_env = _get_shell_env(environ, command.env, command.prepend_paths)
     logger.info(f"Executing command: {shlex.join(command_args)}")
     logger.debug(f"{command_args=}")
     logger.trace(f"{shell_env=}")
-    subprocess.run(command_args, check=True, env=shell_env)
+    if log_output_level is None:
+        subprocess.run(command_args, check=True, env=shell_env)  # pyright: ignore[reportUnusedCallResult]
+        return
+
+    # Capture output (stderr merged into stdout to preserve ordering) and route it through the logger.
+    proc = subprocess.run(
+        command_args, env=shell_env, check=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    if proc.returncode != 0:
+        logger.error(f"Command failed with exit code {proc.returncode}: {shlex.join(command_args)}\n{proc.stdout}")
+        raise subprocess.CalledProcessError(proc.returncode, command_args, output=proc.stdout)
+    if proc.stdout.strip():
+        logger.log(log_output_level, f"Command output:\n{proc.stdout}")

--- a/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/commands/command_python_env.py
@@ -82,7 +82,9 @@ class PythonEnvironment:
         exec_command = CommandExec(
             command=shlex.join(dep_install_cmd), env=self.command.env, prepend_paths=self.command.prepend_paths
         )
-        execute_command_exec(exec_command)
+        # Provisioning output (uv venv / pip install) is noisy diagnostic info; route it through the logger at
+        # DEBUG rather than letting it print directly.
+        execute_command_exec(exec_command, log_output_level="DEBUG")
 
     def _mark_provisioned(self) -> None:
         """Mark environment as successfully provisioned."""

--- a/tests/bfabric_app_runner/commands/test_command_exec.py
+++ b/tests/bfabric_app_runner/commands/test_command_exec.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -48,3 +49,35 @@ def test_execute_full(mocker, command_full, subprocess_run):
         check=True,
         env={"NAME": "sun", "PATH": "/usr/local/bin:/home/user/bin:"},
     )
+
+
+def test_execute_captures_and_logs_output_at_level(command_minimal, subprocess_run, mocker):
+    mock_logger = mocker.patch("bfabric_app_runner.commands.command_exec.logger")
+    subprocess_run.return_value = mocker.MagicMock(returncode=0, stdout="Resolved 1 package\n")
+
+    execute_command_exec(command_minimal, environ={"NAME": "testing"}, log_output_level="DEBUG")
+
+    subprocess_run.assert_called_once_with(
+        ["echo", "hello world"],
+        env={"NAME": "testing"},
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    mock_logger.log.assert_called_once()
+    level, message = mock_logger.log.call_args[0]
+    assert level == "DEBUG"
+    assert "Resolved 1 package" in message
+
+
+def test_execute_capture_mode_raises_and_logs_error_on_failure(command_minimal, subprocess_run, mocker):
+    mock_logger = mocker.patch("bfabric_app_runner.commands.command_exec.logger")
+    subprocess_run.return_value = mocker.MagicMock(returncode=2, stdout="boom\n")
+
+    with pytest.raises(subprocess.CalledProcessError):
+        execute_command_exec(command_minimal, log_output_level="DEBUG")
+
+    mock_logger.error.assert_called_once()
+    assert "boom" in mock_logger.error.call_args[0][0]
+    mock_logger.log.assert_not_called()

--- a/tests/bfabric_app_runner/commands/test_command_python_env.py
+++ b/tests/bfabric_app_runner/commands/test_command_python_env.py
@@ -110,6 +110,10 @@ class TestPythonEnvironment:
         assert "uv pip install" in install_call.command
         assert str(sample_command.pylock) in install_call.command
 
+        # Provisioning output should be routed through the logger at DEBUG, not printed directly
+        for call in mock_execute_command_exec.call_args_list:
+            assert call.kwargs["log_output_level"] == "DEBUG"
+
         # Check marker file created
         assert env.is_provisioned is True
 


### PR DESCRIPTION
Provisioning a `python_env` command's environment ran `uv venv` / `uv pip install` with inherited stdio, so `uv`'s diagnostics printed raw and unconditionally. This routes that output through loguru at DEBUG — quiet on a normal INFO run, visible under `--debug`.

`execute_command_exec` gains an opt-in `log_output_level`; when set it captures the command's output and re-emits it at that level (logging at ERROR and re-raising `CalledProcessError` on failure, preserving the old `check=True` contract). Only the provisioning `uv` commands opt in — the app's own command keeps streaming directly.

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.