### PR TITLE
Move the release procedure to RELEASING.md and condense the changelogs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,7 @@ pytest tests/bfabric/test_something.py # single file
 pytest tests/bfabric -k test_name      # single test
 ```
 
-Run each package's suite in a **separate** `pytest` invocation (as nox does). Passing
-multiple package trees to one invocation (e.g. `pytest tests/bfabric tests/bfabric_app_runner`)
-fails at collection with a basename clash, because tests have no `__init__.py` (see the
-convention below) so identically-named modules across trees collide.
+Run each package's suite in a **separate** `pytest` invocation, as nox does — one invocation over two package trees fails at collection because identically-named test modules collide (see the `__init__.py` convention below).
 
 ### Type Checking
 ```bash
@@ -65,11 +62,7 @@ ruff check bfabric                     # ruff directly
 pre-commit run --all-files             # the formatter gate (black, and blacken-docs for md code blocks)
 ```
 
-**black is the formatter — never run `ruff format`.** It disagrees with black on ~15 files (f-string
-quotes, `assert` message wrapping, implicit string concatenation, and the Python code blocks in
-`docs/**/*.md` that `blacken-docs` owns), so it produces a large spurious diff. Since neither
-`nox -s code_style` nor CI checks formatting, the only thing that catches a wrong formatter is the
-pre-commit hook rejecting the commit.
+**black is the formatter — never run `ruff format`.** It disagrees with black on ~15 files and produces a large spurious diff. Since neither `nox -s code_style` nor CI checks formatting, the pre-commit hook rejecting the commit is the only thing that catches a wrong formatter.
 
 ### Docs
 ```bash
@@ -108,70 +101,49 @@ Each package's docs live alongside its source. Skim the index when working in a 
 
 ## Key Conventions
 
-- Tests must NOT contain `__init__.py` files (enforced by `check_test_inits` nox session)
-- Test order is randomised via [pytest-random-order](https://github.com/pytest-dev/pytest-random-order) (`addopts = "--random-order"`), so both modules and the tests within them run in a shuffled order to surface hidden inter-test dependencies. The seed is printed in the pytest header; reproduce a specific order with `pytest --random-order-seed=<N>`. Tests must therefore be isolation-safe; quarantine a genuinely order-dependent module with `pytestmark = pytest.mark.random_order(disabled=True)` only as a last resort.
-- Test conftest sets `BFABRICPY_CONFIG_ENV=__MOCK` to avoid real credentials
-- Tests use the pytest-mock `mocker` fixture for **all** mocking — do not `import unittest.mock`.
-  Use `mocker.patch(...)`, `mocker.patch.object(...)`, `mocker.patch.dict(...)`, `mocker.MagicMock()`,
-  `mocker.Mock()`, `mocker.mock_open(...)`, etc. (`pytest-mock` is a test dependency in every package.)
-- Group related tests in a file with plain `class TestXyz:` blocks — do **not** use `# --- section ---`
-  comment banners as separators. A bare class (no base) is all pytest needs; move fixtures used by only
-  one group inside its class so their scope matches the grouping. Keep each method name specific enough to
-  read on its own (drop a prefix only when the class already conveys it).
-- Ruff linting is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores)
-- Line length: 120 (ruff and black)
-- Docstrings use Sphinx `:param:` / `:raises:`; Google-style `Args:` / `Returns:` blocks survive in a
-  few older modules (e.g. `entities/core/uri.py`, `entities/core/entity_reader.py`) — don't add more.
-  Keep them at the lowest useful altitude: one summary line by default, plus a short paragraph only for
-  a contract the signature cannot show (why this exists beside a similar function, a gotcha, an ordering
-  constraint). Skip `Returns:` blocks that restate the return annotation and `:param:` lines that re-say
-  the name and type. Avoid `>>>` examples: no session collects doctests, so they read as tested without
-  being tested — put a short example inline in the prose instead.
-- Exception: a cyclopts command function's docstring **is** its `--help` text — the summary line becomes
-  the command description and each `:param:` line becomes that option's help (see
-  `bfabric-cli workunit not-available --help`). Those are user-facing copy: keep them complete and clear
-  rather than terse, and trim the internal helpers around them instead.
-- Do not restate a parameter's default value in its docstring when the signature already shows it (e.g. `client_id: str = DEFAULT_CLIENT_ID`). Writing `(default "CLI")` in the `:param:` line just duplicates the signature and drifts out of sync when the default changes. Keep notes that explain what a value *means* (e.g. `(``0`` = auto-assign)`), not ones that merely repeat it. This also applies to class/model docstrings that restate a field's default shown a few lines below (prefer "see `field_name`" over repeating the literal value). Note the common case where the signature default is a sentinel like `None` but the docstring explains what it resolves to at runtime (e.g. `max_results: int | None = 100` documented as `` (``None`` for all) ``, or `path: Path | None = None` documented as `` (``None`` writes to ``./output.yml``) ``) — that is the *meaning* case, not the restatement case, and should be kept; phrase it as "``None`` does/means X", not "(default: X)", so it isn't mistaken for a literal restatement.
-- basedpyright uses per-package baseline files at `.basedpyright/baseline.{package}.json` — **do not edit baseline files to silence new errors**; fix the code or add a targeted `# pyright: ignore[...]` comment on the offending line. Baselines only exist to grandfather in pre-existing errors.
-- Integration tests live in a separate repository
-- Use TDD: write a failing test first, verify it fails, then fix the code, then verify the test passes
+### Tests
+
+- Tests must NOT contain `__init__.py` files (enforced by the `check_test_inits` nox session).
+- Test order is randomised via [pytest-random-order](https://github.com/pytest-dev/pytest-random-order) (`addopts = "--random-order"`), so tests must be isolation-safe. The seed is printed in the pytest header; reproduce an order with `pytest --random-order-seed=<N>`. Quarantine a genuinely order-dependent module with `pytestmark = pytest.mark.random_order(disabled=True)` only as a last resort.
+- Test conftest sets `BFABRICPY_CONFIG_ENV=__MOCK` to avoid real credentials.
+- Use the pytest-mock `mocker` fixture for **all** mocking — do not `import unittest.mock`.
+- Group related tests with plain `class TestXyz:` blocks (no base class needed), not `# --- section ---` comment banners. Move fixtures used by only one group inside its class. Keep method names specific enough to read on their own.
+- Integration tests live in a separate repository.
+- Use TDD: write a failing test first, verify it fails, then fix the code, then verify the test passes.
+
+### Style and typing
+
+- Line length is 120 (ruff and black). Ruff lint is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores).
+- basedpyright uses per-package baseline files at `.basedpyright/baseline.{package}.json` — **do not edit a baseline to silence a new error**; fix the code or add a targeted `# pyright: ignore[...]` on the offending line. Baselines only exist to grandfather in pre-existing errors.
+- Docstrings use Sphinx `:param:` / `:raises:`; Google-style `Args:` / `Returns:` blocks survive in a few older modules (e.g. `entities/core/uri.py`) — don't add more.
+- Keep docstrings at the lowest useful altitude: one summary line by default, plus a short paragraph only for a contract the signature cannot show (why this exists beside a similar function, a gotcha, an ordering constraint). Skip `Returns:` blocks and `:param:` lines that restate the annotation, and don't restate a default the signature already shows. Do document what a value *means* — a sentinel's runtime resolution (`` ``None`` reads all results ``, `` ``None`` writes to ``./output.yml`` ``) or a magic value (`` ``0`` = auto-assign ``) — phrased as "``None`` does X", not "(default: X)".
+- Avoid `>>>` examples: no session collects doctests, so they read as tested without being tested. Put a short example in the prose instead.
+- Exception: a cyclopts command function's docstring **is** its `--help` text — the summary line becomes the command description and each `:param:` line becomes that option's help (see `bfabric-cli workunit not-available --help`). That is user-facing copy: keep it complete and clear, and trim the internal helpers around it instead.
+
+## Changelog
+
+Each package has its own `docs/changelog.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/): `### Added` / `### Changed` / `### Fixed` / `### Removed` subsections under `## \[Unreleased\]`. Headings escape the brackets — `nox -s changelog` matches `## \[<version>\]` literally.
+
+- One or two lines per entry: the symbol, and the effect a user sees. No code blocks, no before/after examples, no "previously it did X because Y" — rationale belongs in the commit message.
+- Label an entry **Breaking** only when the API has real external consumers; otherwise just describe it in its new shape.
+- Collect dev-facing typing/tooling changes into a single trailing `Internal:` bullet.
+- Release-candidate entries are the one exception to the subsections (flat bullets, cumulative) — see [RELEASING.md](RELEASING.md).
+
+## Pull requests
+
+The body is a short changelog-style bullet list — one line per change a *user* would notice, phrased "Add/Change/Fix X to do Y" — and then it stops. No `##` section headings, no test plan or "Testing:" line, no background paragraph, no implementation notes. Omit internal refactors, docs, and tooling changes entirely; that detail belongs in the commit messages and the package changelog. If a caveat genuinely must be flagged, make it one more bullet, never a section.
+
+`rel-*` release PRs get an empty body (`--body ""`): the pipeline publishes the changelog section as the release notes, so a body would only be a worse copy of it.
 
 ## Releases
 
