### PR TITLE
fix(bfabric): surface OAuth token failures as a clear error

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -10,6 +10,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ## \[Unreleased\]
 
 - `ResultContainer.to_polars()` returns an empty DataFrame for an empty result set instead of raising `polars.exceptions.NoDataError`, fixing a crash in `bfabric-cli api read` when a query matched no records.
+- OAuth token-acquisition failures (expired/revoked refresh token, unreachable token endpoint) now raise a clear `BfabricOAuthError` instead of leaking an `authlib`/`requests` traceback.
 
 ## \[1.20.0rc2\] - 2026-07-15
 

--- a/bfabric/src/bfabric/_oauth/credential_provider.py
+++ b/bfabric/src/bfabric/_oauth/credential_provider.py
@@ -18,11 +18,15 @@ from __future__ import annotations
 import threading
 from typing import TYPE_CHECKING
 
+from authlib.common.errors import AuthlibBaseError
+from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.requests_client import OAuth2Session  # pyright: ignore[reportMissingTypeStubs]
+from requests.exceptions import RequestException
 
 from loguru import logger
 
 from bfabric.config.bfabric_auth import OAUTH_LOGIN, BfabricAuth
+from bfabric.errors import BfabricOAuthError
 from bfabric._oauth._constants import DEFAULT_OAUTH_SCOPE
 from bfabric._oauth.token_cache import TokenCache
 
@@ -123,18 +127,35 @@ class OAuthCredentialProvider:
         Must be called while holding ``self._lock``.
         """
         token = self._session.token  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-        if token:
-            self._strip_unusable_refresh_token()
-            # Let authlib check expiry + refresh/re-fetch as appropriate (operates on self.token).
-            logger.debug("Ensuring token is active (refresh if needed)")
-            self._session.ensure_active_token()  # pyright: ignore[reportUnknownMemberType]
-        else:
-            # No token at all — perform the initial fetch.
-            logger.debug("No token present, fetching initial token")
-            token_endpoint: str | None = self._session.metadata.get("token_endpoint")  # pyright: ignore[reportAny]
-            self._session.fetch_token(token_endpoint)  # pyright: ignore[reportUnknownMemberType]
-            self._strip_unusable_refresh_token()
-            self._persist()
+        try:
+            if token:
+                self._strip_unusable_refresh_token()
+                # Let authlib check expiry + refresh/re-fetch as appropriate (operates on self.token).
+                logger.debug("Ensuring token is active (refresh if needed)")
+                self._session.ensure_active_token()  # pyright: ignore[reportUnknownMemberType]
+            else:
+                # No token at all — perform the initial fetch.
+                logger.debug("No token present, fetching initial token")
+                token_endpoint: str | None = self._session.metadata.get("token_endpoint")  # pyright: ignore[reportAny]
+                self._session.fetch_token(token_endpoint)  # pyright: ignore[reportUnknownMemberType]
+                self._strip_unusable_refresh_token()
+                self._persist()
+        # authlib's errors extend Exception (not RuntimeError) and transport failures raise requests
+        # exceptions, so either would otherwise escape the CLI's error handling as a raw traceback.
+        # Wrap them in the domain error (a RuntimeError) with an actionable message.
+        except OAuthError as e:
+            # An OAuthError under the refresh_token grant means the stored session can no longer be
+            # refreshed (expired/revoked refresh token) — the user must re-authenticate.
+            if self._grant_type == "refresh_token":
+                raise BfabricOAuthError(
+                    f"OAuth session expired ({e}). Re-authenticate with "
+                    "'bfabric-cli auth pkce' or 'bfabric-cli auth device-code'."
+                ) from e
+            raise BfabricOAuthError(f"OAuth token request failed: {e}") from e
+        except AuthlibBaseError as e:
+            raise BfabricOAuthError(f"OAuth token request failed: {e}") from e
+        except RequestException as e:
+            raise BfabricOAuthError(f"Could not reach the OAuth token endpoint ({self._token_url}): {e}") from e
 
     def _strip_unusable_refresh_token(self) -> None:
         """Drop the ``refresh_token`` from a client-credentials session token.

