### PR TITLE
fix(cli): authenticate auth register from the logged-in environment

### DIFF
--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -21,8 +21,9 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - New user guide: [Authentication](https://fgcz.github.io/bfabricPy/user_guides/bfabric-cli/authentication.html) — command surface, scopes, logout vs remove, remote hosts.
 - Packaging: `project.readme` now points at the package's own `README.md` instead of the repository root's, for the same reason as in `bfabric` — hatchling 1.32.0 rejects readme paths outside the project directory, breaking builds from source. The package README was expanded into a proper landing page, since it is what PyPI now shows.
 - `bfabric-cli auth register-webapp` — no longer crashes with a raw traceback when the OAuth session cannot be refreshed (e.g. an expired/revoked refresh token); prints a clean `Error: ...` message and exits 1.
-- `bfabric-cli auth register-webapp` — `--service-user` no longer silently defaults to "none"; now requires either `--service-user LOGIN` or the new `--no-service-user` flag, so omitting a service user by accident (which registers a client without the `client_credentials` grant) fails fast with an explanatory error instead of succeeding silently.
-- Internal: login handlers normalised to `cmd_auth_*`; shared resolution in `cli/login/_common.py`, base-URL handling in a new `_urls.py`.
+- `bfabric-cli auth register` — no longer prompts for an *Employee Bearer token* when a login already exists: with neither `--token` nor `--config-env` it authenticates as the environment in effect (`--config-env` > `BFABRICPY_CONFIG_ENV` > configured default), like every other `auth` command, so `auth login` followed by `auth register` just works. Pass `--token` to keep supplying one explicitly.
+- `bfabric-cli auth register` / `register-webapp` — `--service-user` no longer silently defaults to "none"; both now require either `--service-user LOGIN` or the new `--no-service-user` flag, so omitting a service user by accident (which registers a client without the `client_credentials` grant) fails fast with an explanatory error instead of succeeding silently.
+- Internal: login handlers normalised to `cmd_auth_*`; shared resolution in `cli/login/_common.py`, base-URL handling in a new `_urls.py`. `auth register` obtains its bearer token via `Bfabric.connect()` instead of rebuilding the credential-provider and token-cache lookup itself.
 
 ## \[1.16.0\] - 2026-08-03
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import getpass
 import json
 import sys
 from pathlib import Path
@@ -12,56 +11,26 @@ import cyclopts
 
 from bfabric._oauth.registration import register_client
 from bfabric.config import DEFAULT_CONFIG_FILE
-from bfabric_scripts.cli.login._constants import DEFAULT_CLIENT_ID, DEFAULT_REGISTRATION_SCOPE
+from bfabric_scripts.cli.login._constants import DEFAULT_REGISTRATION_SCOPE
 
 
-def _resolve_token_from_config(config_env: str, config_file: Path) -> tuple[str, str]:
-    """Load the cached OAuth access token and base_url for *config_env* as ``(token, base_url)``.
+def _resolve_token_from_config(config_env: str | None, config_file: Path) -> tuple[str, str]:
+    """The bearer token and base URL of the environment in effect, as ``(token, base_url)``.
 
-    Raises :class:`SystemExit` on failure.
+    Registration authenticates with a bare bearer token rather than a client, but the token is the one
+    ``connect()`` already resolves — so environment precedence, the token cache, and the "log in first"
+    errors are shared with the rest of the CLI instead of being reimplemented here.
+
+    :raises SystemExit: ``connect()`` could not authenticate the environment.
     """
-    import yaml
-
-    from bfabric._oauth.credential_provider import OAuthCredentialProvider
-    from bfabric._oauth.token_cache import compute_token_cache_path
-    from bfabric.config.config_file import ConfigFile
-
-    config_path = config_file.expanduser()
-    if not config_path.is_file():
-        print(f"Error: Config file not found: {config_path}", file=sys.stderr)
-        raise SystemExit(1)
-
-    config_file_obj = ConfigFile.model_validate(yaml.safe_load(config_path.read_text()))
-    if config_env not in config_file_obj.environments:
-        print(f"Error: Environment '{config_env}' not found in config.", file=sys.stderr)
-        raise SystemExit(1)
-
-    env = config_file_obj.environments[config_env]
-    base_url = env.config.base_url.rstrip("/")
-
-    if env.auth_method != "oauth":
-        print(f"Error: Environment '{config_env}' does not use OAuth.", file=sys.stderr)
-        raise SystemExit(1)
-
-    client_id = env.client_id or DEFAULT_CLIENT_ID
-    cache_path = compute_token_cache_path(base_url, client_id, config_env).expanduser()
-    token_url = f"{base_url}/rest/oauth/token"
+    from bfabric import Bfabric
 
     try:
-        provider = OAuthCredentialProvider(
-            client_id=client_id,
-            client_secret="",
-            token_url=token_url,
-            scope="",
-            grant_type="refresh_token",
-            token_cache_path=cache_path,
-        )
-        auth = provider.get_auth()
+        client = Bfabric.connect(config_file_path=config_file, config_file_env=config_env or "default")
+        return client.auth.password.get_secret_value(), str(client.config.base_url).rstrip("/")
     except Exception as e:
-        print(f"Error: Could not obtain token from cached credentials: {e}", file=sys.stderr)
+        print(f"Error: {e}", file=sys.stderr)
         raise SystemExit(1) from None
-
-    return auth.password.get_secret_value(), base_url
 
 
 def cmd_login_register(
@@ -72,13 +41,21 @@ def cmd_login_register(
     ] = None,
     *,
     token: Annotated[
-        str | None, cyclopts.Parameter(help="Employee Bearer token (prompted if omitted and --config-env not given).")
+        str | None,
+        cyclopts.Parameter(help="Employee Bearer token (defaults to the logged-in environment's token)."),
     ] = None,
     config_env: Annotated[str | None, cyclopts.Parameter(help="Reuse OAuth token from this environment.")] = None,
     config_file: Annotated[Path, cyclopts.Parameter(help="Path to the config file.")] = DEFAULT_CONFIG_FILE,
     service_user: Annotated[
         str | None, cyclopts.Parameter(help="Service user login (enables client_credentials grant).")
     ] = None,
+    no_service_user: Annotated[
+        bool,
+        cyclopts.Parameter(
+            help="Explicitly register without a service user (no client_credentials grant).",
+            negative=(),
+        ),
+    ] = False,
     scope: Annotated[str, cyclopts.Parameter(help="OAuth scope.")] = DEFAULT_REGISTRATION_SCOPE,
     grant_types: Annotated[
         list[str] | None,
@@ -86,21 +63,31 @@ def cmd_login_register(
     ] = None,
 ) -> None:
     """Register a new OAuth client with the B-Fabric server."""
+    if service_user is not None and no_service_user:
+        print("Error: --service-user and --no-service-user are mutually exclusive.", file=sys.stderr)
+        raise SystemExit(1)
+    if service_user is None and not no_service_user:
+        print(
+            "Error: pass --service-user LOGIN to enable the client_credentials grant, "
+            "or --no-service-user to register without one.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     resolved_base_url = base_url
     resolved_token = token
 
     if token is not None:
         print("Warning: passing secrets via CLI flags is insecure (visible in ps, shell history).", file=sys.stderr)
-    elif config_env is not None:
+    else:
+        # No token given: authenticate as the environment in effect, like every other `auth` command.
         cached_token, cached_base_url = _resolve_token_from_config(config_env, config_file)
         resolved_token = cached_token
         if resolved_base_url is None:
             resolved_base_url = cached_base_url
-    else:
-        resolved_token = getpass.getpass("Employee Bearer token: ")
 
     if resolved_base_url is None:
-        print("Error: base_url is required when --config-env is not provided.", file=sys.stderr)
+        print("Error: base_url is required when --token is given.", file=sys.stderr)
         raise SystemExit(1)
 
     assert resolved_token is not None  # narrowed: set by every branch above

--- a/tests/bfabric_scripts/cli/login/test_cmd_login_register.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_login_register.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 
 import pytest
@@ -7,6 +8,24 @@ import yaml
 
 from bfabric_scripts.cli.login._constants import DEFAULT_REGISTRATION_SCOPE
 from bfabric_scripts.cli.login.register import cmd_login_register
+
+
+def seed_token_cache(base_url: str, env_name: str, access_token: str, *, client_id: str = "my-app") -> None:
+    """Write a valid cached token where ``connect()`` looks for it (``$HOME`` is isolated per test)."""
+    from bfabric._oauth.token_cache import compute_token_cache_path
+
+    path = compute_token_cache_path(base_url, client_id, env_name).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": access_token,
+                "refresh_token": "rt",
+                "token_type": "Bearer",
+                "expires_at": time.time() + 3600,
+            }
+        )
+    )
 
 
 class TestCmdLoginRegister:
@@ -18,6 +37,7 @@ class TestCmdLoginRegister:
             token="bearer-tok",
             client_name="My App",
             redirect_uri="http://localhost/callback",
+            no_service_user=True,
         )
         output = capsys.readouterr()
         assert '"client_id": "new-client"' in output.out
@@ -36,24 +56,25 @@ class TestCmdLoginRegister:
                 token="bad-tok",
                 client_name="My App",
                 redirect_uri="http://localhost/callback",
+                no_service_user=True,
             )
         except SystemExit as e:
             assert e.code == 1
         err = capsys.readouterr().err
         assert "forbidden" in err
 
-    def test_prompts_when_token_omitted(self, mocker, capsys):
-        result = {"client_id": "new-client", "client_secret": "secret123"}
-        mocker.patch("bfabric_scripts.cli.login.register.register_client", return_value=result)
-        mock_getpass = mocker.patch("bfabric_scripts.cli.login.register.getpass.getpass", return_value="prompted-token")
-        cmd_login_register(
-            base_url="https://example.com/bfabric",
-            client_name="My App",
-            redirect_uri="http://localhost/callback",
-        )
-        mock_getpass.assert_called_once()
-        output = capsys.readouterr()
-        assert '"client_id": "new-client"' in output.out
+    def test_no_token_and_no_config_file_errors(self, tmp_path, capsys):
+        """Without a token the command authenticates via ``connect()``, and surfaces its error."""
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_login_register(
+                base_url="https://example.com/bfabric",
+                client_name="My App",
+                redirect_uri="http://localhost/callback",
+                config_file=tmp_path / "missing.yml",
+                no_service_user=True,
+            )
+        assert exc_info.value.code == 1
+        assert "no config file found" in capsys.readouterr().err
 
     def test_base_url_required_without_config_env(self, capsys):
         with pytest.raises(SystemExit) as exc_info:
@@ -61,6 +82,7 @@ class TestCmdLoginRegister:
                 client_name="My App",
                 redirect_uri="http://localhost/callback",
                 token="bearer-tok",
+                no_service_user=True,
             )
         assert exc_info.value.code == 1
         err = capsys.readouterr().err
@@ -83,23 +105,16 @@ class TestCmdLoginRegister:
             )
         )
 
-        mock_session = mocker.MagicMock()
-        mock_session.token = {
-            "access_token": "cached-jwt",
-            "refresh_token": "rt",
-            "token_type": "Bearer",
-            "expires_at": time.time() + 3600,
-        }
-        mock_session.metadata = {"token_endpoint": f"{base_url}/rest/oauth/token"}
+        seed_token_cache(base_url, "PROD", "cached-jwt", client_id=client_id)
 
         result = {"client_id": "new-client", "client_secret": "secret123"}
-        mocker.patch("bfabric._oauth.credential_provider.OAuth2Session", return_value=mock_session)
         mock_register = mocker.patch("bfabric_scripts.cli.login.register.register_client", return_value=result)
         cmd_login_register(
             client_name="My App",
             redirect_uri="http://localhost/callback",
             config_env="PROD",
             config_file=config_file,
+            no_service_user=True,
         )
         mock_register.assert_called_once_with(
             base_url=base_url,
@@ -128,17 +143,9 @@ class TestCmdLoginRegister:
             )
         )
 
-        mock_session = mocker.MagicMock()
-        mock_session.token = {
-            "access_token": "cached-jwt",
-            "refresh_token": "rt",
-            "token_type": "Bearer",
-            "expires_at": time.time() + 3600,
-        }
-        mock_session.metadata = {"token_endpoint": "https://config-url.com/bfabric/rest/oauth/token"}
+        seed_token_cache("https://config-url.com/bfabric", "PROD", "cached-jwt")
 
         result = {"client_id": "new-client", "client_secret": "secret123"}
-        mocker.patch("bfabric._oauth.credential_provider.OAuth2Session", return_value=mock_session)
         mock_register = mocker.patch("bfabric_scripts.cli.login.register.register_client", return_value=result)
         cmd_login_register(
             base_url="https://explicit-url.com/bfabric",
@@ -146,6 +153,7 @@ class TestCmdLoginRegister:
             redirect_uri="http://localhost/callback",
             config_env="PROD",
             config_file=config_file,
+            no_service_user=True,
         )
         # Explicit base_url should win over config
         mock_register.assert_called_once_with(
@@ -178,12 +186,16 @@ class TestCmdLoginRegister:
                 redirect_uri="http://localhost/callback",
                 config_env="NONEXISTENT",
                 config_file=config_file,
+                no_service_user=True,
             )
         assert exc_info.value.code == 1
-        err = capsys.readouterr().err
-        assert "not found" in err
+        assert "NONEXISTENT" in capsys.readouterr().err
 
-    def test_config_env_non_oauth(self, tmp_path, capsys):
+    def test_config_env_non_oauth_sends_configured_password(self, tmp_path, mocker):
+        """A password environment has no bearer token, so ``connect()`` yields the SOAP password.
+
+        The server rejects it; the command does not pre-screen ``auth_method`` itself.
+        """
         config_file = tmp_path / "config.yml"
         config_file.write_text(
             yaml.dump(
@@ -197,13 +209,171 @@ class TestCmdLoginRegister:
                 }
             )
         )
+        mock_register = mocker.patch(
+            "bfabric_scripts.cli.login.register.register_client",
+            return_value={"client_id": "new-client"},
+        )
+        cmd_login_register(
+            client_name="My App",
+            redirect_uri="http://localhost/callback",
+            config_env="PROD",
+            config_file=config_file,
+            no_service_user=True,
+        )
+        assert mock_register.call_args.kwargs["token"] == "x" * 32
+
+
+class TestCmdLoginRegisterServiceUserChoice:
+    """``register`` requires the same explicit service-user choice as ``register-webapp``."""
+
+    def test_requires_service_user_choice(self, mocker, capsys):
+        mock_register = mocker.patch("bfabric_scripts.cli.login.register.register_client")
         with pytest.raises(SystemExit) as exc_info:
             cmd_login_register(
                 client_name="My App",
                 redirect_uri="http://localhost/callback",
-                config_env="PROD",
-                config_file=config_file,
+                base_url="https://example.com/bfabric",
+                token="tok",
             )
         assert exc_info.value.code == 1
         err = capsys.readouterr().err
-        assert "does not use OAuth" in err
+        assert "--service-user" in err
+        assert "--no-service-user" in err
+        mock_register.assert_not_called()
+
+    def test_rejects_service_user_and_no_service_user_together(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_login_register(
+                client_name="My App",
+                redirect_uri="http://localhost/callback",
+                base_url="https://example.com/bfabric",
+                token="tok",
+                service_user="trace",
+                no_service_user=True,
+            )
+        assert exc_info.value.code == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_no_service_user_registers_without_grant(self, mocker):
+        mock_register = mocker.patch(
+            "bfabric_scripts.cli.login.register.register_client",
+            return_value={"client_id": "new-client"},
+        )
+        cmd_login_register(
+            client_name="My App",
+            redirect_uri="http://localhost/callback",
+            base_url="https://example.com/bfabric",
+            token="tok",
+            no_service_user=True,
+        )
+        assert mock_register.call_args.kwargs["service_user"] is None
+
+    def test_service_user_is_forwarded(self, mocker):
+        mock_register = mocker.patch(
+            "bfabric_scripts.cli.login.register.register_client",
+            return_value={"client_id": "new-client"},
+        )
+        cmd_login_register(
+            client_name="My App",
+            redirect_uri="http://localhost/callback",
+            base_url="https://example.com/bfabric",
+            token="tok",
+            service_user="trace",
+        )
+        assert mock_register.call_args.kwargs["service_user"] == "trace"
+
+
+class TestCmdLoginRegisterResolvesEnvironment:
+    """``register`` resolves the environment like every other ``auth`` command, instead of prompting."""
+
+    @pytest.fixture
+    def oauth_config_file(self, tmp_path):
+        config_file = tmp_path / "config.yml"
+        config_file.write_text(
+            yaml.dump(
+                {
+                    "GENERAL": {"default_config": "PROD"},
+                    "PROD": {
+                        "base_url": "https://prod.example.com/bfabric",
+                        "auth_method": "oauth",
+                        "client_id": "my-app",
+                    },
+                    "STAGE": {
+                        "base_url": "https://stage.example.com/bfabric",
+                        "auth_method": "oauth",
+                        "client_id": "my-app",
+                    },
+                }
+            )
+        )
+        return config_file
+
+    @pytest.fixture
+    def cached_tokens(self):
+        """Seed the on-disk token cache for both environments, so each resolves to a distinct token."""
+        seed_token_cache("https://prod.example.com/bfabric", "PROD", "prod-jwt")
+        seed_token_cache("https://stage.example.com/bfabric", "STAGE", "stage-jwt")
+
+    def test_uses_default_env_when_no_flags_given(self, oauth_config_file, cached_tokens, mocker):
+        """The regression: a bare ``register`` used to demand a hand-pasted bearer token."""
+        mock_register = mocker.patch(
+            "bfabric_scripts.cli.login.register.register_client",
+            return_value={"client_id": "new-client"},
+        )
+        cmd_login_register(
+            client_name="My App",
+            redirect_uri="http://localhost/callback",
+            config_file=oauth_config_file,
+            no_service_user=True,
+        )
+        assert mock_register.call_args.kwargs["base_url"] == "https://prod.example.com/bfabric"
+        assert mock_register.call_args.kwargs["token"] == "prod-jwt"
+
+    def test_config_env_var_takes_precedence_over_default(
+        self, oauth_config_file, cached_tokens, mocker, monkeypatch
+    ):
+        monkeypatch.setenv("BFABRICPY_CONFIG_ENV", "STAGE")
+        mock_register = mocker.patch(
+            "bfabric_scripts.cli.login.register.register_client",
+            return_value={"client_id": "new-client"},
+        )
+        cmd_login_register(
+            client_name="My App",
+            redirect_uri="http://localhost/callback",
+            config_file=oauth_config_file,
+            no_service_user=True,
+        )
+        assert mock_register.call_args.kwargs["base_url"] == "https://stage.example.com/bfabric"
+
+    def test_explicit_config_env_beats_env_var_and_default(
+        self, oauth_config_file, cached_tokens, mocker, monkeypatch
+    ):
+        monkeypatch.setenv("BFABRICPY_CONFIG_ENV", "PROD")
+        mock_register = mocker.patch(
+            "bfabric_scripts.cli.login.register.register_client",
+            return_value={"client_id": "new-client"},
+        )
+        cmd_login_register(
+            client_name="My App",
+            redirect_uri="http://localhost/callback",
+            config_env="STAGE",
+            config_file=oauth_config_file,
+            no_service_user=True,
+        )
+        assert mock_register.call_args.kwargs["base_url"] == "https://stage.example.com/bfabric"
+
+    def test_explicit_token_still_skips_env_resolution(self, oauth_config_file, mocker, capsys):
+        mock_register = mocker.patch(
+            "bfabric_scripts.cli.login.register.register_client",
+            return_value={"client_id": "new-client"},
+        )
+        cmd_login_register(
+            base_url="https://explicit.example.com/bfabric",
+            client_name="My App",
+            redirect_uri="http://localhost/callback",
+            token="flag-token",
+            config_file=oauth_config_file,
+            no_service_user=True,
+        )
+        assert mock_register.call_args.kwargs["token"] == "flag-token"
+        assert "insecure" in capsys.readouterr().err


### PR DESCRIPTION
Stacked on #573 — base is `feature/cli-auth-ux`, so this diff is just the `auth register` fix. Review/merge #573 first; GitHub will retarget this to `main` once it lands.

## The bug

`auth register` prompted for an *Employee Bearer token* whenever neither `--token` nor `--config-env` was given — so immediately after a successful `bfabric-cli login` you still had to paste a token by hand:

```
$ uv run bfabric-cli login
Authenticated successfully.
Config saved to environment 'local' in ~/.bfabricpy.yml

$ uv run bfabric-cli auth register my-app http://localhost:6666
Employee Bearer token:      # ← should not be asking
```

The changelog already promises that *every* `auth` command resolves the environment as `--config-env` > `BFABRICPY_CONFIG_ENV` > configured default. `register` was the one command that didn't — it treated "no `--config-env`" as "prompt" instead of "use the default".

## Changes

- **Respect the environment in effect.** With no `--token`, `register` now authenticates as the resolved environment, so `login` → `register` just works. `--token` still works for supplying one explicitly.
- **Reuse `connect()` instead of reimplementing it.** The old code rebuilt the `OAuthCredentialProvider` + token-cache lookup by hand (~40 lines). `Bfabric.connect()` already resolves the environment (including the `"default"` sentinel), loads the cache, and raises the "log in first" errors — `register_webapp` was already using exactly this. Net −12 lines in `register.py` despite adding a flag.
- **Require an explicit service-user choice**, matching what #573 does for `register-webapp`: `--service-user LOGIN` or the new `--no-service-user`. Silently defaulting to none registers a client without the `client_credentials` grant.
- Fixed two now-stale help/error strings (`--token`'s "prompted if omitted", and "base_url is required when --config-env is not provided").

## Deliberate behaviour change

A non-OAuth (`password`) environment is no longer pre-screened. Previously `register` printed `Environment 'X' does not use OAuth` locally; now `connect()` hands back the SOAP password, it's sent as a bearer token, and the server rejects it (405). Validating that belongs in `connect()` — not bolted onto one CLI command — so it's left out rather than duplicated here. `test_config_env_non_oauth_sends_configured_password` documents the new behaviour.

## Open question, not addressed here

`register` / `register-webapp` may be in the wrong place. Every other top-level group is noun-shaped (`api`, `dataset`, `executable`, `workunit`), while `auth` is verb-shaped — session state. These two create durable server-side objects (an OAuth client, plus a B-Fabric *application* entity, with `--technology-id` / `--application-id` / `--description` fields), which is noun work. Something like `bfabric-cli oauth-client register` may fit better, but that's a user-visible rename and deserves its own discussion.

## Testing

- 224 `bfabric_scripts` tests pass; 16 in `test_cmd_login_register.py`, incl. new coverage for default-env resolution, `BFABRICPY_CONFIG_ENV` precedence, explicit `--config-env` winning, and the service-user choice.
- Tests now seed the real on-disk token cache instead of mocking `OAuth2Session`, so they exercise the path `connect()` actually takes. Two of them previously made live HTTP requests to `example.com`; both are now mocked.
- `ruff check` and `basedpyright(bfabric_scripts)` clean (0 errors).
- Verified manually: `auth register` no longer prompts, and both commands now show `--service-user` / `--no-service-user`.