### PR TITLE
refactor(oauth): explicit cache_login_token API for CLI login-token caching

### DIFF
--- a/bfabric/src/bfabric/_oauth/credential_provider.py
+++ b/bfabric/src/bfabric/_oauth/credential_provider.py
@@ -27,7 +27,7 @@ from loguru import logger
 
 from bfabric.config.bfabric_auth import OAUTH_LOGIN, BfabricAuth
 from bfabric.errors import BfabricOAuthError
-from bfabric._oauth.token_cache import TokenCache
+from bfabric._oauth.token_cache import TokenCache, compute_token_cache_path
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -107,6 +107,29 @@ class OAuthCredentialProvider:
         if initial is not None:
             self._session.token = initial
             self._persist()
+
+    @classmethod
+    def cache_login_token(
+        cls, base_url: str, *, client_id: str, scope: str, token: dict[str, object], env_name: str
+    ) -> Path:
+        """Normalize and cache a freshly obtained login *token*, returning its cache path.
+
+        Ingesting the token derives its absolute ``expires_at`` (from ``expires_in``) and writes the
+        result to the per-identity disk cache, so a later process finds a complete, reusable token.
+        Used by the CLI ``auth login`` / ``auth device-code`` commands once their flow returns a token.
+        """
+        cache_path = compute_token_cache_path(base_url, client_id, env_name).expanduser()
+        # Constructing the provider ingests the token (deriving expires_at) and persists it to the cache.
+        _ = cls(
+            client_id=client_id,
+            client_secret="",
+            token_url=f"{base_url}/rest/oauth/token",
+            token=token,
+            grant_type="refresh_token",
+            scope=scope,
+            token_cache_path=cache_path,
+        )
+        return cache_path
 
     def get_auth(self) -> BfabricAuth:
         """Return a :class:`BfabricAuth` with a valid access token.

--- a/bfabric/src/bfabric/_oauth/credential_provider.py
+++ b/bfabric/src/bfabric/_oauth/credential_provider.py
@@ -34,6 +34,16 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def _canonical_token(token: dict[str, object]) -> dict[str, object]:
+    """The canonical on-disk form of an OAuth *token*.
+
+    ``OAuth2Token`` derives an absolute ``expires_at`` from ``expires_in`` (matching what a live
+    session writes on ingest), so ``auth status`` can read a cached token's freshness. This is the
+    single normalization rule shared by every code path that persists a token to the cache.
+    """
+    return dict(OAuth2Token(dict(token)))
+
+
 class OAuthCredentialProvider:
     """Manages an OAuth 2.0 token and exposes it as :class:`BfabricAuth`.
 
@@ -118,9 +128,7 @@ class OAuthCredentialProvider:
         Used by the CLI ``auth login`` / ``auth device-code`` commands once their flow returns a token.
         """
         cache_path = compute_token_cache_path(base_url, client_id, env_name).expanduser()
-        # OAuth2Token derives an absolute expires_at from expires_in, matching what the live session
-        # writes on ingest, so `auth status` can read the cached token's freshness.
-        TokenCache(cache_path).save(dict(OAuth2Token(dict(token))))
+        TokenCache(cache_path).save(_canonical_token(token))
         return cache_path
 
     def get_auth(self) -> BfabricAuth:
@@ -198,10 +206,9 @@ class OAuthCredentialProvider:
 
     def _persist(self) -> None:
         """Write the current token to disk cache if configured."""
-        if self._cache and self._session.token:  # pyright: ignore[reportUnknownMemberType]
-            self._cache.save(
-                dict(self._session.token)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
-            )
+        token = self._session.token  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        if self._cache and token:
+            self._cache.save(_canonical_token(token))  # pyright: ignore[reportUnknownArgumentType]
 
     def __getstate__(self) -> dict[str, object]:  # pyright: ignore[reportImplicitOverride]
         """Return a picklable representation.

--- a/bfabric/src/bfabric/_oauth/credential_provider.py
+++ b/bfabric/src/bfabric/_oauth/credential_provider.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 from authlib.common.errors import AuthlibBaseError
 from authlib.integrations.base_client.errors import OAuthError
 from authlib.integrations.requests_client import OAuth2Session  # pyright: ignore[reportMissingTypeStubs]
+from authlib.oauth2.rfc6749 import OAuth2Token
 from requests.exceptions import RequestException
 
 from loguru import logger
@@ -109,9 +110,7 @@ class OAuthCredentialProvider:
             self._persist()
 
     @classmethod
-    def cache_login_token(
-        cls, base_url: str, *, client_id: str, scope: str, token: dict[str, object], env_name: str
-    ) -> Path:
+    def cache_login_token(cls, base_url: str, *, client_id: str, token: dict[str, object], env_name: str) -> Path:
         """Normalize and cache a freshly obtained login *token*, returning its cache path.
 
         Ingesting the token derives its absolute ``expires_at`` (from ``expires_in``) and writes the
@@ -119,16 +118,9 @@ class OAuthCredentialProvider:
         Used by the CLI ``auth login`` / ``auth device-code`` commands once their flow returns a token.
         """
         cache_path = compute_token_cache_path(base_url, client_id, env_name).expanduser()
