### PR TITLE
fix(bfabric): reserve query elements for other fields in read_multi

### DIFF
--- a/.basedpyright/baseline.bfabric.json
+++ b/.basedpyright/baseline.bfabric.json
@@ -1376,14 +1376,6 @@
                     "endColumn": 20,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
             }
         ],
         "./bfabric/src/bfabric/entities/core/has_many.py": [
@@ -4662,98 +4654,10 @@
         ],
         "./bfabric/src/bfabric/experimental/multi_query.py": [
             {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnannotatedClassAttribute",
                 "range": {
                     "startColumn": 13,
                     "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingTypeArgument",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingTypeArgument",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 58,
-                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -4770,14 +4674,6 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -5742,58 +5638,6 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 14,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./bfabric/src/bfabric/utils/paginator.py": [
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingTypeArgument",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingTypeArgument",
-                "range": {
-                    "startColumn": 77,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./bfabric/src/bfabric/utils/polars_utils.py": [
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 20,
                     "lineCount": 1
                 }
             }

--- a/.basedpyright/baseline.bfabric_scripts.json
+++ b/.basedpyright/baseline.bfabric_scripts.json
@@ -1032,14 +1032,6 @@
                 }
             },
             {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 11,

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,8 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+- `MultiQuery.read_multi` now reserves query elements for the other fields of `obj` when chunking, since the API counts every value in a query towards its limit of 100 elements. Previously e.g. `read_multi("importresource", {"containerid": cid}, "relativepath", paths)` failed with "Query has 101 elements and exceeds the maximum of 100 allowed elements" as soon as 100 paths were passed. A query whose other fields already use up the limit now raises `ValueError` instead of being sent.
+
 ## \[1.20.0\] - 2026-08-03
 
 - OAuth 2.0 authentication: `connect_oauth` (client-credentials grant, auto-refresh + optional token cache), `connect_pkce` (interactive browser login, PKCE), `connect_device_code` (headless device grant), and `connect_pat` (Personal Access Token). `connect` auto-routes to OAuth when an environment sets `auth_method: oauth`. All three OAuth entry points require an explicit `client_id` and `scope` — the core library bakes in no defaults (those are CLI policy; `bfabric-cli auth …` supplies its own), and `connect()` raises if an `auth_method: oauth` environment has no `client_id`. Token-acquisition failures (expired/revoked refresh token, unreachable token endpoint) raise `BfabricOAuthError` instead of leaking an `authlib`/`requests` traceback, and a failed PKCE login renders a distinct "Login failed" callback page showing the provider's error (e.g. a two-factor-enrollment requirement) rather than always claiming success. Adds the `authlib` / `joserfc` dependencies.

--- a/bfabric/src/bfabric/experimental/multi_query.py
+++ b/bfabric/src/bfabric/experimental/multi_query.py
@@ -1,13 +1,29 @@
 from __future__ import annotations
 
-from copy import deepcopy
+from collections.abc import Mapping
 
 from bfabric.results.result_container import ResultContainer
-from bfabric.utils.paginator import page_iter
+from bfabric.utils.paginator import BFABRIC_QUERY_LIMIT, page_iter
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from bfabric.bfabric import Bfabric
+    from bfabric.typing import ApiRequestDataType, ApiRequestObjectType
+
+
+def _count_query_elements(value: ApiRequestDataType) -> int:
+    """Returns the number of elements `value` contributes to the API's limit of elements per query.
+
+    Nested containers are summed rather than counted as one, since over-counting merely costs an extra request
+    whereas under-counting makes the API reject the query.
+    """
+    if isinstance(value, Mapping):
+        return sum(_count_query_elements(item) for item in value.values())
+    if isinstance(value, list | tuple):
+        return sum(_count_query_elements(item) for item in value)
+    return 1
 
 
 class MultiQuery:
@@ -24,29 +40,40 @@ class MultiQuery:
     def read_multi(
         self,
         endpoint: str,
-        obj: dict,
+        obj: ApiRequestObjectType,
         multi_query_key: str,
-        multi_query_vals: list,
+        multi_query_vals: Sequence[ApiRequestDataType],
         return_id_only: bool = False,
     ) -> ResultContainer:
         """Performs a 1-parameter multi-query (there is 1 parameter that takes a list of values)
-        Since the API only allows BFABRIC_QUERY_LIMIT queries per page, split the list into chunks before querying
+        The API allows at most BFABRIC_QUERY_LIMIT elements per query and counts the values of the other `obj` fields
+        towards that limit too, so the list is split into chunks of the remaining size before querying.
         :param endpoint: endpoint
         :param obj: query dictionary
         :param multi_query_key:  key for which the multi-query is performed
         :param multi_query_vals: list of values for which the multi-query is performed
         :param return_id_only: whether to return only the ids of the objects
         :return: List of responses, packaged in the results container
+        :raises ValueError: if the other fields of `obj` already use up the element limit
 
         NOTE: It is assumed that there is only 1 response for each value.
         """
         # TODO add `check` parameter
         response_tot = ResultContainer([], total_pages_api=0, errors=[])
-        obj_extended = deepcopy(obj)  # Make a copy of the query, not to make edits to the argument
+        # `multi_query_key` is set per chunk below, so only the remaining fields reserve elements from the limit.
+        base_query = {key: value for key, value in obj.items() if key != multi_query_key}
+        n_reserved = _count_query_elements(base_query)
+        page_size = BFABRIC_QUERY_LIMIT - n_reserved
+        if page_size < 1:
+            msg = (
+                f"The query fields {sorted(base_query)} already use {n_reserved} of the {BFABRIC_QUERY_LIMIT} query "
+                f"elements allowed by the API, leaving no room for {multi_query_key!r} values."
+            )
+            raise ValueError(msg)
 
         # Iterate over request chunks that fit into a single API page
-        for page_vals in page_iter(multi_query_vals):
-            obj_extended[multi_query_key] = page_vals
+        for page_vals in page_iter(multi_query_vals, page_size=page_size):
+            query = {**base_query, multi_query_key: page_vals}
 
             # TODO: Test what happens if there are multiple responses to each of the individual queries.
             #     * What would happen?
@@ -57,7 +84,7 @@ class MultiQuery:
             #   exceptions to this? -> yes, when not reading by id but for instance matching a pattern, one might not
             #   be aware that they might accidentally pull the whole db, so it's better to have max_results here as well
             #   but it is not completely trivial to implement
-            response_this = self._client.read(endpoint, obj_extended, max_results=None, return_id_only=return_id_only)
+            response_this = self._client.read(endpoint, query, max_results=None, return_id_only=return_id_only)
             response_tot.extend(response_this, reset_total_pages_api=True)
 
         return response_tot
@@ -100,7 +127,7 @@ class MultiQuery:
         :return:          Return a single bool or a list of bools for each value
             For each value, test if a key with that value is found in the API.
         """
-        is_scalar = isinstance(value, (int, str))
+        is_scalar = isinstance(value, int | str)
         if is_scalar:
             return self._client.exists(endpoint=endpoint, key=key, value=value, check=True)
         elif not isinstance(value, list):

--- a/bfabric/src/bfabric/experimental/multi_query.py
+++ b/bfabric/src/bfabric/experimental/multi_query.py
@@ -14,10 +14,9 @@ if TYPE_CHECKING:
 
 
 def _count_query_elements(value: ApiRequestDataType) -> int:
-    """Returns the number of elements `value` contributes to the API's limit of elements per query.
+    """Returns how many elements `value` contributes to the API's query limit, summing nested containers.
 
-    Nested containers are summed rather than counted as one, since over-counting merely costs an extra request
-    whereas under-counting makes the API reject the query.
+    Over-counting only costs an extra request, whereas under-counting makes the API reject the query.
     """
     if isinstance(value, Mapping):
         return sum(_count_query_elements(item) for item in value.values())
@@ -45,22 +44,17 @@ class MultiQuery:
         multi_query_vals: Sequence[ApiRequestDataType],
         return_id_only: bool = False,
     ) -> ResultContainer:
