### PR TITLE
refactor: rename `bfabric-cli auth pkce` command to `auth login`

### DIFF
--- a/bfabric/docs/design/oauth_integration.md
+++ b/bfabric/docs/design/oauth_integration.md
@@ -44,7 +44,7 @@ All commands registered under `bfabric-cli auth` via cyclopts.
 
 | Command | File | Description |
 |---------|------|-------------|
-| `auth pkce <base_url>` | `cli/login/pkce.py` | Browser-based OAuth login. Caches tokens + writes config. |
+| `auth login <base_url>` | `cli/login/pkce.py` | Browser-based OAuth login. Caches tokens + writes config. |
 | `auth device-code <base_url>` | `cli/login/device_code.py` | Headless OAuth login. |
 | `auth pat <base_url>` | `cli/login/pat.py` | Personal Access Token login. |
 | `auth register <client_name> <redirect_uri>` | `cli/login/register.py` | RFC 7591 dynamic client registration. Outputs JSON. |

--- a/bfabric/docs/user_guides/bfabric-cli/workunits.md
+++ b/bfabric/docs/user_guides/bfabric-cli/workunits.md
@@ -147,7 +147,7 @@ carries the `tus` scope. Install the extra and authenticate once:
 
 ```bash
 pip install 'bfabric[transfer]'
-bfabric-cli auth pkce --scope "api:read api:write openid profile email groups tus"
+bfabric-cli auth login --scope "api:read api:write openid profile email groups tus"
 ```
 
 ### Basic Usage

--- a/bfabric/src/bfabric/_oauth/credential_provider.py
+++ b/bfabric/src/bfabric/_oauth/credential_provider.py
@@ -149,7 +149,7 @@ class OAuthCredentialProvider:
             if self._grant_type == "refresh_token":
                 raise BfabricOAuthError(
                     f"OAuth session expired ({e}). Re-authenticate with "
-                    "'bfabric-cli auth pkce' or 'bfabric-cli auth device-code'."
+                    "'bfabric-cli auth login' or 'bfabric-cli auth device-code'."
                 ) from e
             raise BfabricOAuthError(f"OAuth token request failed: {e}") from e
         except AuthlibBaseError as e:

--- a/bfabric/src/bfabric/bfabric.py
+++ b/bfabric/src/bfabric/bfabric.py
@@ -132,7 +132,7 @@ class Bfabric:
         env_name = config_data.env_name or "default"
         cache_path = compute_token_cache_path(base_url, client_id, env_name).expanduser()
         if not TokenCache(cache_path).load():