-        # Constructing the provider ingests the token (deriving expires_at) and persists it to the cache.
-        _ = cls(
-            client_id=client_id,
-            client_secret="",
-            token_url=f"{base_url}/rest/oauth/token",
-            token=token,
-            grant_type="refresh_token",
-            scope=scope,
-            token_cache_path=cache_path,
-        )
+        # OAuth2Token derives an absolute expires_at from expires_in, matching what the live session
+        # writes on ingest, so `auth status` can read the cached token's freshness.
+        TokenCache(cache_path).save(dict(OAuth2Token(dict(token))))
         return cache_path
 
     def get_auth(self) -> BfabricAuth:

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/oauth_login.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/oauth_login.py
@@ -42,16 +42,13 @@ def _resolve_params(
 def _persist(
     base_url: str,
     client_id: str,
-    scope: str,
     token: dict[str, object],
     config_env: str,
     config_file: Path,
     set_default: bool,
 ) -> None:
     """Cache the fresh OAuth *token* and record the environment in the config."""
-    _ = OAuthCredentialProvider.cache_login_token(
-        base_url, client_id=client_id, scope=scope, token=token, env_name=config_env
-    )
+    _ = OAuthCredentialProvider.cache_login_token(base_url, client_id=client_id, token=token, env_name=config_env)
     env_data = {"base_url": base_url, "auth_method": "oauth", "client_id": client_id}
     write_environment_to_config(config_file, config_env, env_data, set_default=set_default)
     print("Authenticated successfully.")
@@ -83,7 +80,7 @@ def cmd_auth_login(
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         raise SystemExit(1) from None
-    _persist(base_url, client_id, scope, token, config_env, config_file, set_default)
+    _persist(base_url, client_id, token, config_env, config_file, set_default)
 
 
 def cmd_login_device_code(
@@ -108,4 +105,4 @@ def cmd_login_device_code(
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         raise SystemExit(1) from None
-    _persist(base_url, client_id, scope, token, config_env, config_file, set_default)
+    _persist(base_url, client_id, token, config_env, config_file, set_default)

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/oauth_login.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/oauth_login.py
@@ -15,7 +15,6 @@ import cyclopts
 from bfabric._oauth.credential_provider import OAuthCredentialProvider
 from bfabric._oauth.device_code import device_code_login
 from bfabric._oauth.pkce import pkce_login
-from bfabric._oauth.token_cache import compute_token_cache_path
 from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric.config.config_writer import write_environment_to_config
 from bfabric_scripts.cli.login._common import resolve_config_env, resolve_scope, resolve_set_default
@@ -50,15 +49,8 @@ def _persist(
     set_default: bool,
 ) -> None:
     """Cache the fresh OAuth *token* and record the environment in the config."""
-    # OAuthCredentialProvider is constructed for its side effect: writing the token to the disk cache.
-    _ = OAuthCredentialProvider(
-        client_id=client_id,
-        client_secret="",
-        token_url=f"{base_url}/rest/oauth/token",
-        token=token,
-        grant_type="refresh_token",
-        scope=scope,
-        token_cache_path=compute_token_cache_path(base_url, client_id, config_env).expanduser(),
+    _ = OAuthCredentialProvider.cache_login_token(
+        base_url, client_id=client_id, scope=scope, token=token, env_name=config_env
     )
     env_data = {"base_url": base_url, "auth_method": "oauth", "client_id": client_id}
     write_environment_to_config(config_file, config_env, env_data, set_default=set_default)

--- a/tests/bfabric/oauth/test_credential_provider.py
+++ b/tests/bfabric/oauth/test_credential_provider.py
@@ -370,3 +370,27 @@ class TestDiskCache:
         # Fresh token should also be persisted to cache
         saved = json.loads(cache_path.read_text())
         assert saved["access_token"] == "from_caller"
+
+
+class TestCacheLoginToken:
+    def test_normalizes_and_caches_fresh_login_token(self, tmp_path, mocker):
+        import json
+
+        cache_path = tmp_path / "tok.json"
+        mocker.patch(
+            "bfabric._oauth.credential_provider.compute_token_cache_path",
+            return_value=cache_path,
+        )
+        raw = {"access_token": "a", "refresh_token": "r", "expires_in": 3600, "scope": "api:read"}
+        returned = OAuthCredentialProvider.cache_login_token(
+            "https://example.com/bfabric",
+            client_id="CLI",
+            scope="api:read",
+            token=raw,
+            env_name="TRACE",
+        )
+        assert returned == cache_path
+        cached = json.loads(cache_path.read_text())
+        assert cached["access_token"] == "a"
+        # expires_in is normalized to an absolute expires_at so `auth status` can report freshness.
+        assert isinstance(cached["expires_at"], (int, float))

--- a/tests/bfabric/oauth/test_credential_provider.py
+++ b/tests/bfabric/oauth/test_credential_provider.py
@@ -385,12 +385,13 @@ class TestCacheLoginToken:
         returned = OAuthCredentialProvider.cache_login_token(
             "https://example.com/bfabric",
             client_id="CLI",
-            scope="api:read",
             token=raw,
             env_name="TRACE",
         )
         assert returned == cache_path
         cached = json.loads(cache_path.read_text())
         assert cached["access_token"] == "a"
+        # The granted scope is preserved from the token itself (not a separate parameter).
+        assert cached["scope"] == "api:read"
         # expires_in is normalized to an absolute expires_at so `auth status` can report freshness.
         assert isinstance(cached["expires_at"], (int, float))


### PR DESCRIPTION
Add `OAuthCredentialProvider.cache_login_token(base_url, *, client_id, scope, token, env_name)`.
`_persist` in the login CLI now calls it instead of the bare constructor. Behavior-preserving refactor of unreleased OAuth internals, so no changelog entry.