-Each package is versioned and released independently (own `pyproject.toml` version, own `docs/changelog.md`, own `<package>/<version>` git tag). Preparing a release means: bump the `version` in that package's `pyproject.toml` and promote its changelog `[Unreleased]` section to a dated version heading. The release pipeline extracts the changelog section matching the tag and publishes it as the GitHub release notes.
+Each package is versioned and released independently — own `pyproject.toml` version, own `docs/changelog.md`, own `<package>/<version>` git tag. Release preparation is **mechanics only** (version bumps, changelog graduation, dependency-pin updates) and must not introduce code changes; see the `rel-*` rule under [Branches](#branches).
 
-Dispatch mechanics of `publish_release.yml` — apply to every package:
-
-- **Never dispatch `environment: test` as a dry run.** That input switches only the PyPI URL. *Create and push tag* and *Create GitHub Release* are ungated and run **before** the publish step, so a `test` run pushes the real `<pkg>/<version>` tag and opens the draft release — and the follow-up `production` run then dies at `git tag -a` ("already exists") before anything reaches PyPI. Verify locally instead (below) and dispatch straight to `production`.
-- **Pass `force_packages` explicitly.** A non-empty value makes `check_versions.py` skip the PyPI version comparison entirely, so only the named packages build. Confirm via `Forcing release of <pkg>` in the `check-packages` log.
-- **Verify the built package offline before dispatching** — install it the way a user gets it, then import whatever the release touched:
-    ```bash
-    uv venv /tmp/rel -p 3.11
-    uv pip install --python /tmp/rel --no-sources ./<package>   # --no-sources: ignore workspace tool.uv.sources, resolve deps from PyPI
-    uv pip list --python /tmp/rel | grep -i bfabric             # check the resolved dependency floor
-    /tmp/rel/bin/python -c "import <module>"
-    ```
-    Check entry points by **module import, not `--help`**: `@use_client` calls `Bfabric.connect()` before the wrapped function runs, and the legacy argparse scripts build their parser inside the body, so `--help` reads `~/.bfabricpy.yml` first and can fail for config reasons unrelated to the release. Import is also where import-time breakage (a removed symbol, a deprecation shim) actually surfaces. After publishing, PyPI's index needs ~a minute before `uv pip install <pkg>==<new>` resolves.
-- **Leave "Set as the latest release" unchecked when publishing the draft, except for `bfabric` stable.** GitHub keeps one repo-wide "Latest release", so a stable non-core release — or a patch of an older line — would take the badge from the core library. `rcN` and `0.x` tags are auto-flagged as prereleases and never compete for it.
-
-Release-candidate (rc) convention — decided 2026-07-15:
-
-- **One cumulative pre-release entry, not a stack.** While a version is in RC, keep a *single* changelog entry for it (e.g. `## [1.20.0rc2]`) that describes the **full** changeset for the upcoming `X.Y.0`. When cutting the next RC, re-date and extend that same entry and bump the `rcN` suffix — do **not** add a separate `[…rcN]` heading below the previous one. Per-RC history is preserved by the already-published git tags and GitHub releases, so the in-repo changelog doesn't need to re-keep it.
-- **Flat, abbreviated bullets, headline-first.** RC entries merge the `Added`/`Changed`/`Fixed` subsections into one abbreviated bullet list, ordered with the user-facing headline changes first. Group dev-facing/typing/tooling changes (e.g. type-only fixes, ruff config, dead-code removal) under a trailing `Internal:` bullet so they don't crowd the main things. The detailed, structured notes live in git history and the GitHub release; the changelog entry is a quick-review summary.
-- **Graduation.** When the RC becomes final, rename the `[X.Y.0rcN]` heading to `[X.Y.0]` with the release date (no content merge needed, since it was cumulative).
-- **Cross-package dependency floors.** When a package uses a feature from an unreleased/RC `bfabric`, pin its floor to the rc (e.g. `bfabric>=1.20.0rc2,<1.21`). A plain `>=1.20.0` **excludes** `1.20.0rc2` under PEP 440, and naming a prerelease in the specifier is also what lets pip/uv resolve to it.
-
-Hotfix convention (patch release of an older line) — decided 2026-07-24:
-
-- **Branch from the version tag, not `main`/`release`.** When the newest line is unreleased or in RC, `release`/`main` have moved ahead, so a patch of the last stable (e.g. `1.19.1` while `main` is `1.20.0rc`) must be cut from that stable tag: `git checkout -b hotfix/<pkg>-X.Y.Z <pkg>/X.Y.(Z-1)`.
-- **The hotfix branch is authoritative for its release.** Bump the patch version and add the `## [X.Y.Z]` changelog section there. This is what the pipeline extracts into the `<pkg>/X.Y.Z` tag and GitHub Release — the canonical record of what shipped.
-- **Publish out-of-band, don't merge into `release`.** Merging a hotfix into `release` (ahead on a newer line) would mislabel that tree. Instead trigger the publish workflow against the hotfix ref: `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`. The branch then lives on as the release record; it has no merge target.
-- **Forward-port the fix to `main` as a normal PR, `[Unreleased]` only.** Cherry-pick the fix (`git cherry-pick -x`) so `1.X.0` doesn't regress. On `main` the entry stays under `[Unreleased]` with an inline note (e.g. "(also released as the X.Y.Z hotfix)") — do **not** backfill a `## [X.Y.Z]` section into `main`. A past-line patch can't sit in `main`'s version-descending changelog without breaking either version or date order, and it would duplicate the bullet; the tag + GitHub Release are where `X.Y.Z` is recorded.
-- **A fix that can't apply to `main` leaves `main`'s changelog alone.** Some hotfixes only constrain the old line — a dependency cap, say, when `main` has already migrated past the broken API. With nothing to forward-port there is nothing to document, and an `[Unreleased]` bullet would be promoted into the next release's notes, describing a change that release doesn't contain. The tag and GitHub Release are the record; that is what they are for.
-- **No PR from the hotfix branch itself.** Its diff against `main` reads as a mass revert, and PR CI would run the old line's whole nox suite. Push the branch and let the tag and GitHub Release be the record (precedent: `hotfix/bfabric-1.19.1`, `hotfix/bfabric-scripts-1.15.1`). Open a PR only for the forward-port, if there is one.
+The full procedure — the `rel-*` → `release` → `main` branch loop, the release-candidate and hotfix conventions, and how to verify a build offline before it ships — is in [RELEASING.md](RELEASING.md). Read it before touching a release.
 
 ## Branches
 
 - `main` — active development
-- `release` — triggers PyPI publish on merge
+- `release` — pushing to it runs `publish_release.yml` and publishes to PyPI. Release-prep PRs target **this** branch, not `main`, and it is merged back into `main` afterwards.
+- `rel-<date>-NN` — release-preparation branches, cut fresh from `origin/main`, carrying **only release mechanics** so the release ships exactly what is already on `origin/main`. Never merge feature or refactor work into one — new functionality lands on `origin/main` via its own PR and is picked up by a later cut. A genuine hotfix, on the user's explicit say-so, is named `hotfix-*` / `patch-*` instead so the intent is unambiguous.
 - When pushing, give the remote branch a reasonable, descriptive name even if the local branch has an auto-generated worktree name (e.g. `worktree-quiet-gathering-mitten`) — push with an explicit remote ref: `git push -u origin HEAD:feature/short-descriptive-name`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,13 +91,7 @@ Handles dispatch → process → collect workflow for B-Fabric applications. Use
 
 ## Documentation
 
-Each package's docs live alongside its source. Skim the index when working in a package — it links to user guides, API reference, and changelog.
-
-- `bfabric/docs/index.md` — core client (getting started, user guides, API reference, advanced topics, design)
-- `bfabric_app_runner/docs/index.md` — app runner (getting started, user guides, API reference)
-- `bfabric_scripts/docs/changelog.md` — scripts (changelog only; no full docs site)
-- `bfabric_rest_proxy/README.md`, `bfabric_rest_proxy/docs/changelog.md` — REST proxy
-- `bfabric_asgi_auth/README.md`, `bfabric_asgi_auth/docs/changelog.md` — ASGI auth middleware
+Docs live alongside each package's source; skim the index when working in one. `bfabric/docs/index.md` and `bfabric_app_runner/docs/index.md` are full sites (getting started, user guides, API reference, design) and the only two that `nox -s docs` builds. `bfabric_scripts`, `bfabric_rest_proxy` and `bfabric_asgi_auth` have just a `docs/changelog.md`, plus a `README.md` for the latter two.
 
 ## Key Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI agents working with code in this repository.
 
 ## Project Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,11 +192,9 @@ This builds documentation for `bfabric` and `bfabric_app_runner` and places the 
 
 ### Publish Documentation
 
-```bash
-nox -s publish_docs
-```
-
-This publishes the documentation to GitHub Pages by updating the `gh-pages` branch.
+Documentation is published to GitHub Pages by the `publish_docs.yml` workflow, which updates the
+`gh-pages` branch (`dev/` on a push to `main`, the site root on a release). There is nothing to run
+locally.
 
 ## Integration Tests
 
@@ -204,25 +202,12 @@ Note that integration tests have been moved to a separate repository. Please con
 
 ## Release Process
 
-To create a release:
+Each package is released independently: bump its version in `pyproject.toml`, graduate its
+`docs/changelog.md` `[Unreleased]` section, and open a PR from a `rel-<date>-NN` branch to the
+`release` branch — merging it is what publishes to PyPI.
 
-1. **Create a branch** from `main` (e.g., `deploy-yyyymmdd-01`)
-2. **Update versions** in the relevant `pyproject.toml` files
-3. **Update changelogs** with the new version number and date after the "Unreleased" section
-4. **Create a PR** from your new branch to the `release` branch
-
-Once the PR is ready:
-
-5. **Wait for validation pipeline comments**:
-   - One comment will list the package versions that will be updated
-   - Another comment will confirm all tests have passed
-6. **Merge the PR**
-
-After merging:
-
-7. **Wait for PyPI publish**: Your package will be built and sent to PyPI automatically
-8. **Backport to main**: Create a PR from `release` to `main` to include the `pyproject.toml` changes and merge it ASAP
-9. **Publish GitHub release**: If everything worked, the release should be pre-filled with the changelog notes. Create the release using the tag that was automatically created.
+The full procedure, including the release-candidate and hotfix conventions, is in
+[RELEASING.md](RELEASING.md).
 
 ## Troubleshooting
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,126 +1,56 @@
 # Releasing
 
-How the five packages in this workspace get to PyPI. Read this before touching a release; the
-everyday conventions are in [AGENTS.md](AGENTS.md).
+How the five packages get to PyPI. Everyday conventions are in [AGENTS.md](AGENTS.md).
 
-Each package is versioned and released independently: its own `pyproject.toml` version, its own
-`docs/changelog.md`, its own `<package>/<version>` git tag. The pipeline extracts the changelog
-section matching the tag and publishes it as the GitHub release notes.
+Each package is released independently: its own `pyproject.toml` version, its own `docs/changelog.md`, its own `<package>/<version>` tag. The pipeline extracts the changelog section matching the tag and publishes it as the GitHub release notes. Release preparation is **mechanics only** — version bumps, changelog graduation, dependency-pin updates — never code changes.
 
-Release preparation is **mechanics only** — version bumps, changelog graduation, dependency-pin
-updates. It must not introduce code changes; anything that changes behavior lands on `main` first and
-ships in a later cut.
-
-## The normal flow is a branch loop, not a dispatch
+## The branch loop
 
 `publish_release.yml` fires on `push` to `release`, so merging is what publishes.
 
-1. **`rel-<date>-NN` → `release`.** Open the PR against `release`, never `main`. Merging it starts
-   the publish run. (`release` is normally an ancestor of a `rel-*` branch cut from `origin/main`, so
-   this merges cleanly.)
+1. **`rel-<date>-NN` → `release`** — the PR targets `release`, never `main`. Merging it starts the publish run.
 2. **The workflow tags and publishes** on the `release` ref. Never hand-tag, and never tag on `main`.
-3. **`release` → `main`** with a plain merge commit (`gh pr merge <n> --merge`; no squash, no rebase),
-   so the exact released commit is preserved in `main`'s history.
+3. **`release` → `main`** with a plain merge commit (`gh pr merge <n> --merge`), so the exact released commit is preserved in `main`'s history.
 
-The publish jobs run as checks on the step-3 PR, so its rollup is the single place to watch:
-`release-packages (<pkg>)` sits alongside the usual test/basedpyright matrix. Don't merge before it
-is green — a failed publish is much easier to redo while `main` has not yet absorbed the release
-commit.
+The publish jobs run as `release-packages (<pkg>)` checks on the step-3 PR — watch that rollup and don't merge before it is green, since a failed publish is much easier to redo while `main` has not yet absorbed the release commit.
 
-**The push trigger takes no inputs, so it behaves differently from a manual dispatch.** There is no
-`force_packages` and no `environment`: `check-package-versions` auto-detects what to build by
-comparing each package's version against PyPI, and publishes to production. `priority-order:
-bfabric,bfabric_scripts,bfabric_app_runner` plus `max-parallel: 1` releases them sequentially, so
-`bfabric` lands on PyPI before the packages that floor on it.
+The `push` trigger takes no inputs, so it differs from a manual dispatch: with no `force_packages` and no `environment`, `check-package-versions` auto-detects what to build by comparing each version against PyPI and publishes to production. `priority-order: bfabric,bfabric_scripts,bfabric_app_runner` plus `max-parallel: 1` releases sequentially, so `bfabric` lands before the packages that floor on it.
 
-## Verify a build offline before it goes out
+## Verify offline first
 
 Install it the way a user gets it, then import whatever the release touched:
 
 ```bash
 uv venv /tmp/rel -p 3.11
-uv pip install --python /tmp/rel --no-sources ./bfabric   # --no-sources: ignore workspace tool.uv.sources
+uv pip install --python /tmp/rel --no-sources ./bfabric   # --no-sources: resolve deps from PyPI, not the workspace
 uv pip list --python /tmp/rel | grep -i bfabric           # check the resolved dependency floor
 /tmp/rel/bin/python -c "import bfabric"
 ```
 
-Check entry points by **module import, not `--help`**: `@use_client` calls `Bfabric.connect()` before
-the wrapped function runs, and the legacy argparse scripts build their parser inside the body, so
-`--help` reads `~/.bfabricpy.yml` first and can fail for config reasons unrelated to the release.
-Import the real modules named in each `pyproject.toml`'s `[project.scripts]`
-(`bfabric_scripts.cli.__main__:main`, `bfabric_app_runner.cli.__main__:app`) — a guessed path raises
-`ImportError` and reads exactly like a broken release.
+Import the real `[project.scripts]` modules (`bfabric_scripts.cli.__main__`, `bfabric_app_runner.cli.__main__`), not a guessed path — a wrong guess raises `ImportError` and reads exactly like a broken release. Don't check entry points with `--help`: `@use_client` calls `Bfabric.connect()` before the command body runs, so `--help` can fail for config reasons unrelated to the release.
 
-**A dependent package cannot be verified before the core publishes.** Its freshly-bumped floor (e.g.
-`bfabric>=1.20.0`) excludes the current rc under PEP 440, so nothing on PyPI satisfies it until
-`bfabric` itself is out, and the push-triggered run does not pause between packages. Verify `bfabric`
-before opening the PR to `release`, then verify the dependents straight afterwards:
-
-```bash
-uv venv /tmp/rel2 -p 3.13
-uv pip install --python /tmp/rel2 --no-sources 'bfabric_scripts==<ver>' 'bfabric_app_runner==<ver>'
-/tmp/rel2/bin/python -c "import bfabric_scripts.cli.__main__, bfabric_app_runner.cli.__main__"
-```
-
-After publishing, PyPI's index needs about a minute before `uv pip install <pkg>==<new>` resolves.
+A dependent package cannot be verified before the core publishes — its freshly-bumped floor (`bfabric>=1.20.0`) excludes the current rc under PEP 440, and the push-triggered run does not pause between packages. Verify `bfabric` before opening the PR to `release`, then the dependents straight after it publishes (PyPI's index needs about a minute).
 
 ## Out-of-band dispatch (hotfixes, re-runs)
 
-- **Never dispatch `environment: test` as a dry run.** That input switches only the PyPI URL. *Create
-  and push tag* and *Create GitHub Release* are ungated and run **before** the publish step, so a
-  `test` run pushes the real `<pkg>/<version>` tag and opens the draft release — and the follow-up
-  `production` run then dies at `git tag -a` ("already exists") before anything reaches PyPI. Verify
-  locally instead and dispatch straight to `production`.
-- **Pass `force_packages` explicitly.** A non-empty value makes `check_versions.py` skip the PyPI
-  version comparison entirely, so only the named packages build. Confirm via `Forcing release of
-  <pkg>` in the `check-packages` log.
-- **Leave "Set as the latest release" unchecked when publishing the draft, except for `bfabric`
-  stable.** GitHub keeps one repo-wide "Latest release", so a stable non-core release — or a patch of
-  an older line — would take the badge from the core library. `rcN` and `0.x` tags are auto-flagged
-  as prereleases and never compete for it.
+- **Never dispatch `environment: test` as a dry run.** It switches only the PyPI URL, and tag creation plus the GitHub release are ungated and run first — so a `test` run pushes the real tag and the follow-up `production` run dies at `git tag -a` before anything reaches PyPI. Verify locally and dispatch straight to `production`.
+- **Pass `force_packages` explicitly.** A non-empty value makes `check_versions.py` skip the PyPI comparison entirely, so only the named packages build; confirm via `Forcing release of <pkg>` in the `check-packages` log.
+- **Leave "Set as the latest release" unchecked, except for `bfabric` stable.** GitHub keeps one repo-wide badge and it belongs to the core library. `rcN` and `0.x` tags are auto-flagged as prereleases and never compete for it.
 
 ## Release candidates
 
-- **One cumulative pre-release entry, not a stack.** While a version is in RC, keep a *single*
-  changelog entry for it (e.g. `## [1.20.0rc2]`) describing the **full** changeset for the upcoming
-  `X.Y.0`. When cutting the next RC, re-date and extend that same entry and bump the `rcN` suffix —
-  do not add a separate `[…rcN]` heading below the previous one. Per-RC history is preserved by the
-  published tags and GitHub releases.
-- **RC entries use flat, abbreviated bullets, headline-first** — the one exception to the Keep a
-  Changelog subsections normal entries use. User-facing headlines come first; dev-facing
-  typing/tooling changes go in a trailing `Internal:` bullet.
-- **Graduation** renames the `[X.Y.0rcN]` heading to `[X.Y.0]` with the release date. No content merge
-  is needed, since the entry was cumulative.
-- **Cross-package dependency floors must name the rc** when a package uses a feature from an
-  unreleased `bfabric` (e.g. `bfabric>=1.20.0rc2,<1.21`). A plain `>=1.20.0` *excludes* `1.20.0rc2`
-  under PEP 440, and naming the prerelease is also what lets pip/uv resolve to it.
+- Keep **one cumulative entry** per RC line (e.g. `## [1.20.0rc2]`) describing the full changeset for the upcoming `X.Y.0`; re-date and extend that entry for the next RC rather than stacking `[…rcN]` headings below it. The published tags keep the per-RC history.
+- RC entries use flat, abbreviated, headline-first bullets — the one exception to the Keep a Changelog subsections — with dev-facing changes in a trailing `Internal:` bullet.
+- Graduation renames `[X.Y.0rcN]` to `[X.Y.0]` with the release date; no content merge is needed, since the entry was cumulative.
+- A floor on an unreleased `bfabric` must name the rc (`bfabric>=1.20.0rc2,<1.21`) — a plain `>=1.20.0` excludes it under PEP 440, and naming it is what lets pip/uv resolve to it.
 
-## Hotfixes (patch release of an older line)
+## Hotfixes (patch of an older line)
 
-- **First, find what's actually released on that line.** Check the `<pkg>/*` git tags and PyPI for the
-  latest released patch: that tag is your base and your new version is that patch + 1. Skipping this
-  is the classic hotfix error — you either collide with an existing tag or silently drop an
-  already-shipped patch (base `1.19.0` → ship `1.19.3`, dropping `1.19.1`/`1.19.2`).
-- **Land the fix on `main` first, via a normal reviewed PR** (under `[Unreleased]`), so a single
-  commit is the source of truth. Don't build the hotfix branch first and reverse-port afterwards.
-- **Cut the hotfix branch from the version tag, then cherry-pick the merged fix.** `release`/`main`
-  have moved ahead when the newest line is unreleased or in RC:
-  `git checkout -b hotfix/<pkg>-X.Y.Z <pkg>/X.Y.(Z-1)`, then `git cherry-pick -x <main-commit>`
-  **after** the PR merges, so the recorded SHA is permanent.
-- **The version bump and the `## [X.Y.Z]` changelog section live on the hotfix branch** — that is what
-  the pipeline extracts into the tag and GitHub Release.
-- **Publish out-of-band, don't merge into `release`** (which is ahead on a newer line and would be
-  mislabelled):
-  `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`.
-  The branch then lives on as the release record; it has no merge target.
-- **Forward-port to `main` as a normal PR, `[Unreleased]` only.** Cherry-pick with `-x` so `1.X.0`
-  doesn't regress, and note it inline (e.g. "also released as the X.Y.Z hotfix"). Do **not** backfill
-  a `## [X.Y.Z]` section into `main`: a past-line patch can't sit in a version-descending changelog
-  without breaking either version or date order, and the tag + GitHub Release already record it.
-- **A fix that can't apply to `main` leaves `main`'s changelog alone.** Some hotfixes only constrain
-  the old line — a dependency cap, say, when `main` has already migrated past the broken API. With
-  nothing to forward-port there is nothing to document, and an `[Unreleased]` bullet would be promoted
-  into the next release's notes, describing a change that release doesn't contain.
-- **No PR from the hotfix branch itself.** Its diff against `main` reads as a mass revert, and PR CI
-  would run the old line's whole nox suite. Push the branch and let the tag and GitHub Release be the
-  record. Open a PR only for the forward-port.
+- **Find what is actually released on that line first** — check the `<pkg>/*` tags and PyPI. Your base is the latest released patch and your version is that + 1; guessing either collides with an existing tag or silently drops a shipped patch.
+- **Land the fix on `main` first**, via a normal reviewed PR under `[Unreleased]`, so one commit is the source of truth.
+- **Cut from the version tag, then cherry-pick**: `git checkout -b hotfix/<pkg>-X.Y.Z <pkg>/X.Y.(Z-1)`, then `git cherry-pick -x <main-commit>` after the PR merges, so the recorded SHA is permanent.
+- **The version bump and the `## [X.Y.Z]` section live on the hotfix branch** — that is what the pipeline extracts into the tag and GitHub Release.
+- **Publish out-of-band**: `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`. Merging into `release` would mislabel a tree that is ahead on a newer line.
+- **Forward-port under `[Unreleased]` only** — never backfill a `## [X.Y.Z]` section into `main`, which cannot hold a past-line patch without breaking either version or date order.
+- **A fix that cannot apply to `main` leaves its changelog alone** — an `[Unreleased]` bullet would be promoted into the next release's notes, describing a change that release does not contain.
+- **No PR from the hotfix branch itself** — its diff against `main` reads as a mass revert, and CI would run the old line's whole suite. The tag and GitHub Release are the record; open a PR only for the forward-port.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,16 +1,12 @@
 # Releasing
 
