### PR TITLE
chore(deps): raise starlette floor to >=1.0.1

### DIFF
--- a/bfabric_asgi_auth/docs/changelog.md
+++ b/bfabric_asgi_auth/docs/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Require `starlette>=1.0.1,<2` (was `>=0.50.0,<1`) to keep starlette above the advisory floor ([#505](https://github.com/fgcz/bfabricPy/issues/505))
 - Improved secret key example in README to use `secrets.token_urlsafe(64)` with a warning when generating random keys ([#434](https://github.com/fgcz/bfabricPy/issues/434))
 - Fixed redirect URL scheme handling: protocol-relative URLs (//example.com) and absolute URLs with wrong scheme are now corrected based on X-Forwarded-Proto headers
 - Honor `scope["root_path"]` when the app is mounted behind a reverse-proxy sub-path: landing/logout matching strips a leading `root_path` from `scope["path"]`, and root-relative redirect targets (e.g. `authenticated_path="/"`) are prefixed with `root_path` so the browser lands at the correct public URL

--- a/bfabric_asgi_auth/pyproject.toml
+++ b/bfabric_asgi_auth/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "bfabric>=1.13.36",
     "pydantic>=2.11,<3",
     "pydantic-settings>=2.12.0,<3",
-    "starlette>=0.50.0,<1",
+    "starlette>=1.0.1,<2",
 ]
 
 [build-system]

--- a/bfabric_rest_proxy/docs/changelog.md
+++ b/bfabric_rest_proxy/docs/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `feeder_operations.create_workunit` is now a thin authorization + audit-stamping wrapper around `bfabric.operations.workunit.create_workunit`. The workunit creation now flips the workunit to status `failed` on any error after initial creation (was: orphaned in `processing` status).
 - `POST /create/workunit/v1` request body now accepts an optional `created_using` field (e.g. calling-app identifier). It is recorded as the `Created Using` custom attribute alongside the server-stamped `Created For` attribute. The wrapper signature changed accordingly: it now takes a single `CreateWorkunitRequest` (subclass of `CreateWorkunitParams`) instead of separate `params` + `created_using` arguments.
 - Renamed the workunit custom attribute that records the initiating web-app user from `WebApp User` to `Created For`.
+- Require `fastapi>=0.134.0` (was `>=0.124.0`) so the transitive `starlette` dependency resolves to `>=1.0.1` ([#505](https://github.com/fgcz/bfabricPy/issues/505))
 
 ### Fixed
 

--- a/bfabric_rest_proxy/pyproject.toml
+++ b/bfabric_rest_proxy/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "bfabric>=1.18.1,<2",
-    "fastapi>=0.124.0",
+    "fastapi>=0.134.0",
     "pydantic-settings>=2.12.0",
 ]
 


### PR DESCRIPTION
Raises the `starlette` version floor above the recent security advisory. bfabricPy was not affected, but the vulnerable range should no longer be installable.

- **bfabric-asgi-auth** (direct dep): `starlette>=0.50.0,<1` → `starlette>=1.0.1,<2`.
- **bfabric-rest-proxy** (starlette is transitive via fastapi): `fastapi>=0.124.0` → `fastapi>=0.134.0`, the first fastapi that drops the `starlette<1.0` cap, so the transitive starlette resolves to `>=1.0.1`.

No code changes needed — starlette 1.0's breaking changes only removed deprecated app decorators; the APIs used here (`BaseUser`, `SessionMiddleware`) are unchanged.

Verification: `uv sync` resolves starlette 1.3.1; the asgi-auth (94) and rest-proxy (48) test suites and basedpyright both pass.

Closes #505

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.