### PR TITLE
perf(bfabric): import polars lazily in the eagerly-loaded entities

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -10,6 +10,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ## \[Unreleased\]
 
 - `MultiQuery.read_multi` now reserves query elements for the other fields of `obj` when chunking, since the API counts every value in a query towards its limit of 100 elements. Previously e.g. `read_multi("importresource", {"containerid": cid}, "relativepath", paths)` failed with "Query has 101 elements and exceeds the maximum of 100 allowed elements" as soon as 100 paths were passed. A query whose other fields already use up the limit now raises `ValueError` instead of being sent.
+- `import bfabric` no longer imports `polars` eagerly (~296 ms → ~184 ms). The three modules on the import path that pulled it in at module scope — `HasMany.polars`, `Dataset.to_polars`, `MultiplexKit.ids` — now import it inside the function, as `ResultContainer.to_polars` already did. `polars` remains a hard dependency and every API is unchanged; it is simply not loaded until a `DataFrame` is actually requested.
 
 ## \[1.20.0\] - 2026-08-03
 

--- a/bfabric/src/bfabric/entities/core/has_many.py
+++ b/bfabric/src/bfabric/entities/core/has_many.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import Generic, TypeVar, TYPE_CHECKING
 
-import polars as pl
-from polars import DataFrame
-
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from polars import DataFrame
 
     # noinspection PyUnresolvedReferences
     from bfabric.entities.core.entity import Entity
@@ -47,6 +46,11 @@ class _HasManyProxy(Generic[E]):
 
     @property
     def polars(self) -> DataFrame:
+        # Imported here, not at module scope: HasMany is loaded by every `import bfabric`, and polars
+        # is by far the heaviest dependency (~200 MB, ~70 ms). Callers that never ask for a DataFrame
+        # should not pay for it. Same pattern as ResultContainer.to_polars.
+        import polars as pl
+
         return pl.from_dicts([x.data_dict for x in self._items])
 
     def __getitem__(self, key: int) -> E:

--- a/bfabric/src/bfabric/entities/dataset.py
+++ b/bfabric/src/bfabric/entities/dataset.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import io
 from typing import TYPE_CHECKING, Annotated, Any
 
-from polars import DataFrame
 from pydantic import BaseModel, BeforeValidator
 
 from bfabric.entities.core.entity import Entity
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from polars import DataFrame
 
 
 class _AttributeData(BaseModel):
@@ -64,6 +65,11 @@ class Dataset(Entity):
 
     def to_polars(self) -> DataFrame:
         """Returns a Polars DataFrame representation of the dataset."""
+        # Imported here, not at module scope: Dataset is reachable from every `import bfabric`, and
+        # polars is by far the heaviest dependency (~200 MB, ~70 ms). Callers that never ask for a
+        # DataFrame should not pay for it. Same pattern as ResultContainer.to_polars.
+        from polars import DataFrame
+
         column_names = self.column_names
         data: list[dict[str, str]] = []
         for item in self._item_data:

--- a/bfabric/src/bfabric/entities/multiplexkit.py
+++ b/bfabric/src/bfabric/entities/multiplexkit.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-import polars as pl
-
 from bfabric.entities.core.entity import Entity
 from bfabric.entities.core.has_many import HasMany
 
 if TYPE_CHECKING:
+    import polars as pl
+
     from bfabric.entities.multiplexid import MultiplexId
 
 
@@ -19,6 +19,11 @@ class MultiplexKit(Entity):
 
     @cached_property
     def ids(self) -> pl.DataFrame:
+        # Imported here, not at module scope: this entity is loaded by every `import bfabric`, and
+        # polars is by far the heaviest dependency (~200 MB, ~70 ms). Same pattern as
+        # ResultContainer.to_polars.
+        import polars as pl
+
         return self.multiplex_ids.polars.filter(pl.col("enabled") == "true").select(
             ["name", "sequence", "reversesequence", "reversecomplementsequence", "type"]
         )