-How the five packages get to PyPI; the everyday conventions are in [AGENTS.md](AGENTS.md). The pipeline extracts the changelog section matching each tag and publishes it as the GitHub release notes.
+How the five packages get to PyPI; the everyday conventions are in [AGENTS.md](AGENTS.md). `publish_release.yml` fires on `push` to `release`, so merging is what publishes, and the pipeline extracts the changelog section matching each tag as the GitHub release notes.
 
 ## The branch loop
 
-`publish_release.yml` fires on `push` to `release`, so merging is what publishes.
-
 1. **`rel-<date>-NN` → `release`** — the PR targets `release`, never `main`. Merging it starts the publish run.
 2. **The workflow tags and publishes** on the `release` ref. Never hand-tag, and never tag on `main`.
-3. **`release` → `main`** with a plain merge commit (`gh pr merge <n> --merge`), so the exact released commit is preserved in `main`'s history.
-
-The publish jobs appear as `release-packages (<pkg>)` checks on the step-3 PR; don't merge before they are green — a failed publish is easier to redo before `main` absorbs the release commit.
+3. **`release` → `main`** with a plain merge commit (`gh pr merge <n> --merge`), preserving the released commit in `main`'s history. The publish jobs appear as `release-packages (<pkg>)` checks on this PR; don't merge before they are green — a failed publish is easier to redo before `main` absorbs the release commit.
 
 The `push` trigger takes no inputs: with no `force_packages` or `environment`, `check-package-versions` compares each version against PyPI to decide what to build, and publishes to production. `priority-order: bfabric,bfabric_scripts,bfabric_app_runner` plus `max-parallel: 1` releases sequentially, so `bfabric` lands before the packages that floor on it.
 
