### PR TITLE
fix(cli): catch OAuth error in register-webapp

### DIFF
--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,6 +10,8 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 ## \[Unreleased\]
 
+- `bfabric-cli auth register-webapp` — no longer crashes with a raw traceback when the OAuth session cannot be refreshed (e.g. an expired/revoked refresh token); prints a clean `Error: ...` message and exits 1.
+
 ## \[1.16.0\] - 2026-08-03
 
 - `bfabric-cli auth` — OAuth authentication & client management. Login: `login` (browser), `device-code` (headless), `pat`; client registration: `register` / `register-webapp`; environment management: `default`, `list`, `status`, `logout`. Scope presets (`read-only` / `read-write` / `upload`) or a raw scope, via an interactive picker when `--scope` is omitted in a terminal; no baked-in default scope, so a headless run must pass `--scope` (registration keeps the OIDC-inclusive default webapps need). When `--config-env` is omitted it prompts for the environment (else targets the current default / `PRODUCTION`); unless `--set-default` / `--no-set-default` is given it asks (default yes) whether to make the env the default, and cancelling that prompt aborts the login. `status` reports an OAuth env's cached-token freshness and granted scope (annotated with the matching preset); `logout` removes an env's config entry and cached tokens (confirmation required). PATs are stored under a `pat` key (`auth_method: pat`), keeping the config parseable by ≤1.19.0 clients.

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/register_webapp.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/register_webapp.py
@@ -45,7 +45,11 @@ def cmd_login_register_webapp(
         print(f"Error: Could not connect to B-Fabric: {e}", file=sys.stderr)
         raise SystemExit(1) from None
 
-    bearer_token = client.auth.password.get_secret_value()
+    try:
+        bearer_token = client.auth.password.get_secret_value()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        raise SystemExit(1) from None
 
     try:
         result = register_webapp(


### PR DESCRIPTION
## Summary
- `bfabric-cli auth register-webapp` crashed with a raw Python traceback when the OAuth session's refresh token was expired/revoked, instead of printing a clean error like the rest of the command.
- `client.auth.password.get_secret_value()` (the call that triggers a token refresh) sat outside any try/except, so the `BfabricOAuthError` raised by `credential_provider.py` had no local handler and propagated past `__main__.py`'s bare `app()` call.
- Wrapped that call in the same try/except pattern already used by its neighbors in this file, so it now prints `Error: ...` and exits 1.

## Test plan
- [x] Manually confirmed the code path: `credential_provider._ensure_token` raises `BfabricOAuthError` (a `RuntimeError`) on `invalid_grant`; the new try/except in `register_webapp.py` catches it and prints a clean message instead of a traceback.
- [ ] Reproduce locally with a stale/revoked refresh token cached for an OAuth env and confirm `bfabric-cli auth register-webapp` now prints `Error: OAuth session expired (...)` and exits 1 instead of a traceback.