--- a/tests/bfabric/_lazy_import_probe.py
+++ b/tests/bfabric/_lazy_import_probe.py
@@ -1,0 +1,80 @@
+"""Reports every module that imports a heavy dependency at module scope.
+
+Run as a script in a fresh interpreter by ``test_lazy_imports.py`` — it must not run inside pytest,
+whose process has already imported polars for other tests. Prints one line per offending import
+statement; prints nothing when the package is clean.
+"""
+
+import importlib
+import importlib.util
+import pathlib
+import sys
+
+BLOCKED = "polars"
+
+# Modules that may import it eagerly: these are the polars-based features themselves, and none of them
+# is reachable from `import bfabric`. Extend only after confirming the module really cannot be reached
+# by an `import bfabric` that never asks for a DataFrame.
+EAGER_ALLOWLIST = ("bfabric.operations.dataset", "bfabric.utils.polars_utils", "bfabric.utils.table_lint")
+
+# Standalone scripts rather than library code, and not all of them import cleanly.
+SKIP = ("bfabric.examples",)
+
+
+class _Blocker:
+    """Makes ``import polars`` fail, so an eager import raises instead of quietly succeeding.
+
+    Blocking rather than inspecting ``sys.modules`` is what makes every offender visible: once the real
+    module is loaded the first time, later imports hit the cache and can no longer be attributed.
+    """
+
+    def find_spec(self, fullname: str, path: object = None, target: object = None) -> None:
+        if fullname.split(".")[0] == BLOCKED:
+            raise ModuleNotFoundError(f"blocked by {__name__}: {fullname}", name=fullname)
+        return None
+
+
+def _module_names(root: pathlib.Path) -> list[str]:
+    """Every module in the package, `bfabric` itself first, without importing anything."""
+    names = []
+    for path in root.rglob("*.py"):
+        parts = path.relative_to(root).with_suffix("").parts
+        names.append(".".join((root.name, *(parts[:-1] if parts[-1] == "__init__" else parts))))
+    return sorted(names, key=lambda name: (name != root.name, name))
+
+
+def _offending_site(error: ModuleNotFoundError, root: pathlib.Path) -> str:
+    """The deepest frame inside the package, i.e. the module-scope import statement itself."""
+    traceback, site = error.__traceback__, "?"
+    while traceback:
+        filename = traceback.tb_frame.f_code.co_filename
+        if filename.startswith(str(root)):
+            site = f"{pathlib.Path(filename).relative_to(root.parent)}:{traceback.tb_lineno}"
+        traceback = traceback.tb_next
+    return site
+
+
+def main() -> None:
+    # find_spec locates the package without executing its __init__, which may itself be an offender.
+    spec = importlib.util.find_spec("bfabric")
+    assert spec is not None and spec.submodule_search_locations is not None
+    root = pathlib.Path(spec.submodule_search_locations[0])
+
+    sys.meta_path.insert(0, _Blocker())
+    offenders: dict[str, str] = {}
+    for name in _module_names(root):
+        if name.startswith(EAGER_ALLOWLIST + SKIP):
+            continue
+        try:
+            importlib.import_module(name)
+        except ModuleNotFoundError as error:
+            if error.name != BLOCKED:
+                continue  # an optional extra is not installed, e.g. zeep
+            # Many modules reach the same statement transitively; report each one once.
+            offenders.setdefault(_offending_site(error, root), name)
+    for site, name in offenders.items():
+        print(f"{site}  (reached by `import {name}`)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bfabric/test_lazy_imports.py
+++ b/tests/bfabric/test_lazy_imports.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+from pathlib import Path
+
+PROBE = Path(__file__).parent / "_lazy_import_probe.py"
+
+
+def test_no_module_imports_polars_eagerly() -> None:
+    """polars is ~200 MB installed and ~70 ms to import, so nothing may pull it in just to be imported.
+
+    The accessors that return a DataFrame (``HasMany.polars``, ``Dataset.to_polars``,
+    ``MultiplexKit.ids``, ``ResultContainer.to_polars``) import it inside the function body instead.
+    See ``_lazy_import_probe.EAGER_ALLOWLIST`` for the modules that are exempt because they *are* the
+    polars-based features.
+    """
+    # A subprocess is needed because the pytest process has already imported polars for other tests.
+    result = subprocess.run([sys.executable, str(PROBE)], capture_output=True, text=True, check=True)
+    offenders = result.stdout.splitlines()
+    assert not offenders, "modules importing polars at module scope:\n  " + "\n  ".join(offenders)


### PR DESCRIPTION
Three modules on the `import bfabric` path imported `polars` at module scope, none of which need it unless the caller actually asks for a `DataFrame`:

| Module | Why it had polars |
|---|---|
| `entities/core/has_many.py` | the `.polars` convenience property |
| `entities/dataset.py` | `to_polars()` and its `write_*` helpers |
| `entities/multiplexkit.py` | the `.ids` property (uses `pl.col`) |

Each import moves into the function body, with type-only names under `TYPE_CHECKING` — the pattern `ResultContainer.to_polars` already used.

## Effect

```
import bfabric   ~296 ms  ->  ~184 ms
polars in sys.modules after import:  True -> False
```

polars is by far the heaviest dependency — ~200 MB of a ~261 MB install — so this matters most for short-lived processes. A cron-driven uploader was paying ~70 ms per tick, plus the install weight, for a DataFrame library it never touches.

## Scope

**Behaviour is unchanged.** polars remains a hard dependency and every API works exactly as before; it is simply not loaded until a `DataFrame` is requested. `.polars`, `to_polars()` and `.ids` were all exercised after the change and still return real DataFrames.

The remaining module-level imports (`utils/polars_utils`, `utils/table_lint`, `operations/dataset/*`) are untouched: those modules *are* the polars-based features and are not on the `import bfabric` path.

## Testing

Full `tests/bfabric` suite passes (822 on this base); ruff and basedpyright clean.

---
Split out of #581, where it was noticed while packaging an instrument uploader — the change touches core entity modules that every consumer imports, so it is worth reviewing on its own rather than riding along with unrelated upload work.