@@ -25,9 +21,7 @@ uv pip list --python /tmp/rel | grep -i bfabric           # check the resolved d
 /tmp/rel/bin/python -c "import bfabric"
 ```
 
-Import the real `[project.scripts]` modules (`bfabric_scripts.cli.__main__`, `bfabric_app_runner.cli.__main__`); a guessed path raises `ImportError` and reads like a broken release. Don't use `--help` — `@use_client` connects before the command body runs, so it fails for config reasons unrelated to the release.
-
-A dependent package can't be verified until the core publishes: its new floor (`bfabric>=1.20.0`) excludes the current rc under PEP 440, and the run doesn't pause between packages. Verify `bfabric` before opening the PR, the dependents right after (PyPI's index lags about a minute).
+Import the real `[project.scripts]` modules (`bfabric_scripts.cli.__main__`, `bfabric_app_runner.cli.__main__`); a guessed path raises `ImportError` and reads like a broken release. Don't use `--help` — `@use_client` connects before the command body runs, so it fails for config reasons unrelated to the release. A dependent package can't be verified until the core publishes, since its new floor (`bfabric>=1.20.0`) excludes the current rc under PEP 440 and the run doesn't pause between packages: verify `bfabric` before opening the PR, the dependents right after (PyPI's index lags about a minute).
 
 ## Out-of-band dispatch (hotfixes, re-runs)
 
@@ -50,5 +44,4 @@ A dependent package can't be verified until the core publishes: its new floor (`
 4. **Add the version bump and the `## [X.Y.Z]` section on the hotfix branch** — that is what the pipeline extracts into the tag and GitHub Release.
 5. **Publish out-of-band**: `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`. Merging into `release` would mislabel a tree that is ahead on a newer line.
 6. **Forward-port under `[Unreleased]` only** — never backfill a `## [X.Y.Z]` section into `main`, which can't hold a past-line patch without breaking version or date order. A fix that can't apply to `main` leaves its changelog alone, since an `[Unreleased]` bullet would be promoted into the next release's notes.
-
-Never open a PR from the hotfix branch: its diff against `main` reads as a mass revert and CI would run the old line's whole suite. The tag and GitHub Release are the record; the only PR is the forward-port.
+7. **Never open a PR from the hotfix branch** — its diff against `main` reads as a mass revert and CI would run the old line's whole suite. The tag and GitHub Release are the record; the only PR is the forward-port.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,126 @@
+# Releasing
+
+How the five packages in this workspace get to PyPI. Read this before touching a release; the
+everyday conventions are in [AGENTS.md](AGENTS.md).
+
+Each package is versioned and released independently: its own `pyproject.toml` version, its own
+`docs/changelog.md`, its own `<package>/<version>` git tag. The pipeline extracts the changelog
+section matching the tag and publishes it as the GitHub release notes.
+
+Release preparation is **mechanics only** — version bumps, changelog graduation, dependency-pin
+updates. It must not introduce code changes; anything that changes behavior lands on `main` first and
+ships in a later cut.
+
+## The normal flow is a branch loop, not a dispatch
+
+`publish_release.yml` fires on `push` to `release`, so merging is what publishes.
+
+1. **`rel-<date>-NN` → `release`.** Open the PR against `release`, never `main`. Merging it starts
+   the publish run. (`release` is normally an ancestor of a `rel-*` branch cut from `origin/main`, so
+   this merges cleanly.)
+2. **The workflow tags and publishes** on the `release` ref. Never hand-tag, and never tag on `main`.
+3. **`release` → `main`** with a plain merge commit (`gh pr merge <n> --merge`; no squash, no rebase),
+   so the exact released commit is preserved in `main`'s history.
+
+The publish jobs run as checks on the step-3 PR, so its rollup is the single place to watch:
+`release-packages (<pkg>)` sits alongside the usual test/basedpyright matrix. Don't merge before it
+is green — a failed publish is much easier to redo while `main` has not yet absorbed the release
+commit.
+
+**The push trigger takes no inputs, so it behaves differently from a manual dispatch.** There is no
+`force_packages` and no `environment`: `check-package-versions` auto-detects what to build by
+comparing each package's version against PyPI, and publishes to production. `priority-order:
+bfabric,bfabric_scripts,bfabric_app_runner` plus `max-parallel: 1` releases them sequentially, so
+`bfabric` lands on PyPI before the packages that floor on it.
+
+## Verify a build offline before it goes out
+
+Install it the way a user gets it, then import whatever the release touched:
+
+```bash
+uv venv /tmp/rel -p 3.11
+uv pip install --python /tmp/rel --no-sources ./bfabric   # --no-sources: ignore workspace tool.uv.sources
+uv pip list --python /tmp/rel | grep -i bfabric           # check the resolved dependency floor
+/tmp/rel/bin/python -c "import bfabric"
+```
+
+Check entry points by **module import, not `--help`**: `@use_client` calls `Bfabric.connect()` before
+the wrapped function runs, and the legacy argparse scripts build their parser inside the body, so
+`--help` reads `~/.bfabricpy.yml` first and can fail for config reasons unrelated to the release.
+Import the real modules named in each `pyproject.toml`'s `[project.scripts]`
+(`bfabric_scripts.cli.__main__:main`, `bfabric_app_runner.cli.__main__:app`) — a guessed path raises
+`ImportError` and reads exactly like a broken release.
+
+**A dependent package cannot be verified before the core publishes.** Its freshly-bumped floor (e.g.
+`bfabric>=1.20.0`) excludes the current rc under PEP 440, so nothing on PyPI satisfies it until
+`bfabric` itself is out, and the push-triggered run does not pause between packages. Verify `bfabric`
+before opening the PR to `release`, then verify the dependents straight afterwards:
+
+```bash
+uv venv /tmp/rel2 -p 3.13
+uv pip install --python /tmp/rel2 --no-sources 'bfabric_scripts==<ver>' 'bfabric_app_runner==<ver>'
+/tmp/rel2/bin/python -c "import bfabric_scripts.cli.__main__, bfabric_app_runner.cli.__main__"
+```
+
+After publishing, PyPI's index needs about a minute before `uv pip install <pkg>==<new>` resolves.
+
+## Out-of-band dispatch (hotfixes, re-runs)
+
+- **Never dispatch `environment: test` as a dry run.** That input switches only the PyPI URL. *Create
+  and push tag* and *Create GitHub Release* are ungated and run **before** the publish step, so a
+  `test` run pushes the real `<pkg>/<version>` tag and opens the draft release — and the follow-up
+  `production` run then dies at `git tag -a` ("already exists") before anything reaches PyPI. Verify
+  locally instead and dispatch straight to `production`.
+- **Pass `force_packages` explicitly.** A non-empty value makes `check_versions.py` skip the PyPI
+  version comparison entirely, so only the named packages build. Confirm via `Forcing release of
+  <pkg>` in the `check-packages` log.
+- **Leave "Set as the latest release" unchecked when publishing the draft, except for `bfabric`
+  stable.** GitHub keeps one repo-wide "Latest release", so a stable non-core release — or a patch of
+  an older line — would take the badge from the core library. `rcN` and `0.x` tags are auto-flagged
+  as prereleases and never compete for it.
+
+## Release candidates
+
+- **One cumulative pre-release entry, not a stack.** While a version is in RC, keep a *single*
+  changelog entry for it (e.g. `## [1.20.0rc2]`) describing the **full** changeset for the upcoming
+  `X.Y.0`. When cutting the next RC, re-date and extend that same entry and bump the `rcN` suffix —
+  do not add a separate `[…rcN]` heading below the previous one. Per-RC history is preserved by the
+  published tags and GitHub releases.
+- **RC entries use flat, abbreviated bullets, headline-first** — the one exception to the Keep a
+  Changelog subsections normal entries use. User-facing headlines come first; dev-facing
+  typing/tooling changes go in a trailing `Internal:` bullet.
+- **Graduation** renames the `[X.Y.0rcN]` heading to `[X.Y.0]` with the release date. No content merge
+  is needed, since the entry was cumulative.
+- **Cross-package dependency floors must name the rc** when a package uses a feature from an
+  unreleased `bfabric` (e.g. `bfabric>=1.20.0rc2,<1.21`). A plain `>=1.20.0` *excludes* `1.20.0rc2`
+  under PEP 440, and naming the prerelease is also what lets pip/uv resolve to it.
+
+## Hotfixes (patch release of an older line)
+
+- **First, find what's actually released on that line.** Check the `<pkg>/*` git tags and PyPI for the
+  latest released patch: that tag is your base and your new version is that patch + 1. Skipping this
+  is the classic hotfix error — you either collide with an existing tag or silently drop an
+  already-shipped patch (base `1.19.0` → ship `1.19.3`, dropping `1.19.1`/`1.19.2`).
+- **Land the fix on `main` first, via a normal reviewed PR** (under `[Unreleased]`), so a single
+  commit is the source of truth. Don't build the hotfix branch first and reverse-port afterwards.
+- **Cut the hotfix branch from the version tag, then cherry-pick the merged fix.** `release`/`main`
+  have moved ahead when the newest line is unreleased or in RC:
+  `git checkout -b hotfix/<pkg>-X.Y.Z <pkg>/X.Y.(Z-1)`, then `git cherry-pick -x <main-commit>`
+  **after** the PR merges, so the recorded SHA is permanent.
+- **The version bump and the `## [X.Y.Z]` changelog section live on the hotfix branch** — that is what
+  the pipeline extracts into the tag and GitHub Release.
+- **Publish out-of-band, don't merge into `release`** (which is ahead on a newer line and would be
+  mislabelled):
+  `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`.
+  The branch then lives on as the release record; it has no merge target.
+- **Forward-port to `main` as a normal PR, `[Unreleased]` only.** Cherry-pick with `-x` so `1.X.0`
+  doesn't regress, and note it inline (e.g. "also released as the X.Y.Z hotfix"). Do **not** backfill
+  a `## [X.Y.Z]` section into `main`: a past-line patch can't sit in a version-descending changelog
+  without breaking either version or date order, and the tag + GitHub Release already record it.
+- **A fix that can't apply to `main` leaves `main`'s changelog alone.** Some hotfixes only constrain
+  the old line — a dependency cap, say, when `main` has already migrated past the broken API. With
+  nothing to forward-port there is nothing to document, and an `[Unreleased]` bullet would be promoted
+  into the next release's notes, describing a change that release doesn't contain.
+- **No PR from the hotfix branch itself.** Its diff against `main` reads as a mass revert, and PR CI
+  would run the old line's whole nox suite. Push the branch and let the tag and GitHub Release be the
+  record. Open a PR only for the forward-port.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,6 @@
 # Releasing
 
-How the five packages get to PyPI. Everyday conventions are in [AGENTS.md](AGENTS.md).
-
-Each package is released independently: its own `pyproject.toml` version, its own `docs/changelog.md`, its own `<package>/<version>` tag. The pipeline extracts the changelog section matching the tag and publishes it as the GitHub release notes. Release preparation is **mechanics only** — version bumps, changelog graduation, dependency-pin updates — never code changes.
+How the five packages get to PyPI; the everyday conventions are in [AGENTS.md](AGENTS.md). The pipeline extracts the changelog section matching each tag and publishes it as the GitHub release notes.
 
 ## The branch loop
 
@@ -12,9 +10,9 @@ Each package is released independently: its own `pyproject.toml` version, its ow
 2. **The workflow tags and publishes** on the `release` ref. Never hand-tag, and never tag on `main`.
 3. **`release` → `main`** with a plain merge commit (`gh pr merge <n> --merge`), so the exact released commit is preserved in `main`'s history.
 
