### PR TITLE
fix(bfabric): flatten_relations recurses into nested structs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,13 @@ Release-candidate (rc) convention — decided 2026-07-15:
 - **Graduation.** When the RC becomes final, rename the `[X.Y.0rcN]` heading to `[X.Y.0]` with the release date (no content merge needed, since it was cumulative).
 - **Cross-package dependency floors.** When a package uses a feature from an unreleased/RC `bfabric`, pin its floor to the rc (e.g. `bfabric>=1.20.0rc2,<1.21`). A plain `>=1.20.0` **excludes** `1.20.0rc2` under PEP 440, and naming a prerelease in the specifier is also what lets pip/uv resolve to it.
 
+Hotfix convention (patch release of an older line) — decided 2026-07-24:
+
+- **Branch from the version tag, not `main`/`release`.** When the newest line is unreleased or in RC, `release`/`main` have moved ahead, so a patch of the last stable (e.g. `1.19.1` while `main` is `1.20.0rc`) must be cut from that stable tag: `git checkout -b hotfix/<pkg>-X.Y.Z <pkg>/X.Y.(Z-1)`.
+- **The hotfix branch is authoritative for its release.** Bump the patch version and add the `## [X.Y.Z]` changelog section there. This is what the pipeline extracts into the `<pkg>/X.Y.Z` tag and GitHub Release — the canonical record of what shipped.
+- **Publish out-of-band, don't merge into `release`.** Merging a hotfix into `release` (ahead on a newer line) would mislabel that tree. Instead trigger the publish workflow against the hotfix ref: `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`. The branch then lives on as the release record; it has no merge target.
+- **Forward-port the fix to `main` as a normal PR, `[Unreleased]` only.** Cherry-pick the fix (`git cherry-pick -x`) so `1.X.0` doesn't regress. On `main` the entry stays under `[Unreleased]` with an inline note (e.g. "(also released as the X.Y.Z hotfix)") — do **not** backfill a `## [X.Y.Z]` section into `main`. A past-line patch can't sit in `main`'s version-descending changelog without breaking either version or date order, and it would duplicate the bullet; the tag + GitHub Release are where `X.Y.Z` is recorded.
+
 ## Branches
 
 - `main` — active development

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -15,6 +15,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - OAuth token-acquisition failures (expired/revoked refresh token, unreachable token endpoint) now raise a clear `BfabricOAuthError` instead of leaking an `authlib`/`requests` traceback.
 - `EntityReader` lookups (`read_id` / `read_ids` / `query` / `query_one`) now accept an entity **class** in place of the endpoint string — e.g. `client.reader.read_id(Resource, id)` — inferring both the endpoint and the result type; the string form (with optional `expected_type`) still works.
 - The id/URI `EntityReader` lookups (`read_ids` / `read_uris`) now return an `EntityResult` — a `dict[EntityUri, Entity | None]` subclass with `.present` (found entities as a list) and `.by_id` (found entities re-keyed by integer id) properties, so callers write `reader.read_ids(Resource, ids).present` instead of wrapping the result in a helper. Class→endpoint inference is centralized in `import_entity.entity_type_of` (the inverse of `import_entity`).
+- `flatten_relations` (and `ResultContainer.to_polars(flatten=True)`) now recursively flattens nested struct columns instead of only one level, so a nested `b.inner.p` field becomes the `b_inner_p` column. Also shipped as the `1.19.1` hotfix.
 
 ## \[1.20.0rc2\] - 2026-07-15
 

--- a/bfabric/src/bfabric/utils/polars_utils.py
+++ b/bfabric/src/bfabric/utils/polars_utils.py
@@ -2,13 +2,17 @@ import polars as pl
 
 
 def flatten_relations(df: pl.DataFrame) -> pl.DataFrame:
-    """Flattens relations inside of the dataframe into individual columns, this is a bit opinionated for B-Fabric return
-    values where you will often have a struct (1 level deep) that you want to flatten in your results.
+    """Recursively flattens struct columns into individual columns, this is a bit opinionated for B-Fabric return
+    values where you will often have nested structs that you want to flatten in your results.
 
-    The columns of the new values will be the original column name with `_` and the field name appended.
-    All non-struct fields will be kept as is.
+    Each struct field becomes a column named by joining the ancestor column names and the field name with `_`, so a
+    nested `b.inner.p` field becomes `b_inner_p`. All non-struct fields are kept as is.
     If there are conflicts this raises an error.
     """
-    struct_cols = [col for col, dtype in zip(df.columns, df.dtypes) if isinstance(dtype, pl.Struct)]
-    flat_cols = [col for col in df.columns if col not in struct_cols]
-    return df.select(flat_cols + [pl.col(col).struct.unnest().name.prefix(f"{col}_") for col in struct_cols])
+    while any(isinstance(dtype, pl.Struct) for dtype in df.dtypes):
+        struct_cols = [col for col, dtype in zip(df.columns, df.dtypes) if isinstance(dtype, pl.Struct)]
+        flat_cols = [col for col in df.columns if col not in struct_cols]
+        df = df.select(  # pyright: ignore[reportUnknownMemberType]
+            flat_cols + [pl.col(col).struct.unnest().name.prefix(f"{col}_") for col in struct_cols]
+        )
+    return df

--- a/tests/bfabric/utils/test_polars_utils.py
+++ b/tests/bfabric/utils/test_polars_utils.py
@@ -24,6 +24,24 @@ def test_flatten_relations():
     pl.testing.assert_frame_equal(flatten_relations(df), expected_df)
 
 
+def test_flatten_relations_nested_struct():
+    df = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b": [{"x": 10, "inner": {"p": 100, "q": 101}}, {"x": 20, "inner": {"p": 200, "q": 201}}],
+        }
+    )
+    expected_df = pl.DataFrame(
+        {
+            "a": [1, 2],
+            "b_x": [10, 20],
+            "b_inner_p": [100, 200],
+            "b_inner_q": [101, 201],
+        }
+    )
+    pl.testing.assert_frame_equal(flatten_relations(df), expected_df)
+
+
 def test_flatten_relations_empty_df():
     df = pl.DataFrame({"a": [], "b": []})
     pl.testing.assert_frame_equal(flatten_relations(df), df)


### PR DESCRIPTION
`flatten_relations` only unnested structs one level deep, leaving deeper nested structs unflattened after B-Fabric began returning them. It now loops until no struct columns remain, chaining field names with `_` (`b.inner.p` → `b_inner_p`). Non-struct columns and the duplicate-name error are unchanged.

Also shipped as the bfabric 1.19.1 hotfix (cherry-picked onto `bfabric/1.19.0`); this is the forward-port. Adds a short "Hotfix convention" note to `AGENTS.md` documenting how past-line patch releases are cut and logged.

🤖 Prepared with assistance from Claude (Opus 4.8) via Claude Code.