-        """Performs a 1-parameter multi-query (there is 1 parameter that takes a list of values)
+        """Performs a 1-parameter multi-query, i.e. `multi_query_key` is the one `obj` field taking a list of values.
+
         The API allows at most BFABRIC_QUERY_LIMIT elements per query and counts the values of the other `obj` fields
-        towards that limit too, so the list is split into chunks of the remaining size before querying.
-        :param endpoint: endpoint
-        :param obj: query dictionary
-        :param multi_query_key:  key for which the multi-query is performed
-        :param multi_query_vals: list of values for which the multi-query is performed
-        :param return_id_only: whether to return only the ids of the objects
-        :return: List of responses, packaged in the results container
+        towards that limit too, so the values are split into chunks of the remaining size.
         :raises ValueError: if the other fields of `obj` already use up the element limit
 
         NOTE: It is assumed that there is only 1 response for each value.
         """
         # TODO add `check` parameter
         response_tot = ResultContainer([], total_pages_api=0, errors=[])
-        # `multi_query_key` is set per chunk below, so only the remaining fields reserve elements from the limit.
+        # `multi_query_key` is set per chunk below, so only the other fields reserve elements.
         base_query = {key: value for key, value in obj.items() if key != multi_query_key}
         n_reserved = _count_query_elements(base_query)
         page_size = BFABRIC_QUERY_LIMIT - n_reserved
@@ -71,19 +65,10 @@ class MultiQuery:
             )
             raise ValueError(msg)
 
-        # Iterate over request chunks that fit into a single API page
+        # TODO the case of multiple responses per value is untested, and there is no `max_results` here, so a query
+        #   matching a pattern instead of reading by id can accidentally pull the whole database
         for page_vals in page_iter(multi_query_vals, page_size=page_size):
             query = {**base_query, multi_query_key: page_vals}
-
-            # TODO: Test what happens if there are multiple responses to each of the individual queries.
-            #     * What would happen?
-            #     * What would happen if total number of responses would exceed 100 now?
-            #     * What would happen if we naively made a multi-query with more than 100 values? Would API paginate
-            #       automatically? If yes, perhaps we don't need this method at all?
-            # TODO: It is assumed that a user requesting multi_query always wants all of the pages. Can anybody think of
-            #   exceptions to this? -> yes, when not reading by id but for instance matching a pattern, one might not
-            #   be aware that they might accidentally pull the whole db, so it's better to have max_results here as well
-            #   but it is not completely trivial to implement
             response_this = self._client.read(endpoint, query, max_results=None, return_id_only=return_id_only)
             response_tot.extend(response_this, reset_total_pages_api=True)
 

--- a/bfabric/src/bfabric/utils/paginator.py
+++ b/bfabric/src/bfabric/utils/paginator.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Sequence
 
 # Single page query limit for BFabric API (as of time of writing, adapt if it changes)
 BFABRIC_QUERY_LIMIT = 100
 
+T = TypeVar("T")
 
-def page_iter(objs: list, page_size: int = BFABRIC_QUERY_LIMIT) -> Generator[list, None, None]:
+
+def page_iter(objs: Sequence[T], page_size: int = BFABRIC_QUERY_LIMIT) -> Generator[list[T], None, None]:
     """
     :param objs:       A list of objects to provide to bfabric as part of a query
     :param page_size:  Number of objects per page