-The publish jobs run as `release-packages (<pkg>)` checks on the step-3 PR — watch that rollup and don't merge before it is green, since a failed publish is much easier to redo while `main` has not yet absorbed the release commit.
+The publish jobs appear as `release-packages (<pkg>)` checks on the step-3 PR; don't merge before they are green — a failed publish is easier to redo before `main` absorbs the release commit.
 
-The `push` trigger takes no inputs, so it differs from a manual dispatch: with no `force_packages` and no `environment`, `check-package-versions` auto-detects what to build by comparing each version against PyPI and publishes to production. `priority-order: bfabric,bfabric_scripts,bfabric_app_runner` plus `max-parallel: 1` releases sequentially, so `bfabric` lands before the packages that floor on it.
+The `push` trigger takes no inputs: with no `force_packages` or `environment`, `check-package-versions` compares each version against PyPI to decide what to build, and publishes to production. `priority-order: bfabric,bfabric_scripts,bfabric_app_runner` plus `max-parallel: 1` releases sequentially, so `bfabric` lands before the packages that floor on it.
 
 ## Verify offline first
 
@@ -27,30 +25,30 @@ uv pip list --python /tmp/rel | grep -i bfabric           # check the resolved d
 /tmp/rel/bin/python -c "import bfabric"
 ```
 
-Import the real `[project.scripts]` modules (`bfabric_scripts.cli.__main__`, `bfabric_app_runner.cli.__main__`), not a guessed path — a wrong guess raises `ImportError` and reads exactly like a broken release. Don't check entry points with `--help`: `@use_client` calls `Bfabric.connect()` before the command body runs, so `--help` can fail for config reasons unrelated to the release.
+Import the real `[project.scripts]` modules (`bfabric_scripts.cli.__main__`, `bfabric_app_runner.cli.__main__`); a guessed path raises `ImportError` and reads like a broken release. Don't use `--help` — `@use_client` connects before the command body runs, so it fails for config reasons unrelated to the release.
 
-A dependent package cannot be verified before the core publishes — its freshly-bumped floor (`bfabric>=1.20.0`) excludes the current rc under PEP 440, and the push-triggered run does not pause between packages. Verify `bfabric` before opening the PR to `release`, then the dependents straight after it publishes (PyPI's index needs about a minute).
+A dependent package can't be verified until the core publishes: its new floor (`bfabric>=1.20.0`) excludes the current rc under PEP 440, and the run doesn't pause between packages. Verify `bfabric` before opening the PR, the dependents right after (PyPI's index lags about a minute).
 
 ## Out-of-band dispatch (hotfixes, re-runs)
 
-- **Never dispatch `environment: test` as a dry run.** It switches only the PyPI URL, and tag creation plus the GitHub release are ungated and run first — so a `test` run pushes the real tag and the follow-up `production` run dies at `git tag -a` before anything reaches PyPI. Verify locally and dispatch straight to `production`.
-- **Pass `force_packages` explicitly.** A non-empty value makes `check_versions.py` skip the PyPI comparison entirely, so only the named packages build; confirm via `Forcing release of <pkg>` in the `check-packages` log.
-- **Leave "Set as the latest release" unchecked, except for `bfabric` stable.** GitHub keeps one repo-wide badge and it belongs to the core library. `rcN` and `0.x` tags are auto-flagged as prereleases and never compete for it.
+- **Never dispatch `environment: test` as a dry run.** It only switches the PyPI URL; tag creation and the GitHub release are ungated and run first, so the real tag is pushed and the `production` re-run then dies at `git tag -a`. Verify locally and dispatch straight to `production`.
+- **Pass `force_packages` explicitly** — a non-empty value skips the PyPI comparison, so only the named packages build. Confirm via `Forcing release of <pkg>` in the `check-packages` log.
+- **Leave "Set as the latest release" unchecked, except for `bfabric` stable** — GitHub keeps one repo-wide badge and it belongs to the core library. `rcN` and `0.x` tags are auto-flagged as prereleases.
 
 ## Release candidates
 
-- Keep **one cumulative entry** per RC line (e.g. `## [1.20.0rc2]`) describing the full changeset for the upcoming `X.Y.0`; re-date and extend that entry for the next RC rather than stacking `[…rcN]` headings below it. The published tags keep the per-RC history.
+- Keep **one cumulative entry** per RC line (e.g. `## [1.20.0rc2]`) covering the full changeset for the upcoming `X.Y.0`, re-dated and extended for each RC rather than stacked below the last one. The published tags keep the per-RC history.
 - RC entries use flat, abbreviated, headline-first bullets — the one exception to the Keep a Changelog subsections — with dev-facing changes in a trailing `Internal:` bullet.
-- Graduation renames `[X.Y.0rcN]` to `[X.Y.0]` with the release date; no content merge is needed, since the entry was cumulative.
-- A floor on an unreleased `bfabric` must name the rc (`bfabric>=1.20.0rc2,<1.21`) — a plain `>=1.20.0` excludes it under PEP 440, and naming it is what lets pip/uv resolve to it.
+- Graduation renames `[X.Y.0rcN]` to `[X.Y.0]` with the date; no content merge, since the entry was cumulative.
+- A floor on an unreleased `bfabric` must name the rc (`bfabric>=1.20.0rc2,<1.21`); a plain `>=1.20.0` excludes it under PEP 440.
 
 ## Hotfixes (patch of an older line)
 
-- **Find what is actually released on that line first** — check the `<pkg>/*` tags and PyPI. Your base is the latest released patch and your version is that + 1; guessing either collides with an existing tag or silently drops a shipped patch.
-- **Land the fix on `main` first**, via a normal reviewed PR under `[Unreleased]`, so one commit is the source of truth.
-- **Cut from the version tag, then cherry-pick**: `git checkout -b hotfix/<pkg>-X.Y.Z <pkg>/X.Y.(Z-1)`, then `git cherry-pick -x <main-commit>` after the PR merges, so the recorded SHA is permanent.
-- **The version bump and the `## [X.Y.Z]` section live on the hotfix branch** — that is what the pipeline extracts into the tag and GitHub Release.
-- **Publish out-of-band**: `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`. Merging into `release` would mislabel a tree that is ahead on a newer line.
-- **Forward-port under `[Unreleased]` only** — never backfill a `## [X.Y.Z]` section into `main`, which cannot hold a past-line patch without breaking either version or date order.
-- **A fix that cannot apply to `main` leaves its changelog alone** — an `[Unreleased]` bullet would be promoted into the next release's notes, describing a change that release does not contain.
-- **No PR from the hotfix branch itself** — its diff against `main` reads as a mass revert, and CI would run the old line's whole suite. The tag and GitHub Release are the record; open a PR only for the forward-port.
+1. **Find what is actually released on that line** — check the `<pkg>/*` tags and PyPI. Your base is the latest released patch and your version is that + 1; guessing collides with an existing tag or silently drops a shipped patch.
+2. **Land the fix on `main` first**, via a normal reviewed PR under `[Unreleased]`, so one commit is the source of truth.
+3. **Cut from the version tag and cherry-pick once that PR merges**, so the recorded SHA is permanent: `git checkout -b hotfix/<pkg>-X.Y.Z <pkg>/X.Y.(Z-1)`, then `git cherry-pick -x <main-commit>`.
+4. **Add the version bump and the `## [X.Y.Z]` section on the hotfix branch** — that is what the pipeline extracts into the tag and GitHub Release.
+5. **Publish out-of-band**: `gh workflow run publish_release.yml --ref hotfix/<pkg>-X.Y.Z -f environment=production -f force_packages=<pkg>`. Merging into `release` would mislabel a tree that is ahead on a newer line.
+6. **Forward-port under `[Unreleased]` only** — never backfill a `## [X.Y.Z]` section into `main`, which can't hold a past-line patch without breaking version or date order. A fix that can't apply to `main` leaves its changelog alone, since an `[Unreleased]` bullet would be promoted into the next release's notes.
+
+Never open a PR from the hotfix branch: its diff against `main` reads as a mass revert and CI would run the old line's whole suite. The tag and GitHub Release are the record; the only PR is the forward-port.

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -11,8 +11,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ### Added
 
-- Config: new CLI-only `scope` field recording the scope *requested* at login, so a login can be replayed from disk.
-- `config_writer.clear_environment_credentials` strips inline `login` / `password` / `pat` secrets while keeping the environment configured. Backs `bfabric-cli auth logout`.
+- Config: new CLI-only `scope` field recording the scope *requested* at login, so a login can be replayed from disk; `config_writer.clear_environment_credentials` strips inline secrets while keeping the environment configured.
 - `upload_files` / `collect_file_infos` accept `exclude_names`, dropping files by basename at any depth (e.g. `.DS_Store`).
 - `on_duplicate="link"` registers a duplicate as a resource pointing at the existing bytes instead of omitting the file, transferring nothing. See `FileInfo.link_from_resource_id`.
 

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -11,28 +11,31 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ### Added
 
-- Config: new CLI-only `scope` environment field recording the scope *requested* at login, so a login can be replayed from disk.
-- `config_writer.clear_environment_credentials` strips inline secrets (`login` / `password` / `pat`) from an environment while keeping it configured. Backs `bfabric-cli auth logout`.
-- `upload_files` and `collect_file_infos` accept `exclude_names`, dropping files by basename at any depth (e.g. `.DS_Store`); nested files keep their relative resource names.
-- `on_duplicate="link"` registers a content-duplicate as an `AVAILABLE` resource pointing at the existing bytes instead of skipping the file, so the workunit holds a resource per input file with nothing transferred. A duplicate with no `existingResourceId` stays a plain skip. `FileInfo.link_from_resource_id` and `CreatedResource.linked` expose it.
+- Config: new CLI-only `scope` field recording the scope *requested* at login, so a login can be replayed from disk.
+- `config_writer.clear_environment_credentials` strips inline `login` / `password` / `pat` secrets while keeping the environment configured. Backs `bfabric-cli auth logout`.
+- `upload_files` / `collect_file_infos` accept `exclude_names`, dropping files by basename at any depth (e.g. `.DS_Store`).
+- `on_duplicate="link"` registers a duplicate as a resource pointing at the existing bytes instead of omitting the file, transferring nothing. See `FileInfo.link_from_resource_id`.
 
 ### Changed
 
-- `upload_files(client, params)` takes its file list as `UploadFilesParams.files`, a list of `UploadFileParam(path=..., on_duplicate=...)`; the positional `files` argument and the `force` / `link_duplicates` booleans are gone. `on_duplicate` is `upload` / `skip` / `link` and applies to every file under a directory. **It defaults to `upload`, so the duplicate check no longer runs unless asked for** — callers relying on duplicates being skipped must pass `skip`.
-- `UploadSummary` holds one list per outcome — `uploads`, `skips`, `failures`, `links` — replacing the 1.20.0 counters. A skip is now a `FileSkip(filename, category, existing_resource_id)` naming the duplicate it lost out to; `links` is separate from `uploads` because a linked file has a resource but transferred no bytes. A workunit whose files were all linked completes instead of failing the "nothing uploaded" check.
-- Two input files mapping to the same resource name are rejected *before* the workunit is created, so a rejected upload no longer leaves a `failed` workunit behind.
-- `import bfabric` no longer imports `polars` eagerly (~296 ms → ~184 ms); the module-scope imports in `HasMany.polars`, `Dataset.to_polars` and `MultiplexKit.ids` moved into the functions. `polars` remains a hard dependency and no API changed.
-- PKCE: the printed-URL fallback and the timeout error name the loopback redirect target and point at the device-code flow, for the remote-host case a browser elsewhere cannot complete.
-- `use_client` logs the reported error's traceback at DEBUG (`BFABRICPY_LOG_LEVEL=DEBUG` recovers it); the one-line `Error: <message>` output and exit code 1 are unchanged.
+- `upload_files(client, params)` takes its files as `UploadFilesParams.files`, a list of `UploadFileParam(path=..., on_duplicate=...)`; the `force` / `link_duplicates` booleans are gone.
+- **`on_duplicate` defaults to `upload`, so the duplicate check no longer runs unless asked for** — pass `skip` for the old behaviour.
+- `UploadSummary` holds one list per outcome — `uploads`, `skips`, `failures`, `links` — replacing the 1.20.0 counters; skips carry the duplicate they lost out to.
+- A workunit whose files were all linked now completes instead of failing the "nothing uploaded" check.
+- Two input files mapping to the same resource name are rejected before the workunit is created, not after.
+- `import bfabric` no longer imports `polars` eagerly (~296 ms → ~184 ms); it loads on first use.
+- PKCE's printed-URL fallback and timeout error now name the loopback redirect target and point at the device-code flow.
+- `use_client` logs the reported error's traceback at DEBUG; the `Error: <message>` line and exit code 1 are unchanged.
 
 ### Fixed
 
