### PR TITLE
Fix builds from source broken by hatchling 1.32.0

### DIFF
--- a/bfabric/README.md
+++ b/bfabric/README.md
@@ -1,7 +1,8 @@
 # bfabric
 
-Python client for [B-Fabric](https://fgcz-bfabric.uzh.ch/bfabric/), the data management platform of the Functional
-Genomics Center Zurich (FGCZ).
+Python client for the [B-Fabric](https://fgcz-bfabric.uzh.ch/bfabric/) API — the system that runs the Functional
+Genomics Center Zurich (FGCZ), covering project and service management, data production, annotation, search and
+analysis workflows.
 
 - A general client for all B-Fabric web service operations (CRUD) and configuration management.
 - A relational API for low-boilerplate read access to B-Fabric entities.

--- a/bfabric/README.md
+++ b/bfabric/README.md
@@ -1,0 +1,49 @@
+# bfabric
+
+Python client for [B-Fabric](https://fgcz-bfabric.uzh.ch/bfabric/), the data management platform of the Functional
+Genomics Center Zurich (FGCZ).
+
+- A general client for all B-Fabric web service operations (CRUD) and configuration management.
+- A relational API for low-boilerplate read access to B-Fabric entities.
+
+## Installation
+
+```bash
+pip install bfabric
+```
+
+Two extras are available: `bfabric[zeep]` swaps the default suds SOAP engine for zeep, and `bfabric[transfer]` adds
+resource download and upload.
+
+## Usage
+
+Credentials are read from `~/.bfabricpy.yml`:
+
+```python
+from bfabric import Bfabric
+
+client = Bfabric.connect()
+results = client.read(endpoint="workunit", obj={}, max_results=5)
+
+for workunit in results:
+    print(workunit["id"], workunit.get("status"))
+```
+
+See the [getting started guide](https://fgcz.github.io/bfabricPy) for configuring the client, and the user guides for
+the relational entity API, caching and error handling.
+
+## Links
+
+- [Documentation](https://fgcz.github.io/bfabricPy)
+- [Changelog](https://github.com/fgcz/bfabricPy/blob/main/bfabric/docs/changelog.md)
+- [Source and issue tracker](https://github.com/fgcz/bfabricPy)
+
+This package is part of the bfabricPy monorepo, which also publishes
+[bfabric-scripts](https://pypi.org/project/bfabric-scripts/) (command line tools) and
+[bfabric-app-runner](https://pypi.org/project/bfabric-app-runner/) (application workflows).
+
+## How to cite
+
+Panse, Christian, Trachsel, Christian and Türker, Can. "Bridging data management platforms and visualization tools to
+enable ad-hoc and smart analytics in life sciences" Journal of Integrative Bioinformatics, 2022, pp. 20220031.
+[doi: 10.1515/jib-2022-0031](https://doi.org/10.1515/jib-2022-0031).

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+- Packaging: `project.readme` now points at a package-local `README.md` instead of the repository root's. hatchling 1.32.0 rejects readme paths that resolve outside the project directory, which broke every build from source (CI and git-pinned installs); the previous setting also produced an sdist containing a `../README.md` member that tar refuses to extract. Installing the published wheels was never affected.
 - `MultiQuery.read_multi` now reserves query elements for the other fields of `obj` when chunking, since the API counts every value in a query towards its limit of 100 elements. Previously e.g. `read_multi("importresource", {"containerid": cid}, "relativepath", paths)` failed with "Query has 101 elements and exceeds the maximum of 100 allowed elements" as soon as 100 paths were passed. A query whose other fields already use up the limit now raises `ValueError` instead of being sent.
 
 ## \[1.20.0\] - 2026-08-03

--- a/bfabric/pyproject.toml
+++ b/bfabric/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bfabric"
 description = "Python client for the B-Fabric API"
-readme = "../README.md"
+readme = "README.md"
 version = "1.20.0"
 license = { text = "GPL-3.0" }
 authors = [

--- a/bfabric_scripts/README.md
+++ b/bfabric_scripts/README.md
@@ -1,5 +1,34 @@
 # bfabric-scripts
 
+Command line tools for [B-Fabric](https://fgcz-bfabric.uzh.ch/bfabric/), built on the
+[bfabric](https://pypi.org/project/bfabric/) client.
+
+## Installation
+
+```bash
+pip install bfabric-scripts
+```
+
+## Usage
+
+Everything is reachable through the `bfabric-cli` entry point, which shares its configuration with the `bfabric`
+client:
+
+```bash
+# Read the 10 most recent resources, showing selected columns
+bfabric-cli api read resource --limit 10 --columns id,name,relativepath
+
+# Filter by attribute, passed as key/value pairs
+bfabric-cli api read resource createdby pfeeder createdafter 2024-05-01
+
+# Export machine-readable output
+bfabric-cli api read resource --limit 100 --format json --file results.json
+```
+
+The command groups are `api`, `auth`, `dataset`, `executable`, `external-job`, `feeder` and `workunit`; run
+`bfabric-cli <group> --help` for the commands in each. A handful of legacy scripts (`bfabric_read.py` and friends)
+remain available as separate entry points.
+
 ## Useful commands
 
 ### List not available analysis workunits
@@ -7,3 +36,9 @@
 ```bash
 bfabric-cli workunit not-available
 ```
+
+## Links
+
+- [Documentation](https://fgcz.github.io/bfabricPy)
+- [Changelog](https://github.com/fgcz/bfabricPy/blob/main/bfabric_scripts/docs/changelog.md)
+- [Source and issue tracker](https://github.com/fgcz/bfabricPy)

--- a/bfabric_scripts/README.md
+++ b/bfabric_scripts/README.md
@@ -1,13 +1,24 @@
 # bfabric-scripts
 
-Command line tools for [B-Fabric](https://fgcz-bfabric.uzh.ch/bfabric/), built on the
+Command line scripts for the [B-Fabric](https://fgcz-bfabric.uzh.ch/bfabric/) API, built on the
 [bfabric](https://pypi.org/project/bfabric/) client.
 
 ## Installation
 
+These are command line tools, so the most convenient option is to let [uv](https://docs.astral.sh/uv/) install them
+into their own isolated environment:
+
 ```bash
-pip install bfabric-scripts
+uv tool install bfabric-scripts
 ```
+
+Add the `excel` extra for the `.xlsx` support in `bfabric-cli dataset upload|download|update`:
+
+```bash
+uv tool install "bfabric-scripts[excel]"
+```
+
+To install into an environment you already have, use `pip install bfabric-scripts` instead.
 
 ## Usage
 

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,6 +10,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 ## \[Unreleased\]
 
+- Packaging: `project.readme` now points at the package's own `README.md` instead of the repository root's, for the same reason as in `bfabric` — hatchling 1.32.0 rejects readme paths outside the project directory, breaking builds from source. The package README was expanded into a proper landing page, since it is what PyPI now shows.
 - `bfabric-cli auth register-webapp` — no longer crashes with a raw traceback when the OAuth session cannot be refreshed (e.g. an expired/revoked refresh token); prints a clean `Error: ...` message and exits 1.
 
 ## \[1.16.0\] - 2026-08-03

--- a/bfabric_scripts/pyproject.toml
+++ b/bfabric_scripts/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bfabric_scripts"
 description = "Python command line scripts for the B-Fabric API"
-readme = "../README.md"
+readme = "README.md"
 version = "1.16.0"
 
 dependencies = [


### PR DESCRIPTION
- `bfabric` and `bfabric_scripts` now use a package-local `README.md` instead of the repository root's. hatchling 1.32.0 (released today) rejects `project.readme` paths that resolve outside the project directory, which broke all of CI and any install that builds from source, including git pins. Installing the published wheels was never affected.
- Also fixes a latent packaging bug: the old setting produced sdists containing a `../README.md` member that tar refuses to extract.
- Both package READMEs are now proper landing pages, since that is what PyPI shows for each.

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.