@@ -18,7 +20,7 @@ def page_iter(objs: list, page_size: int = BFABRIC_QUERY_LIMIT) -> Generator[lis
     """
 
     for i in range(0, len(objs), page_size):
-        yield objs[i : i + page_size]
+        yield list(objs[i : i + page_size])
 
 
 def compute_requested_pages(

--- a/bfabric/src/bfabric/utils/paginator.py
+++ b/bfabric/src/bfabric/utils/paginator.py
@@ -13,12 +13,7 @@ T = TypeVar("T")
 
 
 def page_iter(objs: Sequence[T], page_size: int = BFABRIC_QUERY_LIMIT) -> Generator[list[T], None, None]:
-    """
-    :param objs:       A list of objects to provide to bfabric as part of a query
-    :param page_size:  Number of objects per page
-    :return:           An iterator over chunks that would be sent to bfabric, 1 chunk per query
-    """
-
+    """Yields `objs` in chunks of at most `page_size`, i.e. one chunk per B-Fabric query."""
     for i in range(0, len(objs), page_size):
         yield list(objs[i : i + page_size])
 

--- a/tests/bfabric/experimental/test_multi_query.py
+++ b/tests/bfabric/experimental/test_multi_query.py
@@ -1,0 +1,102 @@
+import pytest
+
+from bfabric.bfabric import Bfabric
+from bfabric.experimental.multi_query import MultiQuery, _count_query_elements
+from bfabric.results.result_container import ResultContainer
+
+
+@pytest.fixture
+def mock_client(mocker):
+    client = mocker.MagicMock(name="mock_client", spec=Bfabric)
+    client.read.side_effect = lambda *args, **kwargs: ResultContainer([], total_pages_api=1, errors=[])
+    return client
+
+
+@pytest.fixture
+def multi_query(mock_client):
+    return MultiQuery(client=mock_client)
+
+
+class TestReadMulti:
+    def test_chunks_leave_room_for_other_query_fields(self, mocker, mock_client, multi_query):
+        values = list(range(100))
+        multi_query.read_multi("importresource", {"containerid": 5}, "relativepath", values)
+        assert mock_client.read.mock_calls == [
+            mocker.call(
+                "importresource",
+                {"containerid": 5, "relativepath": values[:99]},
+                max_results=None,
+                return_id_only=False,
+            ),
+            mocker.call(
+                "importresource",
+                {"containerid": 5, "relativepath": values[99:]},
+                max_results=None,
+                return_id_only=False,
+            ),
+        ]
+
+    def test_single_request_for_full_chunk_without_other_fields(self, mocker, mock_client, multi_query):
+        values = list(range(100))
+        multi_query.read_multi("project", {}, "id", values)
+        assert mock_client.read.mock_calls == [
+            mocker.call("project", {"id": values}, max_results=None, return_id_only=False)
+        ]
+
+    def test_list_valued_field_reserves_one_element_per_value(self, mock_client, multi_query):
+        values = list(range(100))
+        multi_query.read_multi("resource", {"workunitid": [1, 2, 3]}, "id", values)
+        sent = [call.args[1]["id"] for call in mock_client.read.mock_calls]
+        assert sent == [values[:97], values[97:]]
+
+    def test_multi_query_key_in_obj_reserves_nothing(self, mock_client, multi_query):
+        values = list(range(100))
+        multi_query.read_multi("project", {"id": [1, 2, 3]}, "id", values)
+        sent = [call.args[1]["id"] for call in mock_client.read.mock_calls]
+        assert sent == [values]
+
+    def test_raises_when_query_leaves_no_room(self, mock_client, multi_query):
+        with pytest.raises(ValueError, match="already use 100 of the 100 query elements"):
+            multi_query.read_multi("importresource", {"containerid": list(range(100))}, "relativepath", ["a"])
+        mock_client.read.assert_not_called()
+
+    def test_does_not_mutate_the_caller_query(self, multi_query):
+        obj = {"containerid": 5}
+        multi_query.read_multi("importresource", obj, "relativepath", list(range(150)))
+        assert obj == {"containerid": 5}
+
+    def test_no_values_makes_no_requests(self, mock_client, multi_query):
+        result = multi_query.read_multi("project", {}, "id", [])
+        mock_client.read.assert_not_called()
+        assert len(result) == 0
+
+    def test_concatenates_results_across_chunks(self, mock_client, multi_query):
+        mock_client.read.side_effect = lambda endpoint, query, **kwargs: ResultContainer(
+            [{"id": value} for value in query["id"][:1]], total_pages_api=1, errors=[]
+        )
+        result = multi_query.read_multi("project", {}, "id", list(range(150)))
+        assert result.results == [{"id": 0}, {"id": 100}]
+        assert result.total_pages_api is None
+
+    def test_forwards_return_id_only(self, mock_client, multi_query):
+        multi_query.read_multi("project", {}, "id", [1], return_id_only=True)
+        assert mock_client.read.mock_calls[0].kwargs["return_id_only"]
+
+
+class TestCountQueryElements:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (5, 1),
+            ("abc", 1),
+            (None, 1),
+            (False, 1),
+            ([1, 2, 3], 3),
+            ({}, 0),
+            ({"a": 1, "b": 2}, 2),
+            ({"a": [1, 2]}, 2),
+            ([{"a": 1, "b": 2}], 2),
+        ],
+    )
+    def test_count(self, value, expected):
+        assert _count_query_elements(value) == expected


### PR DESCRIPTION
- `MultiQuery.read_multi` now shrinks its chunk size by the elements the other query fields use, so e.g. `read_multi("importresource", {"containerid": cid}, "relativepath", paths)` no longer fails with "Query has 101 elements and exceeds the maximum of 100 allowed elements".
- A query whose other fields already use up the 100-element limit raises `ValueError` instead of being sent.

Fixes #379

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.