-- `setup_script_logging` guards against repeated setup with a process-local flag instead of the inherited `BFABRICPY_SCRIPT_LOGGING_SETUP` environment variable, which made any subprocess (e.g. the `bfabric-app-runner action` in a prepared workunit's Makefile) skip setup and fall back to loguru's verbose DEBUG default. Subprocesses now configure their own sinks and honor `BFABRICPY_LOG_LEVEL`.
-- `write_environment_to_config` merges into an existing environment instead of replacing it, so unrelated keys (`application_ids`, `engine`, hand-written extras) survive a re-login. Auth-owned keys (`login`, `password`, `pat`, `auth_method`, `client_id`, `scope`) are replaced wholesale, so a stale `pat` cannot outlive the auth method that wrote it.
-- `MultiQuery.read_multi` reserves query elements for the other fields of `obj` when chunking, since the API counts every value towards its 100-element limit — 100 paths plus a `containerid` previously failed with "Query has 101 elements". A query whose other fields already exhaust the limit now raises `ValueError`.
-- `Bfabric.connect()` raises a clear error when an `auth_method: oauth` config has no `env_name` (reachable via `BFABRICPY_CONFIG_OVERRIDE`), instead of deriving a token-cache key that could never match.
-- Packaging: `project.readme` points at a package-local `README.md`; hatchling 1.32.0 rejects readme paths outside the project directory, which broke every build from source. Published wheels were unaffected.
-- Uploading a folder with sub-directories works against servers that echo the resource name verbatim; the duplicate-check and resource-pairing guards previously fired on nested names. A nested re-upload now reports `renamed_duplicate` rather than `exact_duplicate` — both carry the `skip` action, so branch on `action`, not `category`.
+- `setup_script_logging` no longer skips setup in subprocesses, which fell back to loguru's verbose DEBUG default; its repeat guard is now process-local.
+- `write_environment_to_config` merges into an existing environment instead of replacing it, so unrelated keys survive a re-login; auth-owned keys are still replaced wholesale.
+- `MultiQuery.read_multi` reserves query elements for `obj`'s other fields when chunking, instead of overflowing the API's 100-element limit. A query that already exhausts it raises `ValueError`.
+- `Bfabric.connect()` errors clearly when an `auth_method: oauth` config has no `env_name`.
+- Packaging: `project.readme` points at a package-local `README.md`; hatchling 1.32.0 rejects paths outside the project directory, breaking builds from source.
+- Uploading a folder with sub-directories now works against servers that echo the resource name verbatim.
+- A nested re-upload reports `renamed_duplicate` rather than `exact_duplicate`; both carry the `skip` action, so branch on `action`, not `category`.
 
 ## \[1.20.0\] - 2026-08-03
 

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,46 +9,30 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
-- `setup_script_logging` now guards against repeated setup with a process-local flag instead of the `BFABRICPY_SCRIPT_LOGGING_SETUP` environment variable. Children inherited that variable, so any subprocess (e.g. the `bfabric-app-runner action` invoked by a prepared workunit's Makefile) skipped setup entirely and fell back to loguru's default handler — full timestamp/source format, at DEBUG level. Subprocesses now configure their own sinks and honor `BFABRICPY_LOG_LEVEL`.
-- `use_client` now logs the traceback of the error it reports at DEBUG, so `BFABRICPY_LOG_LEVEL=DEBUG` recovers it. Previously the traceback of a `RuntimeError`-derived error was discarded unconditionally. The one-line `Error: <message>` output and exit code 1 are unchanged.
-- Config: new `scope` environment field recording the scope *requested* at login (not the granted one), so a login can be replayed from disk without retyping it. CLI-only — excluded from `BfabricClientConfig` and `ConfigData`.
-- `write_environment_to_config` now **merges** into an existing environment instead of replacing it, so unrelated keys (`application_ids`, `engine`, hand-written extras) survive a re-login. Auth-owned keys (`login`, `password`, `pat`, `auth_method`, `client_id`, `scope`) are replaced wholesale, so a stale `pat` cannot outlive the auth method that wrote it.
-- New `config_writer.clear_environment_credentials` — strip inline secrets (`login` / `password` / `pat`) from an environment while keeping it configured, returning the keys removed. Backs `bfabric-cli auth logout`.
-- PKCE: the printed-URL fallback and the timeout error now name the loopback redirect target and point at the device-code flow, for the remote-host case a browser elsewhere cannot complete.
-- `Bfabric.connect()` now raises a clear error when an `auth_method: oauth` config has no `env_name` (reachable via `BFABRICPY_CONFIG_OVERRIDE`), instead of deriving a token-cache key that could never match a cached token.
-- Packaging: `project.readme` now points at a package-local `README.md` instead of the repository root's. hatchling 1.32.0 rejects readme paths that resolve outside the project directory, which broke every build from source (CI and git-pinned installs); the previous setting also produced an sdist containing a `../README.md` member that tar refuses to extract. Installing the published wheels was never affected.
-- `MultiQuery.read_multi` now reserves query elements for the other fields of `obj` when chunking, since the API counts every value in a query towards its limit of 100 elements. Previously e.g. `read_multi("importresource", {"containerid": cid}, "relativepath", paths)` failed with "Query has 101 elements and exceeds the maximum of 100 allowed elements" as soon as 100 paths were passed. A query whose other fields already use up the limit now raises `ValueError` instead of being sent.
-- `import bfabric` no longer imports `polars` eagerly (~296 ms → ~184 ms). The three modules on the import path that pulled it in at module scope — `HasMany.polars`, `Dataset.to_polars`, `MultiplexKit.ids` — now import it inside the function, as `ResultContainer.to_polars` already did. `polars` remains a hard dependency and every API is unchanged; it is simply not loaded until a `DataFrame` is actually requested.
-- `upload_files` and `collect_file_infos` accept `exclude_names`, dropping files by basename at any depth (e.g. a caller's sentinel file, `.DS_Store`). Filtering here rather than pre-filtering the path list preserves the relative resource names of nested files.
-- **Breaking:** `upload_files` takes its file list inside `params` and decides duplicate handling **per file**. The signature is now `upload_files(client, params)` — the positional `files` argument is gone — and `UploadFilesParams.files` is a list of `UploadFileParam(path=..., on_duplicate=...)`. `on_duplicate` is one of `upload` / `skip` / `link` (the same three words as the server's `check-duplicates` verdict), replacing the mutually-interfering `force` and `link_duplicates` booleans, both of which are removed. **It defaults to `upload`, so the duplicate check no longer runs unless asked for**: callers that relied on duplicates being skipped must now say so. A directory applies its policy to every file under it, and a file with `on_duplicate="upload"` is left out of the `check-duplicates` request entirely.
+### Added
 
-  ```python
-  # before
-  upload_files(
-      client,
-      [Path("a.raw"), Path("run/")],
-      UploadFilesParams(container_id=1, application_id=2),
-  )
-  # after — same behaviour (duplicates skipped)
-  upload_files(
-      client,
-      UploadFilesParams(
-          files=[
-              UploadFileParam(path=Path("a.raw"), on_duplicate="skip"),
-              UploadFileParam(path=Path("run/"), on_duplicate="skip"),
-          ],
-          container_id=1,
-          application_id=2,
-      ),
-  )
-  ```
-- `on_duplicate="link"` registers a content-duplicate as a link instead of skipping it. Any duplicate verdict naming an `existingResourceId` — in practice a `skip` on an `exact_duplicate` / `renamed_duplicate` — has that id passed back as `linkFromResourceId`, and the server creates an `AVAILABLE` resource pointing at the existing bytes with no transfer. The workunit then holds a resource for every input file, rather than silently omitting the duplicates. A duplicate with no `existingResourceId` stays a plain skip.
-- Two input files mapping to the same resource name are now rejected *before* the workunit is created, rather than after (verdicts and resources are keyed by name alone, so nothing downstream could disambiguate them). The error is unchanged; only its timing is, so a rejected upload no longer leaves a `failed` workunit behind.
-- **Breaking:** `UploadSummary` now holds one list per outcome and nothing else — `uploads`, `skips`, `failures`, `links` — so a count is `len(summary.uploads)`. The `uploaded`, `skipped` and `failed` counters (released in 1.20.0) are removed, along with the never-released `linked`; each was only ever the length of its list, with no consumer needing it independently, and keeping both invited the two to drift.
-- `skips` is new detail rather than a renamed counter: a skipped file now arrives as `FileSkip(filename, category, existing_resource_id)`, naming the duplicate it lost out to (`exact_duplicate` / `renamed_duplicate` / …, plus the resource already holding those bytes). Previously a skip was only a number, so which files were dropped — and what they matched — was unrecoverable.
-- `links` records files registered as links to already-stored bytes, reported separately from `uploads` and `skips`: a linked file *has* a resource but transferred no bytes, whereas a skipped one has no resource at all. A workunit whose files were all linked now completes instead of being marked failed by the "nothing uploaded" check.
-- `FileInfo` gains `link_from_resource_id`, and `CreatedResource` exposes the `linked` field from `create-resources`. Server-side linked resources are excluded from the `initiate` id lists and never transferred. Both default to `None`/`False`, so servers that omit the field behave exactly as before.
-- Uploading a folder with sub-directories now works against servers that echo the resource name verbatim. The duplicate-check and resource-pairing guards previously fired on nested names (`sub/nested.raw`) because the server replied with the basename; the fix is server-side, and no duplicate-policy workaround is needed for it. Note a nested re-upload is now reported as `renamed_duplicate` rather than `exact_duplicate` (name matching misses on a subpath, so detection falls back to MD5) — both still carry the `skip` action, so branch on `action`, not `category`.
+- Config: new CLI-only `scope` environment field recording the scope *requested* at login, so a login can be replayed from disk.
+- `config_writer.clear_environment_credentials` strips inline secrets (`login` / `password` / `pat`) from an environment while keeping it configured. Backs `bfabric-cli auth logout`.
+- `upload_files` and `collect_file_infos` accept `exclude_names`, dropping files by basename at any depth (e.g. `.DS_Store`); nested files keep their relative resource names.
+- `on_duplicate="link"` registers a content-duplicate as an `AVAILABLE` resource pointing at the existing bytes instead of skipping the file, so the workunit holds a resource per input file with nothing transferred. A duplicate with no `existingResourceId` stays a plain skip. `FileInfo.link_from_resource_id` and `CreatedResource.linked` expose it.
+
+### Changed
+
+- `upload_files(client, params)` takes its file list as `UploadFilesParams.files`, a list of `UploadFileParam(path=..., on_duplicate=...)`; the positional `files` argument and the `force` / `link_duplicates` booleans are gone. `on_duplicate` is `upload` / `skip` / `link` and applies to every file under a directory. **It defaults to `upload`, so the duplicate check no longer runs unless asked for** — callers relying on duplicates being skipped must pass `skip`.
+- `UploadSummary` holds one list per outcome — `uploads`, `skips`, `failures`, `links` — replacing the 1.20.0 counters. A skip is now a `FileSkip(filename, category, existing_resource_id)` naming the duplicate it lost out to; `links` is separate from `uploads` because a linked file has a resource but transferred no bytes. A workunit whose files were all linked completes instead of failing the "nothing uploaded" check.
+- Two input files mapping to the same resource name are rejected *before* the workunit is created, so a rejected upload no longer leaves a `failed` workunit behind.
+- `import bfabric` no longer imports `polars` eagerly (~296 ms → ~184 ms); the module-scope imports in `HasMany.polars`, `Dataset.to_polars` and `MultiplexKit.ids` moved into the functions. `polars` remains a hard dependency and no API changed.
+- PKCE: the printed-URL fallback and the timeout error name the loopback redirect target and point at the device-code flow, for the remote-host case a browser elsewhere cannot complete.
+- `use_client` logs the reported error's traceback at DEBUG (`BFABRICPY_LOG_LEVEL=DEBUG` recovers it); the one-line `Error: <message>` output and exit code 1 are unchanged.
+
+### Fixed
+
+- `setup_script_logging` guards against repeated setup with a process-local flag instead of the inherited `BFABRICPY_SCRIPT_LOGGING_SETUP` environment variable, which made any subprocess (e.g. the `bfabric-app-runner action` in a prepared workunit's Makefile) skip setup and fall back to loguru's verbose DEBUG default. Subprocesses now configure their own sinks and honor `BFABRICPY_LOG_LEVEL`.
+- `write_environment_to_config` merges into an existing environment instead of replacing it, so unrelated keys (`application_ids`, `engine`, hand-written extras) survive a re-login. Auth-owned keys (`login`, `password`, `pat`, `auth_method`, `client_id`, `scope`) are replaced wholesale, so a stale `pat` cannot outlive the auth method that wrote it.
+- `MultiQuery.read_multi` reserves query elements for the other fields of `obj` when chunking, since the API counts every value towards its 100-element limit — 100 paths plus a `containerid` previously failed with "Query has 101 elements". A query whose other fields already exhaust the limit now raises `ValueError`.
+- `Bfabric.connect()` raises a clear error when an `auth_method: oauth` config has no `env_name` (reachable via `BFABRICPY_CONFIG_OVERRIDE`), instead of deriving a token-cache key that could never match.
+- Packaging: `project.readme` points at a package-local `README.md`; hatchling 1.32.0 rejects readme paths outside the project directory, which broke every build from source. Published wheels were unaffected.
+- Uploading a folder with sub-directories works against servers that echo the resource name verbatim; the duplicate-check and resource-pairing guards previously fired on nested names. A nested re-upload now reports `renamed_duplicate` rather than `exact_duplicate` — both carry the `skip` action, so branch on `action`, not `category`.
 
 ## \[1.20.0\] - 2026-08-03
 

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -6,19 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- New `${app.dir}` template variable holding the app spec's directory, for paths no spec field can resolve, e.g. a script referenced from inside a `command` string: `command: uv run --script ${app.dir}/dispatch.py`.
+- New `${app.dir}` template variable holding the app spec's directory, for paths no spec field resolves — e.g. `command: uv run --script ${app.dir}/dispatch.py`.
 
 ### Changed
 
-- Relative paths in the app spec (`pylock`, `local_extra_deps`, `prepend_paths`, and the host side of docker `mounts`) resolve against the `app.yml` directory, with a leading `~` expanded ([#212](https://github.com/fgcz/bfabricPy/issues/212)) — previously against the run's per-workunit scratch directory. Container-side mount paths are unchanged. Together with `${app.dir}`, a spec directory can be relocated without rewriting its paths.
-- Captured command output (`uv venv` / `uv pip install` / `uv pip list`) is logged one record per line, so every line carries its level prefix and stays greppable.
-- Requires `bfabric` 1.20.1, whose logging fix keeps a nested app-runner (Makefile or SLURM) from falling back to loguru's verbose DEBUG format.
-- Internal: the demo app copier template can be instantiated again — it rendered `_copier_conf.dst_path.resolve()`, which current copier rejects now that `dst_path` is a `PurePath`. Its `app.yml` uses spec-relative paths and its stale `app_runner: 0.1.2` pin is refreshed; the destination must now be an absolute path, for the `<program>` path in `bfabric_app.xml`.
+- Relative paths in the app spec (`pylock`, `local_extra_deps`, `prepend_paths`, host side of docker `mounts`) resolve against the `app.yml` directory instead of the run's scratch directory, with a leading `~` expanded ([#212](https://github.com/fgcz/bfabricPy/issues/212)).
+- Captured command output (`uv venv` / `uv pip install`) is logged one record per line, so every line carries its level prefix.
+- Requires `bfabric` 1.20.1 for the logging fix that keeps a nested app-runner from falling back to loguru's verbose DEBUG format.
+- Internal: the demo app copier template can be instantiated again; its `app.yml` uses spec-relative paths, the stale `app_runner: 0.1.2` pin is refreshed, and the destination must now be an absolute path.
 
 ### Fixed
 
-- A failing app command reports a single `Error: Command failed with exit code N: <command>` line instead of ~10 frames of app-runner boilerplate under the app's own error output ([#231](https://github.com/fgcz/bfabricPy/issues/231)). Commands raise the new `CommandFailedError`, rendered without a traceback (`BFABRICPY_LOG_LEVEL=DEBUG` still shows it); a genuine app-runner bug keeps its full traceback.
-- `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory. The workunit is still marked `failed`.
+- A failing app command reports a single `Error: Command failed with exit code N: <command>` line instead of ~10 frames of app-runner boilerplate ([#231](https://github.com/fgcz/bfabricPy/issues/231)).
+- `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory.
 
 ## \[0.7.0\] - 2026-08-03
 

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -4,13 +4,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## \[Unreleased\]
 
-- Relative paths in the app spec (`pylock`, `local_extra_deps`, `prepend_paths`, and the host side of the docker `mounts` entries) are now resolved against the directory containing the `app.yml`, and a leading `~` is expanded ([#212](https://github.com/fgcz/bfabricPy/issues/212)). Previously they were resolved against the working directory of the run (a per-workunit scratch directory), which could not be relied on. Container-side mount paths are unchanged.
-- New `${app.dir}` template variable holding the app spec's directory, for paths that no spec field can resolve, e.g. a script referenced from inside a `command` string: `command: uv run --script ${app.dir}/dispatch.py`. Together with the above, an app spec directory can be relocated or checked out elsewhere without rewriting its paths.
-- A failing app command now reports as a single `Error: Command failed with exit code N: <command>` line instead of stacking ~10 frames of app-runner boilerplate under the app's own error output ([#231](https://github.com/fgcz/bfabricPy/issues/231)). Commands raise the new `CommandFailedError`, which the CLI renders without a traceback; `BFABRICPY_LOG_LEVEL=DEBUG` still shows it. A genuine app-runner bug (e.g. a `TypeError`) keeps its full traceback as before.
+### Added
+
+- New `${app.dir}` template variable holding the app spec's directory, for paths no spec field can resolve, e.g. a script referenced from inside a `command` string: `command: uv run --script ${app.dir}/dispatch.py`.
+
+### Changed
+
+- Relative paths in the app spec (`pylock`, `local_extra_deps`, `prepend_paths`, and the host side of docker `mounts`) resolve against the `app.yml` directory, with a leading `~` expanded ([#212](https://github.com/fgcz/bfabricPy/issues/212)) — previously against the run's per-workunit scratch directory. Container-side mount paths are unchanged. Together with `${app.dir}`, a spec directory can be relocated without rewriting its paths.
+- Captured command output (`uv venv` / `uv pip install` / `uv pip list`) is logged one record per line, so every line carries its level prefix and stays greppable.
+- Requires `bfabric` 1.20.1, whose logging fix keeps a nested app-runner (Makefile or SLURM) from falling back to loguru's verbose DEBUG format.
+- Internal: the demo app copier template can be instantiated again — it rendered `_copier_conf.dst_path.resolve()`, which current copier rejects now that `dst_path` is a `PurePath`. Its `app.yml` uses spec-relative paths and its stale `app_runner: 0.1.2` pin is refreshed; the destination must now be an absolute path, for the `<program>` path in `bfabric_app.xml`.
+
+### Fixed
+
+- A failing app command reports a single `Error: Command failed with exit code N: <command>` line instead of ~10 frames of app-runner boilerplate under the app's own error output ([#231](https://github.com/fgcz/bfabricPy/issues/231)). Commands raise the new `CommandFailedError`, rendered without a traceback (`BFABRICPY_LOG_LEVEL=DEBUG` still shows it); a genuine app-runner bug keeps its full traceback.
 - `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory. The workunit is still marked `failed`.
-- Captured command output (`uv venv` / `uv pip install` / `uv pip list`) is now logged one record per line, so every line carries its level prefix and stays greppable. Previously it was one multi-line record whose lines after the first were indistinguishable from raw `print` output.
-- Requires `bfabric` 1.20.1, whose logging fix is what keeps a nested app-runner (Makefile or SLURM) from falling back to loguru's verbose DEBUG format.
-- Internal: the demo app copier template can be instantiated again. It rendered `_copier_conf.dst_path.resolve()`, which current copier rejects because it now exposes `dst_path` as a `PurePath`. Its `app.yml` uses spec-relative paths instead of a generation-time host path, and its stale `app_runner: 0.1.2` pin is refreshed. The destination must now be given as an absolute path, for the `<program>` path in `bfabric_app.xml`.
 
 ## \[0.7.0\] - 2026-08-03
 

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -13,10 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Relative paths in the app spec (`pylock`, `local_extra_deps`, `prepend_paths`, host side of docker `mounts`) resolve against the `app.yml` directory instead of the run's scratch directory, with a leading `~` expanded ([#212](https://github.com/fgcz/bfabricPy/issues/212)).
 - Captured command output (`uv venv` / `uv pip install`) is logged one record per line, so every line carries its level prefix.
 - Requires `bfabric` 1.20.1 for the logging fix that keeps a nested app-runner from falling back to loguru's verbose DEBUG format.
-- Internal: the demo app copier template can be instantiated again; its `app.yml` uses spec-relative paths, the stale `app_runner: 0.1.2` pin is refreshed, and the destination must now be an absolute path.
 
 ### Fixed
 
+- The demo app copier template can be instantiated again; the destination must now be given as an absolute path.
 - A failing app command reports a single `Error: Command failed with exit code N: <command>` line instead of ~10 frames of app-runner boilerplate ([#231](https://github.com/fgcz/bfabricPy/issues/231)).
 - `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory.
 

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,21 +10,28 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 ## \[Unreleased\]
 
-- `bfabric-cli login` renews an expired token with **no arguments**: the instance URL and scope are read back from the environment. A first login picks the instance from the known hosts and derives the environment name. `login` is also a top-level shortcut for `auth login`.
-- **Breaking:** `auth default` is now `auth activate` (no alias), and `auth logout` no longer deletes the environment — it clears only this machine's credentials (cached OAuth token, or an inline `pat` / `login`+`password`), leaving it ready for a zero-argument re-login. `--all` covers every environment; the old behaviour is `auth remove`.
+### Added
+
+- `bfabric-cli login` renews an expired token with **no arguments** — instance URL and scope are read back from the environment; a first login picks the instance from the known hosts and derives the environment name. Also a top-level shortcut for `auth login`.
+- `auth login --no-browser` prints the authorization URL instead of opening a browser (local machines only — over SSH use `auth device-code`).
+- `auth register` / `register-webapp` gain `--no-service-user`, and `--service-user` no longer silently defaults to "none": omitting it by accident (registering a client without the `client_credentials` grant) now fails fast.
+- New user guide: [Authentication](https://fgcz.github.io/bfabricPy/user_guides/bfabric-cli/authentication.html) — command surface, scopes, logout vs remove, remote hosts.
+
+### Changed
+
+- `auth default` is now `auth activate` (no alias). `auth logout` no longer deletes the environment — it clears only this machine's credentials (cached OAuth token, inline `pat` or `login`+`password`), leaving it ready for a zero-argument re-login; `--all` covers every environment, and the old behaviour is `auth remove`. It does not revoke the token server-side, which it now says.
 - `auth list` groups environments by instance and shows scope and token expiry; `list` and `status` mark *why* an environment is the active one.
 - Every `auth` command resolves the environment as `--config-env` > `BFABRICPY_CONFIG_ENV` > the configured default, and commands that write the config refuse to run under `BFABRICPY_CONFIG_OVERRIDE`.
-- Re-pointing an environment at a different instance URL now needs confirmation, and is refused non-interactively.
-- Base URLs are normalised up front: scheme defaulted, host lowercased, trailing slash dropped, bare known hosts expanded, non-http(s) rejected as input.
-- `auth login --no-browser` prints the authorization URL instead of opening a browser (local machines only — over SSH use `auth device-code`).
-- `auth logout` notes that it does not revoke the token server-side: an issued token stays valid until it expires, so only local access is removed.
-- New user guide: [Authentication](https://fgcz.github.io/bfabricPy/user_guides/bfabric-cli/authentication.html) — command surface, scopes, logout vs remove, remote hosts.
-- Packaging: `project.readme` now points at the package's own `README.md` instead of the repository root's, for the same reason as in `bfabric` — hatchling 1.32.0 rejects readme paths outside the project directory, breaking builds from source. The package README was expanded into a proper landing page, since it is what PyPI now shows.
-- `bfabric-cli auth register-webapp` — no longer crashes with a raw traceback when the OAuth session cannot be refreshed (e.g. an expired/revoked refresh token); prints a clean `Error: ...` message and exits 1.
-- `bfabric-cli auth register` — no longer prompts for an *Employee Bearer token* when a login already exists: with neither `--token` nor `--config-env` it authenticates as the environment in effect (`--config-env` > `BFABRICPY_CONFIG_ENV` > configured default), like every other `auth` command, so `auth login` followed by `auth register` just works. Pass `--token` to keep supplying one explicitly.
-- `bfabric-cli auth register` / `register-webapp` — `--service-user` no longer silently defaults to "none"; both now require either `--service-user LOGIN` or the new `--no-service-user` flag, so omitting a service user by accident (which registers a client without the `client_credentials` grant) fails fast with an explanatory error instead of succeeding silently.
-- Internal: login handlers normalised to `cmd_auth_*`; shared resolution in `cli/login/_common.py`, base-URL handling in a new `_urls.py`. `auth register` obtains its bearer token via `Bfabric.connect()` instead of rebuilding the credential-provider and token-cache lookup itself.
-- **Breaking:** `bfabric-cli workunit upload --force` is replaced by `--on-duplicate upload|skip|link`, which is also **the new default (`upload`)** — the duplicate check no longer runs unless you ask for it, so a re-upload of content the container already holds now transfers it again instead of being skipped. Pass `--on-duplicate skip` for the old default. `--on-duplicate link` gives the workunit a resource pointing at the already-stored bytes instead of omitting the file, without re-transferring content B-Fabric already stores; the final summary line reports the number linked when any were.
+- Re-pointing an environment at a different instance URL needs confirmation, and is refused non-interactively.
+- Base URLs are normalised up front: scheme defaulted, host lowercased, trailing slash dropped, bare known hosts expanded, non-http(s) rejected.
+- `workunit upload --force` is replaced by `--on-duplicate upload|skip|link`, and `upload` is the new default — the duplicate check no longer runs unless asked for, so a re-upload of content the container already holds transfers it again. Pass `skip` for the old behaviour, or `link` to give the workunit a resource pointing at the already-stored bytes instead of omitting the file.
+- Packaging: `project.readme` points at the package's own `README.md` (same hatchling 1.32.0 constraint as `bfabric`); the README was expanded into a proper landing page, since it is what PyPI shows.
+- Internal: login handlers normalised to `cmd_auth_*`; shared resolution in `cli/login/_common.py`, base-URL handling in a new `_urls.py`; `auth register` obtains its bearer token via `Bfabric.connect()` instead of rebuilding the credential-provider and token-cache lookup itself.
+
+### Fixed
+
+- `auth register-webapp` prints a clean `Error: ...` and exits 1 when the OAuth session cannot be refreshed (e.g. an expired/revoked refresh token), instead of a raw traceback.
+- `auth register` no longer prompts for an *Employee Bearer token* when a login already exists: with neither `--token` nor `--config-env` it authenticates as the environment in effect, so `auth login` followed by `auth register` just works. Pass `--token` to supply one explicitly.
 
 ## \[1.16.0\] - 2026-08-03
 

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -26,7 +26,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - Base URLs are normalised up front (scheme, host case, trailing slash, known-host expansion), and re-pointing an environment at a different instance needs confirmation.
 - `workunit upload --force` is replaced by `--on-duplicate upload|skip|link`, defaulting to `upload` — the duplicate check no longer runs unless asked for. Pass `skip` for the old behaviour.
 - Packaging: `project.readme` points at the package's own `README.md`, expanded into a proper landing page since PyPI shows it.
-- Internal: login handlers normalised to `cmd_auth_*`, shared resolution in `cli/login/_common.py`, base-URL handling in `_urls.py`; `auth register` gets its bearer token via `Bfabric.connect()`.
+- Internal: the `auth` command implementations were reorganised onto shared environment- and URL-resolution helpers.
 
 ### Fixed
 

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -12,26 +12,26 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 ### Added
 
-- `bfabric-cli login` renews an expired token with **no arguments** — instance URL and scope are read back from the environment; a first login picks the instance from the known hosts and derives the environment name. Also a top-level shortcut for `auth login`.
-- `auth login --no-browser` prints the authorization URL instead of opening a browser (local machines only — over SSH use `auth device-code`).
-- `auth register` / `register-webapp` gain `--no-service-user`, and `--service-user` no longer silently defaults to "none": omitting it by accident (registering a client without the `client_credentials` grant) now fails fast.
+- `bfabric-cli login` (also a top-level shortcut for `auth login`) renews an expired token with **no arguments**; a first login picks the instance from the known hosts and derives the environment name.
+- `auth login --no-browser` prints the authorization URL instead of opening one; over SSH use `auth device-code`.
+- `auth register` / `register-webapp` require `--service-user LOGIN` or the new `--no-service-user`, instead of silently registering without the `client_credentials` grant.
 - New user guide: [Authentication](https://fgcz.github.io/bfabricPy/user_guides/bfabric-cli/authentication.html) — command surface, scopes, logout vs remove, remote hosts.
 
 ### Changed
 
-- `auth default` is now `auth activate` (no alias). `auth logout` no longer deletes the environment — it clears only this machine's credentials (cached OAuth token, inline `pat` or `login`+`password`), leaving it ready for a zero-argument re-login; `--all` covers every environment, and the old behaviour is `auth remove`. It does not revoke the token server-side, which it now says.
-- `auth list` groups environments by instance and shows scope and token expiry; `list` and `status` mark *why* an environment is the active one.
-- Every `auth` command resolves the environment as `--config-env` > `BFABRICPY_CONFIG_ENV` > the configured default, and commands that write the config refuse to run under `BFABRICPY_CONFIG_OVERRIDE`.
-- Re-pointing an environment at a different instance URL needs confirmation, and is refused non-interactively.
-- Base URLs are normalised up front: scheme defaulted, host lowercased, trailing slash dropped, bare known hosts expanded, non-http(s) rejected.
-- `workunit upload --force` is replaced by `--on-duplicate upload|skip|link`, and `upload` is the new default — the duplicate check no longer runs unless asked for, so a re-upload of content the container already holds transfers it again. Pass `skip` for the old behaviour, or `link` to give the workunit a resource pointing at the already-stored bytes instead of omitting the file.
-- Packaging: `project.readme` points at the package's own `README.md` (same hatchling 1.32.0 constraint as `bfabric`); the README was expanded into a proper landing page, since it is what PyPI shows.
-- Internal: login handlers normalised to `cmd_auth_*`; shared resolution in `cli/login/_common.py`, base-URL handling in a new `_urls.py`; `auth register` obtains its bearer token via `Bfabric.connect()` instead of rebuilding the credential-provider and token-cache lookup itself.
+- `auth default` is now `auth activate`; deleting an environment is `auth remove`.
+- `auth logout` clears only this machine's credentials, leaving the environment ready for a zero-argument re-login (`--all` covers every environment). It does not revoke the token server-side.
+- `auth list` groups environments by instance and shows scope and token expiry; `list` and `status` mark *why* an environment is active.
+- Every `auth` command resolves its environment as `--config-env` > `BFABRICPY_CONFIG_ENV` > the configured default, and refuses to write the config under `BFABRICPY_CONFIG_OVERRIDE`.
+- Base URLs are normalised up front (scheme, host case, trailing slash, known-host expansion), and re-pointing an environment at a different instance needs confirmation.
+- `workunit upload --force` is replaced by `--on-duplicate upload|skip|link`, defaulting to `upload` — the duplicate check no longer runs unless asked for. Pass `skip` for the old behaviour.
+- Packaging: `project.readme` points at the package's own `README.md`, expanded into a proper landing page since PyPI shows it.
+- Internal: login handlers normalised to `cmd_auth_*`, shared resolution in `cli/login/_common.py`, base-URL handling in `_urls.py`; `auth register` gets its bearer token via `Bfabric.connect()`.
 
 ### Fixed
 
-- `auth register-webapp` prints a clean `Error: ...` and exits 1 when the OAuth session cannot be refreshed (e.g. an expired/revoked refresh token), instead of a raw traceback.
-- `auth register` no longer prompts for an *Employee Bearer token* when a login already exists: with neither `--token` nor `--config-env` it authenticates as the environment in effect, so `auth login` followed by `auth register` just works. Pass `--token` to supply one explicitly.
+- `auth register-webapp` prints `Error: ...` and exits 1 when the OAuth session cannot be refreshed, instead of a raw traceback.
+- `auth register` no longer prompts for an *Employee Bearer token* when a login exists; it authenticates as the environment in effect.
 
 ## \[1.16.0\] - 2026-08-03
 


### PR DESCRIPTION
- Move the release, release-candidate and hotfix procedure out of AGENTS.md into a new RELEASING.md, linked rather than inlined (AGENTS.md 2981 → 1492 words).
- Add AGENTS.md conventions for changelog entries and PR descriptions.
- Condense the `[Unreleased]` changelog sections of bfabric, bfabric_scripts and bfabric_app_runner into Keep a Changelog subsections, and drop the `Breaking:` labels on APIs that have no external consumers yet.
- Point CONTRIBUTING.md at RELEASING.md instead of its own stale copy of the release steps.

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.