-            raise ValueError("No OAuth tokens found. Run 'bfabric-cli auth pkce' or 'bfabric-cli auth device-code'.")
+            raise ValueError("No OAuth tokens found. Run 'bfabric-cli auth login' or 'bfabric-cli auth device-code'.")
         provider = OAuthCredentialProvider(
             client_id=client_id,
             client_secret="",

--- a/bfabric/src/bfabric/examples/prove_tus_resume.py
+++ b/bfabric/src/bfabric/examples/prove_tus_resume.py
@@ -25,7 +25,7 @@ It exercises the same path ``bfabric.operations.workunit.upload_files`` uses:
 Prerequisites: an OAuth-backed config env with the ``tus`` scope. Authenticate once
 with::
 
-    bfabric-cli auth pkce --scope "api:read api:write openid profile email groups tus"
+    bfabric-cli auth login --scope "api:read api:write openid profile email groups tus"
 
 then run like the equivalent CLI upload::
 

--- a/bfabric/src/bfabric/transfer/tokens.py
+++ b/bfabric/src/bfabric/transfer/tokens.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from bfabric.config import BfabricAuth
 
 # Scopes the CLI is pre-registered for but that DEFAULT_OAUTH_SCOPE does not request by default.
-_PKCE_SCOPE_HINT = 'bfabric-cli auth pkce --scope "api:read api:write openid profile email groups {scope}"'
+_PKCE_SCOPE_HINT = 'bfabric-cli auth login --scope "api:read api:write openid profile email groups {scope}"'
 
 
 def _safe_auth(client: Bfabric) -> BfabricAuth | None:

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -13,7 +13,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 ## \[1.16.0rc2\] - 2026-07-15
 
 - `bfabric-cli auth` command group for OAuth authentication and client management:
-    - Login: `auth pkce` (browser), `auth device-code` (headless), `auth pat` (Personal Access Token).
+    - Login: `auth login` (browser), `auth device-code` (headless), `auth pat` (Personal Access Token).
     - `auth register` / `auth register-webapp` — dynamic client registration, optionally with a linked B-Fabric app.
     - `auth default` / `auth default set [CONFIG_ENV]` — show and set the default environment (interactive picker when no value is given).
     - `auth status` and `auth logout`.

--- a/bfabric_scripts/src/bfabric_scripts/cli/cli_auth.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/cli_auth.py
@@ -4,14 +4,14 @@ from bfabric_scripts.cli.login.default_config import cmd_auth_default
 from bfabric_scripts.cli.login.device_code import cmd_login_device_code
 from bfabric_scripts.cli.login.logout import cmd_login_logout
 from bfabric_scripts.cli.login.pat import cmd_login_pat
-from bfabric_scripts.cli.login.pkce import cmd_login_pkce
+from bfabric_scripts.cli.login.pkce import cmd_auth_login
 from bfabric_scripts.cli.login.register import cmd_login_register
 from bfabric_scripts.cli.login.register_webapp import cmd_login_register_webapp
 from bfabric_scripts.cli.login.status import cmd_login_status
 
 cmd_auth = cyclopts.App(help="Authentication commands for B-Fabric.")
 _ = cmd_auth.command(cmd_login_pat, name="pat")
-_ = cmd_auth.command(cmd_login_pkce, name="pkce")
+_ = cmd_auth.command(cmd_auth_login, name="login")
 _ = cmd_auth.command(cmd_login_device_code, name="device-code")
 _ = cmd_auth.command(cmd_login_register, name="register")
 _ = cmd_auth.command(cmd_login_register_webapp, name="register-webapp")

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/pkce.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/pkce.py
@@ -1,4 +1,4 @@
-"""PKCE (browser-based) login command."""
+"""Browser-based login command (OAuth PKCE flow)."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric.config.config_writer import write_environment_to_config
 
 
-def cmd_login_pkce(
+def cmd_auth_login(
     base_url: Annotated[str, cyclopts.Parameter(help="B-Fabric instance URL.")],
     *,
     client_id: Annotated[str, cyclopts.Parameter(help="OAuth client ID.")] = DEFAULT_CLIENT_ID,
@@ -28,7 +28,7 @@ def cmd_login_pkce(
         bool, cyclopts.Parameter(help="Set this environment as the default in the config file.")
     ] = True,
 ) -> None:
-    """Authenticate via browser-based PKCE flow."""
+    """Authenticate via browser-based login (OAuth PKCE flow)."""
     import sys
 
     base_url = base_url.rstrip("/")

--- a/bfabric_scripts/src/bfabric_scripts/cli/workunit/upload.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/workunit/upload.py
@@ -75,7 +75,7 @@ def cmd_workunit_upload(params: UploadParams, *, client: Bfabric) -> None:
 
     Creates a new workunit, or uploads into an existing one with ``--workunit-id``. Requires an
     OAuth-backed client with the ``tus`` scope; authenticate with
-    ``bfabric-cli auth pkce --scope "api:read api:write openid profile email groups tus"``.
+    ``bfabric-cli auth login --scope "api:read api:write openid profile email groups tus"``.
     """
     with _upload_progress(enabled=_progress_enabled(requested=params.progress)) as reporter:
         summary = upload_files(

--- a/tests/bfabric/oauth/test_credential_provider.py
+++ b/tests/bfabric/oauth/test_credential_provider.py
@@ -234,7 +234,7 @@ class TestOAuthErrorHandling:
             token={"access_token": "stale", "refresh_token": "rt", "expires_at": 1},
         )
 
-        with pytest.raises(BfabricOAuthError, match="pkce") as exc_info:
+        with pytest.raises(BfabricOAuthError, match="login") as exc_info:
             provider.get_auth()
 
         assert "device-code" in str(exc_info.value)

--- a/tests/bfabric/transfer/test_tokens.py
+++ b/tests/bfabric/transfer/test_tokens.py
@@ -66,7 +66,7 @@ class TestRequireScope:
 
         message = str(exc_info.value)
         assert "tus" in message
-        assert "bfabric-cli auth pkce --scope" in message
+        assert "bfabric-cli auth login --scope" in message
 
     def test_non_oauth_client_skips(self, mocker):
         client = _login_client(mocker, "someuser")

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_login.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_login.py
@@ -4,10 +4,10 @@ import time
 
 import yaml
 
-from bfabric_scripts.cli.login.pkce import cmd_login_pkce
+from bfabric_scripts.cli.login.pkce import cmd_auth_login
 
 
-class TestCmdLoginPkce:
+class TestCmdAuthLogin:
     def test_writes_config_and_caches_token(self, tmp_path, mocker):
         config_file = tmp_path / "config.yml"
         token = {
@@ -23,7 +23,7 @@ class TestCmdLoginPkce:
 
         mock_pkce = mocker.patch("bfabric_scripts.cli.login.pkce.pkce_login", return_value=token)
         mocker.patch("bfabric._oauth.credential_provider.OAuth2Session", return_value=mock_session)
-        cmd_login_pkce(
+        cmd_auth_login(
             base_url="https://example.com/bfabric",
             client_id="test-client",
             config_env="PROD",
@@ -50,7 +50,7 @@ class TestCmdLoginPkce:
 
         mocker.patch("bfabric_scripts.cli.login.pkce.pkce_login", return_value=token)
         mocker.patch("bfabric._oauth.credential_provider.OAuth2Session", return_value=mock_session)
-        cmd_login_pkce(
+        cmd_auth_login(
             base_url="https://example.com/bfabric",
             client_id="test-client",
             config_env="PROD",


### PR DESCRIPTION
Renames the browser-based login command `bfabric-cli auth pkce` → `auth login`.
"PKCE" named the OAuth mechanism; `login` is the clearer entry point.

- Backing function `cmd_login_pkce` → `cmd_auth_login` (matches the `auth`-group convention, cf. `cmd_auth_default`).
- Module file and library PKCE machinery (`pkce_login`, `connect_pkce`) unchanged — "PKCE" still names the OAuth grant.
- Updates all user-facing references: error messages, scope hint, docstrings, docs, changelog (rc2 edited in place; `pkce` was never released).

🤖 Prepared with assistance from Claude Opus 4.8 via Claude Code.