### PR TITLE
fix(bfabric): show error on PKCE login callback page

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -10,6 +10,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ## \[Unreleased\]
 
 - `ResultContainer.to_polars()` returns an empty DataFrame for an empty result set instead of raising `polars.exceptions.NoDataError`, fixing a crash in `bfabric-cli api read` when a query matched no records.
+- PKCE login: the browser callback page now renders a distinct, styled "Login failed" page showing the provider's error (e.g. a two-factor-enrollment requirement) instead of always claiming "Login successful".
 
 ## \[1.20.0rc2\] - 2026-07-15
 

--- a/bfabric/src/bfabric/_oauth/pkce.py
+++ b/bfabric/src/bfabric/_oauth/pkce.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import html
 import secrets
 import sys
 import threading
@@ -59,6 +60,56 @@ class _AuthorizationResult:
     error_description: str | None = None
 
 
+_PAGE_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+  :root {{ color-scheme: light dark; }}
+  body {{ font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+          margin: 0; min-height: 100vh; display: flex;
+          align-items: center; justify-content: center; background: #f5f5f7; }}
+  .card {{ max-width: 28rem; padding: 2.5rem 3rem; text-align: center;
+           background: #fff; border-radius: 12px;
+           box-shadow: 0 4px 24px rgba(0,0,0,.08); }}
+  .icon {{ font-size: 3rem; line-height: 1; color: {accent}; }}
+  h1 {{ margin: .75rem 0 .5rem; font-size: 1.4rem; color: {accent}; }}
+  p {{ margin: .25rem 0; color: #555; }}
+  @media (prefers-color-scheme: dark) {{
+    body {{ background: #1c1c1e; }} .card {{ background: #2c2c2e; box-shadow: none; }}
+    p {{ color: #aaa; }}
+  }}
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">{icon}</div>
+    <h1>{title}</h1>
+    {body}
+  </div>
+</body>
+</html>"""
+
+
+def _render_callback_page(result: _AuthorizationResult) -> bytes:
+    """Build the HTML page shown in the browser after the OAuth redirect.
+
+    No auto-close / close button: browsers only let scripts close windows they
+    opened themselves, so ``window.close()`` is a no-op for this browser-navigated
+    tab. We just tell the user they can close it.
+    """
+    if result.error is not None or result.code is None:
+        accent, icon, title = "#cf222e", "✕", "Login failed"
+        detail = result.error_description or result.error or "No authorization code was received."
+        body = f"<p>{html.escape(detail)}</p><p>You can close this tab and return to your terminal.</p>"
+    else:
+        accent, icon, title = "#1a7f37", "✓", "Login successful"
+        body = "<p>You can close this tab and return to your terminal.</p>"
+    return _PAGE_TEMPLATE.format(accent=accent, icon=icon, title=title, body=body).encode("utf-8")
+
+
 class _CallbackHandler(BaseHTTPRequestHandler):
     """HTTP request handler that captures the OAuth authorization callback."""
 
@@ -66,17 +117,18 @@ class _CallbackHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:  # noqa: N802
         qs = parse_qs(urlparse(self.path).query)
-        self.server.result = _AuthorizationResult(
+        result = _AuthorizationResult(
             code=qs.get("code", [None])[0],
             state=qs.get("state", [None])[0],
             error=qs.get("error", [None])[0],
             error_description=qs.get("error_description", [None])[0],
         )
+        self.server.result = result
 
         self.send_response(200)
-        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Type", "text/html; charset=utf-8")
         self.end_headers()
-        _ = self.wfile.write(b"<html><body><h1>Login successful</h1>" b"<p>You can close this tab.</p></body></html>")
+        _ = self.wfile.write(_render_callback_page(result))
 
         # Shut down the server from a daemon thread so this handler can return.
         threading.Thread(target=self.server.shutdown, daemon=True).start()

--- a/tests/bfabric/oauth/test_pkce.py
+++ b/tests/bfabric/oauth/test_pkce.py
@@ -109,6 +109,41 @@ class TestCallbackServer:
         assert server.result.code is None
         server.server_close()
 
+    @staticmethod
+    def _fetch_callback(query: str) -> str:
+        """Drive one loopback callback request and return the HTML response body."""
+        server = _CallbackServer(port=0)
+        port = server.server_address[1]
+        body = {}
+
+        def make_request():
+            body["text"] = httpx.get(f"http://127.0.0.1:{port}/callback?{query}").text
+
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        make_request()
+        server_thread.join(timeout=5)
+        server.server_close()
+        return body["text"]
+
+    def test_success_page_rendered(self):
+        html = self._fetch_callback("code=auth_code_123&state=csrf_state_456")
+        assert "Login successful" in html
+        assert "Login failed" not in html
+
+    def test_error_page_rendered(self):
+        html = self._fetch_callback(
+            "error=access_denied&error_description=Access+requires+two-factor+authentication&state=s"
+        )
+        assert "Login failed" in html
+        assert "Access requires two-factor authentication" in html
+        assert "Login successful" not in html
+
+    def test_error_description_is_html_escaped(self):
+        html = self._fetch_callback("error=access_denied&error_description=<script>alert(1)</script>")
+        assert "&lt;script&gt;" in html
+        assert "<script>alert(1)</script>" not in html
+
 
 class TestExchangeCode:
     def test_posts_correct_params(self, mocker):


### PR DESCRIPTION
The PKCE login callback page always said "Login successful", even when the OAuth
provider redirected back with an error (e.g. a two-factor-enrolment requirement).
The CLI aborted correctly, but the browser tab claimed the opposite.

The handler now renders a distinct "Login failed" page with the provider's error
(HTML-escaped) when the redirect carries an error or no code; otherwise the success
page. No close button / auto-close: window.close() is a no-op on a browser-navigated
tab, so the page just tells the user to close it.

Tested: pytest tests/bfabric/oauth/test_pkce.py (23 passed, incl. new success/error/
escaping cases); ruff + basedpyright clean.

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.