--- a/tests/bfabric/oauth/test_credential_provider.py
+++ b/tests/bfabric/oauth/test_credential_provider.py
@@ -4,8 +4,11 @@ import threading
 import time
 
 import pytest
+from authlib.integrations.base_client.errors import OAuthError
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
+from bfabric.errors import BfabricOAuthError
 from bfabric._oauth.credential_provider import OAuthCredentialProvider
 
 
@@ -211,6 +214,60 @@ class TestRefreshToken:
         )
         call_kwargs = cls.call_args
         assert call_kwargs[1]["grant_type"] == "refresh_token"
+
+
+class TestOAuthErrorHandling:
+    """authlib's OAuthError (extends Exception, not RuntimeError) must be wrapped as
+    BfabricOAuthError so callers get an actionable message and the CLI's RuntimeError
+    handler surfaces it cleanly instead of leaking a traceback."""
+
+    def test_refresh_failure_raises_bfabric_oauth_error(self, mock_oauth2_session):
+        """An expired/revoked refresh token maps to an actionable BfabricOAuthError."""
+        oauth_error = OAuthError(error="invalid_grant", description="Refresh token is invalid, expired, or revoked")
+        mock_oauth2_session.token = {"access_token": "stale", "refresh_token": "rt", "expires_at": 1}
+        mock_oauth2_session.ensure_active_token.side_effect = oauth_error
+        provider = OAuthCredentialProvider(
+            client_id="app-id",
+            client_secret="",
+            token_url="https://example.com/rest/oauth/token",
+            grant_type="refresh_token",
+            token={"access_token": "stale", "refresh_token": "rt", "expires_at": 1},
+        )
+
+        with pytest.raises(BfabricOAuthError, match="pkce") as exc_info:
+            provider.get_auth()
+
+        assert "device-code" in str(exc_info.value)
+        assert exc_info.value.__cause__ is oauth_error
+
+    def test_initial_fetch_failure_raises_bfabric_oauth_error(self, provider, mock_oauth2_session):
+        """A failing initial client_credentials fetch maps to BfabricOAuthError."""
+        oauth_error = OAuthError(error="invalid_client", description="bad client")
+        mock_oauth2_session.token = None
+        mock_oauth2_session.fetch_token.side_effect = oauth_error
+
+        with pytest.raises(BfabricOAuthError) as exc_info:
+            provider.get_auth()
+
+        assert exc_info.value.__cause__ is oauth_error
+
+    def test_transport_failure_raises_bfabric_oauth_error(self, mock_oauth2_session):
+        """An unreachable token endpoint (requests error) maps to BfabricOAuthError, not a raw traceback."""
+        transport_error = RequestsConnectionError("connection refused")
+        mock_oauth2_session.token = {"access_token": "stale", "refresh_token": "rt", "expires_at": 1}
+        mock_oauth2_session.ensure_active_token.side_effect = transport_error
+        provider = OAuthCredentialProvider(
+            client_id="app-id",
+            client_secret="",
+            token_url="https://example.com/rest/oauth/token",
+            grant_type="refresh_token",
+            token={"access_token": "stale", "refresh_token": "rt", "expires_at": 1},
+        )
+
+        with pytest.raises(BfabricOAuthError, match="Could not reach") as exc_info:
+            provider.get_auth()
+
+        assert exc_info.value.__cause__ is transport_error
 
 
 class TestDiskCache:


### PR DESCRIPTION
An expired or revoked OAuth refresh token crashed `bfabric-cli` commands with a raw multi-frame traceback (`authlib ... OAuthError: invalid_grant`). authlib's `OAuthError` extends `Exception`, not `RuntimeError`, so `@use_client`'s handler never caught it.

`OAuthCredentialProvider._ensure_token` now wraps authlib errors **and** `requests` transport failures raised during refresh/fetch in the existing `BfabricOAuthError` (a `RuntimeError`), so the CLI prints a concise `Error: ...` and exits non-zero:
- expired/revoked refresh token → advises re-authenticating with `bfabric-cli auth pkce` / `auth device-code`
- unreachable token endpoint → reports the connection failure
- the original exception is chained (`from e`) so `--debug` still shows the root cause

Verified with new unit tests covering the refresh, initial-fetch, and transport-failure paths; `nox` basedpyright + ruff clean.

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.