### PR TITLE
Make the demo app copier template instantiable again

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory. The workunit is still marked `failed`.
 - Captured command output (`uv venv` / `uv pip install` / `uv pip list`) is now logged one record per line, so every line carries its level prefix and stays greppable. Previously it was one multi-line record whose lines after the first were indistinguishable from raw `print` output.
 - Requires `bfabric` 1.20.1, whose logging fix is what keeps a nested app-runner (Makefile or SLURM) from falling back to loguru's verbose DEBUG format.
+- Internal: the demo app copier template can be instantiated again. It rendered `_copier_conf.dst_path.resolve()`, which current copier rejects because it now exposes `dst_path` as a `PurePath`. Its `app.yml` uses spec-relative paths instead of a generation-time host path, and its stale `app_runner: 0.1.2` pin is refreshed. The destination must now be given as an absolute path, for the `<program>` path in `bfabric_app.xml`.
 
 ## \[0.7.0\] - 2026-08-03
 

--- a/bfabric_app_runner/examples/README.md
+++ b/bfabric_app_runner/examples/README.md
@@ -15,9 +15,13 @@ Copier templates for creating BFabric app runner applications with proper struct
 1. **Generate from template:**
 
     ```bash
-    uvx copier copy ~/code/bfabricPy/bfabric_app_runner/examples/template my_app
+    uvx copier copy ~/code/bfabricPy/bfabric_app_runner/examples/template $PWD/my_app
     # Enter your project name when prompted
     ```
+
+    Give the destination as an absolute path: it is written into `bfabric_app.xml` as the
+    `<program>` path that B-Fabric uses to find `app.yml`. The paths in `app.yml` itself are
+    relative to the app directory, so the app can be moved or checked out elsewhere.
 
 2. **Test in development mode:**
 

--- a/bfabric_app_runner/examples/template/app.yml.jinja
+++ b/bfabric_app_runner/examples/template/app.yml.jinja
@@ -1,38 +1,39 @@
 bfabric:
-  app_runner: 0.1.2
+  app_runner: 0.8.0
+# Paths are relative to the directory containing this file, so the app can be moved or checked out elsewhere.
 versions:
   - version:
       - 0.0.1
     commands:
       dispatch:
         type: python_env
-        pylock: {{ _copier_conf.dst_path.resolve() }}/dist/${app.version}/pylock.toml
+        pylock: dist/${app.version}/pylock.toml
         local_extra_deps:
-          - {{ _copier_conf.dst_path.resolve() }}/dist/${app.version}/{{project_name}}-${app.version}-py3-none-any.whl
+          - dist/${app.version}/{{project_name}}-${app.version}-py3-none-any.whl
         command: -m {{project_name}}.integrations.bfabric.dispatch
       process:
         type: python_env
-        pylock: {{ _copier_conf.dst_path.resolve() }}/dist/${app.version}/pylock.toml
+        pylock: dist/${app.version}/pylock.toml
         local_extra_deps:
-          - {{ _copier_conf.dst_path.resolve() }}/dist/${app.version}/{{project_name}}-${app.version}-py3-none-any.whl
+          - dist/${app.version}/{{project_name}}-${app.version}-py3-none-any.whl
         command: -m {{project_name}}.integrations.bfabric.process
 
   # - The development version has the flag "refresh: true" which ensures, that it will always create a new venv.
-  # - Additionally, instead of using the packaged code, it loads the code directly from the specified directory.
+  # - Additionally, instead of using the packaged code, it loads the code directly from this directory.
   - version:
       - devel
     commands:
       dispatch:
         type: python_env
-        pylock: {{ _copier_conf.dst_path.resolve() }}/pylock.toml
+        pylock: pylock.toml
         local_extra_deps:
-          - {{ _copier_conf.dst_path.resolve() }}
+          - .
         refresh: true
         command: -m {{project_name}}.integrations.bfabric.dispatch
       process:
         type: python_env
-        pylock: {{ _copier_conf.dst_path.resolve() }}/pylock.toml
+        pylock: pylock.toml
         local_extra_deps:
-          - {{ _copier_conf.dst_path.resolve() }}
+          - .
         refresh: true
         command: -m {{project_name}}.integrations.bfabric.process

--- a/bfabric_app_runner/examples/template/bfabric_app.xml.jinja
+++ b/bfabric_app_runner/examples/template/bfabric_app.xml.jinja
@@ -2,7 +2,7 @@
 <executable classname="executable">
     <name>{{project_name}}</name>
     <description>Demo application</description>
-    <program>{{ _copier_conf.dst_path.resolve() }}/app.yml</program>
+    <program>{{ _copier_conf.dst_path }}/app.yml</program>
     <context>APPLICATION</context>
     <enabled>true</enabled>
     <valid>true</valid>

--- a/bfabric_app_runner/examples/template/copier.yml
+++ b/bfabric_app_runner/examples/template/copier.yml
@@ -6,14 +6,14 @@ deploy_with_lfs:
   default: true
   help: Whether to deploy the application by tracking it with Git LFS (Large File Storage)
 _message_after_copy: |
-  Application {{project_name}} was successfully created at {{ _copier_conf.dst_path.resolve() }}.
+  Application {{project_name}} was successfully created at {{ _copier_conf.dst_path }}.
 
   Before you can run the application, you need to ensure you have `uv` installed and perform the following steps:
 
   - Release mode (i.e. 0.0.1 version):
-    - `cd {{ _copier_conf.dst_path.resolve() }}`
+    - `cd {{ _copier_conf.dst_path }}`
     - `./release.bash`
   - Development mode (i.e. devel version):
-    - `cd {{ _copier_conf.dst_path.resolve() }}`
+    - `cd {{ _copier_conf.dst_path }}`
     - `uv lock -U`
     - `uv export --no-emit-project --format pylock.toml > pylock.toml`

--- a/bfabric_app_runner/examples/test_template.py
+++ b/bfabric_app_runner/examples/test_template.py
@@ -32,7 +32,8 @@ def hello_app(temp_test_dir: Path) -> Path:
         "copier",
         "copy",
         str(template_path.resolve()),
-        "hello1",
+        # Absolute, as the README instructs: it ends up as the <program> path in bfabric_app.xml.
+        str(temp_test_dir / "hello1"),
         "--data",
         "project_name=hello1",
         "--data",


### PR DESCRIPTION
- The demo app copier template can be generated again: it rendered
  `_copier_conf.dst_path.resolve()`, which current copier rejects since it exposes
  `dst_path` as a `PurePath`.
- The generated `app.yml` now uses spec-relative paths (#578) rather than a
  generation-time host path, so the app directory can be relocated.
- `app_runner` pin refreshed from the stale `0.1.2` (predates `type: python_env`) to
  `0.8.0` — so the Makefile flow needs that release before it works; until then use
  `--use-external-runner`. If the release is numbered differently, this pin must match it.
- The copier destination must now be given as an absolute path, for the `<program>`
  path in `bfabric_app.xml`.

Verified by generating the app, checking `validate app-spec` resolves the paths into the
app directory (and follows it when moved), and running its `process` step end-to-end
offline against a failing chunk.

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.