### PR TITLE
feat(app_runner): support Parquet in bfabric_dataset output

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `SaveDatasetSpec` (the `bfabric_dataset` output) gains a `format` field (`csv`, the default, or `parquet`) so an output dataset can be registered from a Parquet file, consistent with `bfabric-cli dataset upload`. `separator` is now optional (csv-only; defaults to a comma) and, together with `has_header`, is ignored for `format: parquet` ([#359](https://github.com/fgcz/bfabricPy/issues/359)).
 - `BfabricResourceSpec` gains an `access` field (`ssh`/`http`) selecting the transport used to stage a resource. `access: http` streams the file from the storage's HTTP endpoint instead of rsync/scp — portable, but requires an OAuth-backed client whose token carries the `containers` scope. The generic `file` spec also gained an HTTP source (`FileSourceHttp`), always fetched anonymously. See the input specification docs for details.
 
 ### Changed

--- a/bfabric_app_runner/docs/specs/output_specification.md
+++ b/bfabric_app_runner/docs/specs/output_specification.md
@@ -64,7 +64,8 @@ Copy a local file into B-Fabric storage as a resource:
 .. autopydantic_model:: bfabric_app_runner.specs.outputs_spec.CopyResourceSpec
 ```
 
-Register a local table as a B-Fabric dataset:
+Register a local table as a B-Fabric dataset. The `format` field selects the reader — `csv` (the
+default, a delimited text file) or `parquet`; `separator` and `has_header` apply to `csv` only:
 
 ```{eval-rst}
 .. autopydantic_model:: bfabric_app_runner.specs.outputs_spec.SaveDatasetSpec

--- a/bfabric_app_runner/docs/user_guides/working_with_outputs.md
+++ b/bfabric_app_runner/docs/user_guides/working_with_outputs.md
@@ -47,7 +47,8 @@ outputs:
 
 ### bfabric_dataset
 
-Registers a local tabular file as a B-Fabric dataset.
+Registers a local tabular file as a B-Fabric dataset. The `format` field selects the reader
+(`csv`, the default, or `parquet`); `separator` and `has_header` apply to `csv` only.
 
 ```yaml
 outputs:
@@ -57,6 +58,16 @@ outputs:
     name: "Experiment Results"
     has_header: true
     invalid_characters: remove
+```
+
+For a Parquet file, set `format: parquet` (no `separator` needed):
+
+```yaml
+outputs:
+  - type: bfabric_dataset
+    local_path: results/summary.parquet
+    format: parquet
+    name: "Experiment Results"
 ```
 
 ### bfabric_link

--- a/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/output_registration/register.py
@@ -139,6 +139,20 @@ def copy_file_to_storage(
         )
 
 
+def _read_dataset_table(spec: SaveDatasetSpec) -> pl.DataFrame:
+    """Reads the local file into a polars DataFrame according to ``spec.format``.
+
+    New formats slot in as additional branches here (mirroring ``bfabric-cli dataset upload``).
+    """
+    if spec.format == "parquet":
+        return pl.read_parquet(spec.local_path)
+    elif spec.format == "csv":
+        separator = spec.separator if spec.separator is not None else ","
+        return pl.read_csv(spec.local_path, separator=separator, has_header=spec.has_header, infer_schema_length=None)
+    else:
+        raise ValueError(f"Unsupported dataset format: {spec.format!r}")
+
+
 def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: WorkunitDefinition) -> None:
     """Saves a dataset to the bfabric, updating the workunit's output dataset if it already has one.
 
@@ -150,7 +164,7 @@ def _save_dataset(spec: SaveDatasetSpec, client: Bfabric, workunit_definition: W
     if registration is None:
         raise ValueError("workunit_definition has no registration; cannot save dataset")
     name = spec.name or spec.local_path.stem
-    table = pl.read_csv(spec.local_path, separator=spec.separator, has_header=spec.has_header, infer_schema_length=None)
+    table = _read_dataset_table(spec)
     check_for_invalid_characters(table=table, invalid_characters=spec.invalid_characters)
 
     existing = client.reader.query_one("dataset", {"workunitid": registration.workunit_id}, expected_type=Dataset)

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/outputs_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/outputs_spec.py
@@ -50,22 +50,27 @@ class CopyResourceSpec(BaseModel):
 
 
 class SaveDatasetSpec(BaseModel):
-    """Uploads a local delimited file as the workunit's output dataset."""
+    """Uploads a local file as the workunit's output dataset."""
 
     model_config = ConfigDict(extra="forbid")
     type: Literal["bfabric_dataset"] = "bfabric_dataset"
 
     local_path: Path
-    """Path to the local delimited file to upload as the dataset."""
+    """Path to the local file to upload as the dataset."""
 
-    separator: str
-    """Field separator of the local file (e.g. a comma or a tab character)."""
+    format: Literal["csv", "parquet"] = "csv"
+    """Format of the local file. ``csv`` reads a delimited text file (see ``separator``/``has_header``);
+    ``parquet`` reads a Parquet file (``separator``/``has_header`` are ignored)."""
+
+    separator: str | None = None
+    """Field separator of the local file for ``format: csv`` (e.g. a comma or a tab character);
+    ``None`` defaults to a comma. Ignored for other formats."""
 
     name: str | None = None
     """Name for the dataset in B-Fabric; ``None`` uses the local file's stem."""
 
     has_header: bool = True
-    """Whether the local file's first row contains column names."""
+    """Whether the local file's first row contains column names. Applies to ``format: csv`` only."""
 
     invalid_characters: str = ""
     """Characters that must not appear in any cell; upload fails if any occur (empty string disables the check)."""

--- a/tests/bfabric_app_runner/output_registration/test_save_dataset.py
+++ b/tests/bfabric_app_runner/output_registration/test_save_dataset.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import polars as pl
 import pytest
 
 from bfabric.entities import Dataset
@@ -25,6 +26,13 @@ def mock_workunit_definition(mocker):
 def csv_path(tmp_path) -> Path:
     path = tmp_path / "my_dataset.csv"
     path.write_text("a,b\n1,2\n3,4\n")
+    return path
+
+
+@pytest.fixture()
+def parquet_path(tmp_path) -> Path:
+    path = tmp_path / "my_dataset.parquet"
+    pl.DataFrame({"a": [1, 3], "b": [2, 4]}).write_parquet(path)
     return path
 
 
@@ -63,6 +71,21 @@ def test_save_dataset_no_existing_creates(mock_client, mock_workunit_definition,
     assert params.container_id == 7
     assert params.workunit_id == 42
     assert table.columns == ["a", "b"]
+    mock_operations["update"].assert_not_called()
+
+
+def test_save_dataset_reads_parquet(mock_client, mock_workunit_definition, parquet_path, mock_operations):
+    """A parquet-format spec is read via pl.read_parquet and creates a new dataset."""
+    spec = SaveDatasetSpec(local_path=parquet_path, format="parquet", name="my_dataset")
+    mock_client.reader.query_one.return_value = None
+
+    _save_dataset(spec, mock_client, mock_workunit_definition)
+
+    mock_operations["create"].assert_called_once()
+    _, table, params = mock_operations["create"].call_args.args
+    assert params.name == "my_dataset"
+    assert table.columns == ["a", "b"]
+    assert table.to_dicts() == [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
     mock_operations["update"].assert_not_called()
 
 

--- a/tests/bfabric_app_runner/specs/test_outputs_spec.py
+++ b/tests/bfabric_app_runner/specs/test_outputs_spec.py
@@ -35,7 +35,8 @@ def serialized() -> str:
   store_folder_path: null
   type: bfabric_copy_resource
   update_existing: 'no'
-- has_header: true
+- format: csv
+  has_header: true
   invalid_characters: ''
   local_path: local_path
   name: null


### PR DESCRIPTION
Adds Parquet support to the app-runner's `bfabric_dataset` output, matching
`bfabric-cli dataset upload`. `SaveDatasetSpec` gains a `format` field (`csv`
default, or `parquet`); `separator` becomes optional (csv-only) and is ignored
for Parquet. Existing csv specs are unaffected.

Verified via the app-runner test suite (new parquet case), basedpyright, and a
`validate outputs-spec` smoke test.

Closes #359

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.