### PR TITLE
Fix ResultContainer.to_polars crash on empty result set

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,8 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+- `ResultContainer.to_polars()` returns an empty DataFrame for an empty result set instead of raising `polars.exceptions.NoDataError`, fixing a crash in `bfabric-cli api read` when a query matched no records.
+
 ## \[1.20.0rc2\] - 2026-07-15
 
 - OAuth 2.0 authentication: `connect_oauth` (client-credentials grant, auto-refresh + optional token cache), `connect_pkce` (interactive browser login, PKCE), `connect_device_code` (headless device grant), and `connect_pat` (Personal Access Token). `connect` auto-routes to OAuth when an environment sets `auth_method: oauth`. Adds `BfabricOAuthError` and the `authlib` / `joserfc` dependencies.

--- a/bfabric/src/bfabric/results/result_container.py
+++ b/bfabric/src/bfabric/results/result_container.py
@@ -123,7 +123,11 @@ class ResultContainer:
 
         from bfabric.utils.polars_utils import flatten_relations
 
-        df = polars.from_dicts(self.to_list_dict(drop_empty=drop_empty), infer_schema_length=None)
+        records = self.to_list_dict(drop_empty=drop_empty)
+        if not records:
+            # An empty result set has no schema to infer; from_dicts([]) would raise NoDataError.
+            return polars.DataFrame()
+        df = polars.from_dicts(records, infer_schema_length=None)
         if flatten:
             df = flatten_relations(df)
         return df

--- a/tests/bfabric/results/test_result_container.py
+++ b/tests/bfabric/results/test_result_container.py
@@ -21,6 +21,11 @@ def res_with_empty() -> ResultContainer:
     return ResultContainer([{"a": None, "b": 1, "c": []}, {"a": 2, "b": 3, "c": None}], total_pages_api=None, errors=[])
 
 
+@pytest.fixture
+def res_empty() -> ResultContainer:
+    return ResultContainer([], total_pages_api=1, errors=[])
+
+
 def test_str(res1, res2):
     assert str(res1) == "[1, 2, 3]"
     assert str(res2) == "[4, 5]"
@@ -109,6 +114,18 @@ def test_to_list_dict_when_not_drop_empty(res_with_empty, case):
 def test_to_list_dict_when_drop_empty(res_with_empty):
     expected = [{"b": 1}, {"a": 2, "b": 3}]
     assert expected == res_with_empty.to_list_dict(drop_empty=True)
+
+
+def test_to_list_dict_when_empty(res_empty):
+    assert res_empty.to_list_dict() == []
+    assert res_empty.to_list_dict(drop_empty=True) == []
+
+
+@pytest.mark.parametrize("flatten", [False, True])
+def test_to_polars_when_empty(res_empty, flatten):
+    df = res_empty.to_polars(flatten=flatten)
+    assert df.is_empty()
+    assert df.columns == []
 
 
 def test_to_polars(res1):

--- a/tests/bfabric_cli/test_cli_api_read.py
+++ b/tests/bfabric_cli/test_cli_api_read.py
@@ -75,6 +75,24 @@ class TestPerformQuery:
         assert len(results) == 2
         assert all("id" in item for item in results)
 
+    def test_perform_query_empty_results(self, mock_client):
+        # Regression: an empty result set must not raise polars NoDataError from the log line.
+        # Arrange
+        params = Params(
+            endpoint="importresource",
+            query=[("name", "%RData")],
+            format=OutputFormat.TSV,
+            columns=["id", "relativepath"],
+            limit=1000,
+        )
+        mock_client.read.return_value = ResultContainer([], total_pages_api=1, errors=[])
+
+        # Act
+        results = perform_query(params, mock_client)
+
+        # Assert
+        assert len(results) == 0
+
 
 class TestRenderOutput:
     def test_render_json_output(self, mocker, sample_results):


### PR DESCRIPTION
`ResultContainer.to_polars()` raised `polars.exceptions.NoDataError` on an empty result set (`polars.from_dicts([])` can't infer a schema); it now returns an empty DataFrame, fixing a crash in `bfabric-cli api read` when a query matches no records. Follow-up to #161 / #239.

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.