### PR TITLE
fix(bfabric): canonicalise base_url without a trailing slash

### DIFF
--- a/.basedpyright/baseline.bfabric.json
+++ b/.basedpyright/baseline.bfabric.json
@@ -132,14 +132,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 96,
@@ -1079,14 +1071,6 @@
             }
         ],
         "./bfabric/src/bfabric/entities/core/uri.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportUnknownMemberType",
                 "range": {

--- a/bfabric/docs/api_reference/entity_uri/index.md
+++ b/bfabric/docs/api_reference/entity_uri/index.md
@@ -59,7 +59,7 @@ from bfabric.entities.core.uri import EntityUri
 uri = EntityUri("https://fgcz-bfabric.uzh.ch/bfabric/sample/show.html?id=123")
 
 # Access components
-print(uri.components.bfabric_instance)  # "https://fgcz-bfabric.uzh.ch/bfabric/"
+print(uri.components.bfabric_instance)  # "https://fgcz-bfabric.uzh.ch/bfabric"
 print(uri.components.entity_type)  # "sample"
 print(uri.components.entity_id)  # 123
 ```
@@ -94,7 +94,7 @@ from bfabric.entities.core.uri import EntityUri
 
 # Build URI from parts
 uri = EntityUri.from_components(
-    bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
+    bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric",
     entity_type="sample",
     entity_id=123,
 )
@@ -133,7 +133,7 @@ entities = reader.read_uris(uris)
 
 | Component | Description | Example |
 |-----------|-------------|---------|
-| `bfabric_instance` | Base URL of B-Fabric instance | `https://fgcz-bfabric.uzh.ch/bfabric/` |
+| `bfabric_instance` | Base URL of B-Fabric instance | `https://fgcz-bfabric.uzh.ch/bfabric` |
 | `entity_type` | Entity name (lowercase) | `sample`, `project`, `workunit` |
 | `entity_id` | Numeric entity ID | `123` |
 

--- a/bfabric/docs/api_reference/token_data/index.md
+++ b/bfabric/docs/api_reference/token_data/index.md
@@ -36,8 +36,8 @@ from bfabric import Bfabric
 from bfabric.experimental.webapp_integration_settings import TokenValidationSettings
 
 settings = TokenValidationSettings(
-    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
-    supported_bfabric_instances=["https://fgcz-bfabric.uzh.ch/bfabric/"],
+    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric",
+    supported_bfabric_instances=["https://fgcz-bfabric.uzh.ch/bfabric"],
 )
 
 client, token_data = Bfabric.connect_token(token=token, settings=settings)

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -9,6 +9,18 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ## \[Unreleased\]
 
+### Changed
+
+- **Breaking: `BfabricClientConfig.base_url` is canonicalised *without* a trailing slash**, reversing 1.15.0. Config files and `connect_*` arguments still accept one, and `EntityUri` strings are unchanged.
+- **Breaking: new `bfabric.BaseUrl`**, a `str` subclass holding a validated slash-free instance URL. It is now the type of `BfabricClientConfig.base_url`, `Entity.bfabric_instance` and `EntityUriComponents.bfabric_instance` (was a pydantic `HttpUrl`), and is required by `EntityReader`'s `bfabric_instance` arguments. A plain string still validates; only a type checker asks for `BaseUrl(...)`.
+- `connect_oauth` / `connect_pkce` / `connect_device_code` / `connect_pat` and `WebappClient.create` also normalise host case and a default port, and reject a non-HTTP URL with a `ValueError`.
+- `UrlTokenContext.base_url` and `bfabric.transfer.api_to_rest_url` return a `BaseUrl`.
+- `TokenValidationSettings` / `WebappIntegrationSettings` hold their instance URLs as `BaseUrl`, so a non-http one is rejected on parse and a trailing slash no longer has to match exactly.
+
+### Fixed
+
+- The SUDS WSDL URL, and the `show.html` links printed by `bfabric_read` and `bfabric-cli api read`, no longer contain a doubled slash.
+
 ## \[1.21.0\] - 2026-08-20
 
 ### Added

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -15,9 +15,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 ### Changed
 
-- **Breaking: `BfabricClientConfig.base_url` is canonicalised *without* a trailing slash**, reversing 1.15.0. Config files and `connect_*` arguments still accept one, and `EntityUri` strings are unchanged.
-- **Breaking: new `bfabric.BaseUrl`**, a `str` subclass holding a validated slash-free instance URL. It is now the type of `BfabricClientConfig.base_url`, `Entity.bfabric_instance` and `EntityUriComponents.bfabric_instance` (was a pydantic `HttpUrl`), and is required by `EntityReader`'s `bfabric_instance` arguments. A plain string still validates; only a type checker asks for `BaseUrl(...)`.
-- **Breaking: a `BaseUrl` must end in a `/bfabric` path segment**, so a bare host or a URL reaching past the servlet root is refused where it is configured rather than as a later 404 or instance mismatch. The error names the URL it was given and the one it takes to be meant. `bfabric-cli login`/`auth pat` complete a bare host, so `bfabric-cli login my-instance.example.com` still works.
+- **Breaking: new `bfabric.BaseUrl`**, a `str` subclass replacing the pydantic `HttpUrl` on `BfabricClientConfig.base_url`, `Entity.bfabric_instance` and `EntityUriComponents.bfabric_instance` it ensures the base_url always ends with `/bfabric`.
 - `connect_oauth` / `connect_pkce` / `connect_device_code` / `connect_pat` and `WebappClient.create` also normalise host case and a default port, and reject a non-HTTP URL with a `ValueError`.
 - `UrlTokenContext.base_url` returns a `BaseUrl`.
 - `TokenValidationSettings` / `WebappIntegrationSettings` hold their instance URLs as `BaseUrl`, so a non-http one is rejected on parse and a trailing slash no longer has to match exactly.

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -17,8 +17,9 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - **Breaking: `BfabricClientConfig.base_url` is canonicalised *without* a trailing slash**, reversing 1.15.0. Config files and `connect_*` arguments still accept one, and `EntityUri` strings are unchanged.
 - **Breaking: new `bfabric.BaseUrl`**, a `str` subclass holding a validated slash-free instance URL. It is now the type of `BfabricClientConfig.base_url`, `Entity.bfabric_instance` and `EntityUriComponents.bfabric_instance` (was a pydantic `HttpUrl`), and is required by `EntityReader`'s `bfabric_instance` arguments. A plain string still validates; only a type checker asks for `BaseUrl(...)`.
+- **Breaking: a `BaseUrl` must end in a `/bfabric` path segment**, so a bare host or a URL reaching past the servlet root is refused where it is configured rather than as a later 404 or instance mismatch. The error names the URL it was given and the one it takes to be meant. `bfabric-cli login`/`auth pat` complete a bare host, so `bfabric-cli login my-instance.example.com` still works.
 - `connect_oauth` / `connect_pkce` / `connect_device_code` / `connect_pat` and `WebappClient.create` also normalise host case and a default port, and reject a non-HTTP URL with a `ValueError`.
-- `UrlTokenContext.base_url` and `bfabric.transfer.api_to_rest_url` return a `BaseUrl`.
+- `UrlTokenContext.base_url` returns a `BaseUrl`.
 - `TokenValidationSettings` / `WebappIntegrationSettings` hold their instance URLs as `BaseUrl`, so a non-http one is rejected on parse and a trailing slash no longer has to match exactly.
 - `DuplicateResult` carries the `check-duplicates` response's `linkable` and `existingResourceStatus`, and `linkable` decides whether a duplicate may be linked. **Breaking:** `on_duplicate="link"` now requires a B-Fabric that reports `linkable`; a response omitting it is refused rather than guessed.
 - `on_duplicate="link"` only links to a duplicate the server reports as linkable; one whose resource is still `pending` or `failed` is uploaded instead, so a retry after a failed transfer no longer fails until B-Fabric's orphan cleanup runs.
@@ -31,6 +32,10 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ### Fixed
 
 - The SUDS WSDL URL, and the `show.html` links printed by `bfabric_read` and `bfabric-cli api read`, no longer contain a doubled slash.
+
+### Removed
+
+- **Breaking:** `bfabric.transfer.api_to_rest_url`. The REST endpoints hang off the instance URL, which `base_url` now always is, so it had become the identity function — use `client.config.base_url`.
 
 ## \[1.21.0\] - 2026-08-20
 

--- a/bfabric/docs/getting_started/configuration.md
+++ b/bfabric/docs/getting_started/configuration.md
@@ -19,13 +19,13 @@ GENERAL:
   default_config: PRODUCTION  # Default environment to use
 
 PRODUCTION:
-  base_url: https://fgcz-bfabric.uzh.ch/bfabric/
+  base_url: https://fgcz-bfabric.uzh.ch/bfabric
   auth_method: oauth
   client_id: CLI
   scope: api:read
 
 TEST:
-  base_url: https://fgcz-bfabric-test.uzh.ch/bfabric/
+  base_url: https://fgcz-bfabric-test.uzh.ch/bfabric
   auth_method: oauth
   client_id: CLI
   scope: api:write
@@ -41,7 +41,7 @@ scopes and for managing several environments.
 
 ```yaml
 PRODUCTION:
-  base_url: https://fgcz-bfabric.uzh.ch/bfabric/
+  base_url: https://fgcz-bfabric.uzh.ch/bfabric
   auth_method: pat
   pat: yourPersonalAccessToken
 ```
@@ -58,7 +58,7 @@ An environment can also hold a login and web service password directly:
 PRODUCTION:
   login: yourBfabricLogin
   password: yourBfabricWebServicePassword  # Get from B-Fabric profile
-  base_url: https://fgcz-bfabric.uzh.ch/bfabric/
+  base_url: https://fgcz-bfabric.uzh.ch/bfabric
 ```
 
 The password here is **NOT** your login password. Find your web service password:
@@ -116,7 +116,7 @@ python script.py  # Will use TEST environment
 Complete configuration override (highest priority). Used primarily for integration tests, where it needs to be prevented that the regular config file leads to the wrong B-Fabric instance being modified.
 
 ```bash
-export BFABRICPY_CONFIG_OVERRIDE='{"client": {"base_url": "https://fgcz-bfabric.uzh.ch/bfabric/"}, "auth": {"login": "myuser", "password": "mypass"}}'
+export BFABRICPY_CONFIG_OVERRIDE='{"client": {"base_url": "https://fgcz-bfabric.uzh.ch/bfabric"}, "auth": {"login": "myuser", "password": "mypass"}}'
 python script.py  # Uses this config, ignoring ~/.bfabricpy.yml
 ```
 
@@ -139,7 +139,7 @@ from bfabric.config import BfabricAuth, BfabricClientConfig
 
 # Create config programmatically
 client_config = BfabricClientConfig(
-    base_url="https://fgcz-bfabric.uzh.ch/bfabric/",
+    base_url="https://fgcz-bfabric.uzh.ch/bfabric",
 )
 
 auth = BfabricAuth(

--- a/bfabric/docs/getting_started/configuration.md
+++ b/bfabric/docs/getting_started/configuration.md
@@ -35,6 +35,13 @@ The token itself is not stored here — it lives in a separate cache under `~/.b
 `Bfabric.connect()` refreshes it as needed. See [CLI Authentication](../user_guides/bfabric-cli/authentication.md) for
 scopes and for managing several environments.
 
+### base_url
+
+`base_url` is the instance's servlet root and must end in `/bfabric` — everything else is derived from
+it, so a host on its own (`https://fgcz-bfabric.uzh.ch`) or a URL reaching further in
+(`https://fgcz-bfabric.uzh.ch/bfabric/api`) is rejected when the config loads. A trailing slash is
+accepted and dropped. `bfabric-cli login fgcz-bfabric.uzh.ch` completes a bare host for you.
+
 ### Personal Access Tokens
 
 `bfabric-cli auth pat` stores a token inline instead, for non-interactive logins:

--- a/bfabric/docs/getting_started/troubleshooting.md
+++ b/bfabric/docs/getting_started/troubleshooting.md
@@ -54,7 +54,7 @@ GENERAL:
 PRODUCTION:
   login: yourBfabricLogin
   password: yourBfabricWebServicePassword
-  base_url: https://fgcz-bfabric.uzh.ch/bfabric/
+  base_url: https://fgcz-bfabric.uzh.ch/bfabric
 ```
 
 ## Query Issues
@@ -148,8 +148,8 @@ print(f"User: {client.auth.login}")
 
 Common URLs:
 
-- **Production**: `https://fgcz-bfabric.uzh.ch/bfabric/`
-- **Test**: `https://fgcz-bfabric-test.uzh.ch/bfabric/`
+- **Production**: `https://fgcz-bfabric.uzh.ch/bfabric`
+- **Test**: `https://fgcz-bfabric-test.uzh.ch/bfabric`
 
 If you're connecting to the wrong instance, update your config file or use a different environment:
 

--- a/bfabric/docs/getting_started/troubleshooting.md
+++ b/bfabric/docs/getting_started/troubleshooting.md
@@ -41,6 +41,19 @@ Check that you haven't named it incorrectly (e.g., `.bfabric.yml` instead of `.b
 - Ensure you're using your **web service password**, not your login password
 - Check that password doesn't contain special characters that need escaping in YAML
 
+### "is not a B-Fabric instance URL"
+
+`base_url` has to name the instance's servlet root, which ends in `/bfabric`. The error quotes the URL
+it got and the one you probably meant:
+
+```
+'https://fgcz-bfabric.uzh.ch' is not a B-Fabric instance URL: it must end in '/bfabric' --
+did you mean 'https://fgcz-bfabric.uzh.ch/bfabric'?
+```
+
+Fix `base_url` in `~/.bfabricpy.yml` (or the `connect_*` argument) to the suggested value. The same
+applies to a URL that reaches past the servlet root, such as one ending in `/bfabric/api`.
+
 ### "No default_config found"
 
 Add a `default_config` field under the `GENERAL` section in your config file:
@@ -177,6 +190,7 @@ Still stuck?
 | Config file in wrong location | "Configuration file not found" | Ensure `~/.bfabricpy.yml` (not `.bfabric.yml`) |
 | Wrong environment variable | Querying wrong instance | Check `BFABRICPY_CONFIG_ENV` value |
 | Missing default_config | "No default_config found" | Add `default_config` field under `GENERAL` section |
+| `base_url` without the `/bfabric` path | "is not a B-Fabric instance URL" | Use the URL the error suggests |
 | Typos in filter names | No results or errors | Use `bfabric-cli api inspect` to check valid parameter names |
 
 ## Next Steps

--- a/bfabric/docs/user_guides/connecting/interactive_scripted_usage.md
+++ b/bfabric/docs/user_guides/connecting/interactive_scripted_usage.md
@@ -113,7 +113,7 @@ An environment can also hold a B-Fabric login and web service password directly:
 PRODUCTION:
   login: yourBfabricLogin
   password: yourBfabricWebServicePassword
-  base_url: https://fgcz-bfabric.uzh.ch/bfabric/
+  base_url: https://fgcz-bfabric.uzh.ch/bfabric
 ```
 
 `Bfabric.connect()` uses these the same way — the auth method is a property of the environment, not of the call.

--- a/bfabric/docs/user_guides/connecting/server_webapp_usage.md
+++ b/bfabric/docs/user_guides/connecting/server_webapp_usage.md
@@ -76,10 +76,10 @@ from bfabric.experimental.webapp_integration_settings import TokenValidationSett
 
 # Configure which B-Fabric instances are allowed
 settings = TokenValidationSettings(
-    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
+    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric",
     supported_bfabric_instances=[
-        "https://fgcz-bfabric.uzh.ch/bfabric/",
-        "https://fgcz-bfabric-test.uzh.ch/bfabric/",
+        "https://fgcz-bfabric.uzh.ch/bfabric",
+        "https://fgcz-bfabric-test.uzh.ch/bfabric",
     ],
 )
 
@@ -108,12 +108,12 @@ from bfabric import Bfabric
 from bfabric.rest.token_data import get_token_data
 
 # Validate token first
-base_url = "https://fgcz-bfabric.uzh.ch/bfabric/"
+base_url = "https://fgcz-bfabric.uzh.ch/bfabric"
 token = "your_token_here"
 token_data = get_token_data(base_url=base_url, token=token)
 
 # Check if the token is from an allowed instance
-allowed_instances = ["https://fgcz-bfabric.uzh.ch/bfabric/"]
+allowed_instances = ["https://fgcz-bfabric.uzh.ch/bfabric"]
 if token_data.caller not in allowed_instances:
     raise ValueError(f"Token from {token_data.caller} is not allowed")
 
@@ -131,10 +131,10 @@ The `TokenValidationSettings` class configures which B-Fabric instances are allo
 from bfabric.experimental.webapp_integration_settings import TokenValidationSettings
 
 settings = TokenValidationSettings(
-    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
+    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric",
     supported_bfabric_instances=[
-        "https://fgcz-bfabric.uzh.ch/bfabric/",
-        "https://fgcz-bfabric-test.uzh.ch/bfabric/",
+        "https://fgcz-bfabric.uzh.ch/bfabric",
+        "https://fgcz-bfabric-test.uzh.ch/bfabric",
     ],
 )
 ```
@@ -157,10 +157,10 @@ from bfabric.experimental.webapp_integration_settings import WebappIntegrationSe
 from bfabric.config import BfabricAuth
 
 settings = WebappIntegrationSettings(
-    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
-    supported_bfabric_instances=["https://fgcz-bfabric.uzh.ch/bfabric/"],
+    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric",
+    supported_bfabric_instances=["https://fgcz-bfabric.uzh.ch/bfabric"],
     feeder_user_credentials={
-        "https://fgcz-bfabric.uzh.ch/bfabric/": BfabricAuth(
+        "https://fgcz-bfabric.uzh.ch/bfabric": BfabricAuth(
             login="feeder_user", password="feeder_user_password"
         ),
     },
@@ -184,10 +184,10 @@ Always restrict `supported_bfabric_instances` to only the instances you trust:
 
 ```python
 settings = TokenValidationSettings(
-    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric/",
+    validation_bfabric_instance="https://fgcz-bfabric.uzh.ch/bfabric",
     supported_bfabric_instances=[
-        "https://fgcz-bfabric.uzh.ch/bfabric/",  # Only allow production
-        # "https://fgcz-bfabric-test.uzh.ch/bfabric/",  # Commented out to prevent test tokens
+        "https://fgcz-bfabric.uzh.ch/bfabric",  # Only allow production
+        # "https://fgcz-bfabric-test.uzh.ch/bfabric",  # Commented out to prevent test tokens
     ],
 )
 ```

--- a/bfabric/docs/user_guides/reading_data/entity_api.md
+++ b/bfabric/docs/user_guides/reading_data/entity_api.md
@@ -78,7 +78,7 @@ sample = reader.read_id(entity_type="sample", entity_id=123)
 # Entity identifier
 print(sample.id)  # 123
 print(sample.classname)  # "sample"
-print(sample.bfabric_instance)  # "https://fgcz-bfabric.uzh.ch/bfabric/"
+print(sample.bfabric_instance)  # "https://fgcz-bfabric.uzh.ch/bfabric"
 
 # Entity URI
 uri = sample.uri

--- a/bfabric/src/bfabric/__init__.py
+++ b/bfabric/src/bfabric/__init__.py
@@ -1,10 +1,12 @@
 import importlib.metadata
 
 from bfabric.bfabric import Bfabric
+from bfabric.config.base_url import BaseUrl
 from bfabric.config.bfabric_auth import BfabricAuth
 from bfabric.config.bfabric_client_config import BfabricAPIEngineType, BfabricClientConfig
 
 __all__ = [
+    "BaseUrl",
     "Bfabric",
     "BfabricAPIEngineType",
     "BfabricAuth",

--- a/bfabric/src/bfabric/bfabric.py
+++ b/bfabric/src/bfabric/bfabric.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from loguru import logger
 from rich.console import Console
 
-from bfabric.config import DEFAULT_CONFIG_FILE, BfabricAuth, BfabricClientConfig
+from bfabric.config import DEFAULT_CONFIG_FILE, BaseUrl, BfabricAuth, BfabricClientConfig
 from bfabric.config.config_data import ConfigData, load_config_data
 from bfabric.config.config_file import read_config_file
 from bfabric.engine.engine_suds import EngineSUDS
@@ -116,7 +116,7 @@ class Bfabric:
         from bfabric.oauth._credential_provider import OAuthCredentialProvider
         from bfabric.oauth._token_cache import TokenCache, compute_token_cache_path
 
-        base_url = config_data.client.base_url.rstrip("/")
+        base_url = config_data.client.base_url
         if not config_data.client_id:
             raise ValueError(
                 "OAuth config is missing 'client_id'. Set it in the config environment "
@@ -183,7 +183,7 @@ class Bfabric:
         cls,
         token: str,
         *,
-        validation_instance_url: str = "https://fgcz-bfabric.uzh.ch/bfabric/",
+        validation_instance_url: str = "https://fgcz-bfabric.uzh.ch/bfabric",
         config_file_path: None = None,
         config_file_env: None = None,
     ) -> tuple[Bfabric, TokenData]:
@@ -241,13 +241,12 @@ class Bfabric:
 
         :param client_id: OAuth client ID (from ``register_client`` or admin setup)
         :param client_secret: OAuth client secret
-        :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
         :param scope: OAuth scope
         :param token_cache_path: Optional path to cache tokens on disk (survives restarts)
         """
         from bfabric.oauth._credential_provider import OAuthCredentialProvider
 
-        base_url = base_url.rstrip("/")
+        base_url = BaseUrl(base_url)
         token_url = f"{base_url}/rest/oauth/token"
         provider = OAuthCredentialProvider(
             client_id=client_id,
@@ -257,8 +256,7 @@ class Bfabric:
             grant_type="client_credentials",
             token_cache_path=token_cache_path,
         )
-        config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
-        config_data = ConfigData(client=config, auth=None)
+        config_data = ConfigData(client=BfabricClientConfig(base_url=base_url), auth=None)
         return cls(config_data=config_data, _credential_provider=provider)
 
     @classmethod
@@ -279,7 +277,6 @@ class Bfabric:
         the user logs in, tokens are exchanged automatically and the returned
         client uses :class:`OAuthCredentialProvider` for transparent refresh.
 
-        :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
         :param client_id: OAuth client ID
         :param scope: OAuth scope
         :param port: Local port for the callback server (``0`` = auto-assign)
@@ -290,7 +287,7 @@ class Bfabric:
         from bfabric.oauth._credential_provider import OAuthCredentialProvider
         from bfabric.oauth._pkce import pkce_login
 
-        base_url = base_url.rstrip("/")
+        base_url = BaseUrl(base_url)
         token = pkce_login(
             base_url,
             client_id=client_id,
@@ -309,8 +306,7 @@ class Bfabric:
             scope=scope,
             token_cache_path=token_cache_path,
         )
-        config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
-        config_data = ConfigData(client=config, auth=None)
+        config_data = ConfigData(client=BfabricClientConfig(base_url=base_url), auth=None)
         return cls(config_data=config_data, _credential_provider=provider)
 
     @classmethod
@@ -333,7 +329,6 @@ class Bfabric:
         This flow is suitable for headless environments (SSH, containers)
         where a localhost redirect is not feasible.
 
-        :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
         :param client_id: OAuth client ID
         :param scope: OAuth scope
         :param timeout: Seconds to wait for the user to authorize
@@ -342,7 +337,7 @@ class Bfabric:
         from bfabric.oauth._credential_provider import OAuthCredentialProvider
         from bfabric.oauth._device_code import device_code_login
 
-        base_url = base_url.rstrip("/")
+        base_url = BaseUrl(base_url)
         token = device_code_login(
             base_url,
             client_id=client_id,
@@ -359,8 +354,7 @@ class Bfabric:
             scope=scope,
             token_cache_path=token_cache_path,
         )
-        config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
-        config_data = ConfigData(client=config, auth=None)
+        config_data = ConfigData(client=BfabricClientConfig(base_url=base_url), auth=None)
         return cls(config_data=config_data, _credential_provider=provider)
 
     @classmethod
@@ -376,17 +370,16 @@ class Bfabric:
         API accepts them directly. There is no automatic refresh; if the token
         expires a new one must be obtained.
 
-        :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
         :param pat: Personal Access Token (string or ``SecretStr``)
         """
         from pydantic import SecretStr
 
         from bfabric.config.bfabric_auth import OAUTH_LOGIN
 
-        base_url = base_url.rstrip("/")
+        base_url = BaseUrl(base_url)
         pat_value: str = pat.get_secret_value() if isinstance(pat, SecretStr) else pat
         auth = BfabricAuth(login=OAUTH_LOGIN, password=SecretStr(pat_value))
-        config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
+        config = BfabricClientConfig(base_url=base_url)
         config_data = ConfigData(client=config, auth=auth)
         return cls(config_data=config_data)
 
@@ -662,6 +655,7 @@ def get_system_auth(
     )
 
     resolved_path = Path(config_path or "~/.bfabricpy.yml").expanduser()
+    canonical_base_url = BaseUrl(base_url) if base_url is not None else None
 
     # Use the provided config data from arguments instead of the file
     if not resolved_path.is_file():
@@ -669,13 +663,13 @@ def get_system_auth(
             # NOTE: If user explicitly specifies a path to a wrong config file, this has to be an exception
             raise OSError(f"Explicitly specified config file does not exist: {resolved_path}")
         logger.warning(f"could not find the config file in the default location: {resolved_path}")
-        config = BfabricClientConfig(base_url=base_url)
+        config = BfabricClientConfig(base_url=canonical_base_url)  # pyright: ignore[reportArgumentType]
         auth = None if login is None or password is None else BfabricAuth(login=login, password=password)
 
     # Load config from file, override some of the fields with the provided ones
     else:
         config, auth = read_config_file(resolved_path, config_env=config_env)
-        config = config.copy_with(base_url=base_url)
+        config = config.copy_with(base_url=canonical_base_url)
         if (login is not None) and (password is not None):
             auth = BfabricAuth(login=login, password=password)
         elif (login is None) and (password is None):

--- a/bfabric/src/bfabric/config/__init__.py
+++ b/bfabric/src/bfabric/config/__init__.py
@@ -1,5 +1,6 @@
+from .base_url import BaseUrl
 from .bfabric_auth import BfabricAuth
 from .bfabric_client_config import BfabricClientConfig
 from .config_file import ConfigFile, DEFAULT_CONFIG_FILE
 
-__all__ = ["BfabricAuth", "BfabricClientConfig", "ConfigFile", "DEFAULT_CONFIG_FILE"]
+__all__ = ["BfabricAuth", "BfabricClientConfig", "BaseUrl", "ConfigFile", "DEFAULT_CONFIG_FILE"]

--- a/bfabric/src/bfabric/config/base_url.py
+++ b/bfabric/src/bfabric/config/base_url.py
@@ -1,0 +1,30 @@
+"""The type of a B-Fabric instance base URL."""
+
+from __future__ import annotations
+
+from pydantic import AnyHttpUrl, GetCoreSchemaHandler, TypeAdapter, ValidationError
+from pydantic_core import core_schema
+
+
+class BaseUrl(str):
+    """A validated B-Fabric instance base URL, without a trailing slash, e.g. ``https://x.uzh.ch/bfabric``.
+
+    A ``str`` subclass, because the value is interpolated into request URLs and used as a cache key --
+    while still being a type the checker can tell apart from a string that never passed through here.
+    Construction is idempotent, which is what a cache key needs.
+    """
+
+    def __new__(cls, value: str) -> BaseUrl:
+        if isinstance(value, cls):
+            return value
+        try:
+            url = TypeAdapter(AnyHttpUrl).validate_python(value)
+        except ValidationError as error:
+            raise ValueError(f"Not a valid http(s) URL: {value!r}") from error
+        # The strip has to come after validation: AnyHttpUrl re-adds the slash for an empty path.
+        return super().__new__(cls, str(url).rstrip("/"))
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: object, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
+        _ = source_type, handler
+        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())

--- a/bfabric/src/bfabric/config/base_url.py
+++ b/bfabric/src/bfabric/config/base_url.py
@@ -2,8 +2,39 @@
 
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 from pydantic import AnyHttpUrl, GetCoreSchemaHandler, TypeAdapter, ValidationError
 from pydantic_core import core_schema
+
+_SERVLET = "bfabric"
+"""The path segment every B-Fabric instance is served under.
+
+Already assumed throughout: ``EngineSUDS`` fetches ``{base_url}/{endpoint}?wsdl`` and ``EntityUri``
+rejects a URI whose first path segment is not this, so a base URL that stops short of the servlet
+(or reaches past it) cannot work. Requiring it here turns a later 404 -- or an
+``Unsupported B-Fabric instances`` mismatch against a URI-derived instance -- into one error at
+config load.
+"""
+
+
+def _segments(path: str) -> list[str]:
+    return [segment for segment in path.split("/") if segment]
+
+
+def _nearest_instance_url(canonical: str) -> str:
+    """The instance URL *canonical* was probably meant to be: truncated at its ``bfabric`` segment, else appended.
+
+    Covers the two mistakes actually seen: a bare host, and a URL reaching past the servlet root
+    (a REST endpoint copied out of a log).
+    """
+    parts = urlsplit(canonical)
+    segments = _segments(parts.path)
+    if _SERVLET in segments:
+        segments = segments[: segments.index(_SERVLET) + 1]
+    else:
+        segments.append(_SERVLET)
+    return f"{parts.scheme}://{parts.netloc}/" + "/".join(segments)
 
 
 class BaseUrl(str):
@@ -22,7 +53,18 @@ class BaseUrl(str):
         except ValidationError as error:
             raise ValueError(f"Not a valid http(s) URL: {value!r}") from error
         # The strip has to come after validation: AnyHttpUrl re-adds the slash for an empty path.
-        return super().__new__(cls, str(url).rstrip("/"))
+        canonical = str(url).rstrip("/")
+        parts = urlsplit(canonical)
+        segments = _segments(parts.path)
+        # The last path segment, not a string suffix -- `https://bfabric` would pass that while
+        # naming a host rather than a servlet. A query or fragment is refused too: it would survive
+        # into every interpolated request URL.
+        if not segments or segments[-1] != _SERVLET or parts.query or parts.fragment:
+            raise ValueError(
+                f"{value!r} is not a B-Fabric instance URL: it must end in {'/' + _SERVLET!r} -- "
+                f"did you mean {_nearest_instance_url(canonical)!r}?"
+            )
+        return super().__new__(cls, canonical)
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type: object, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:

--- a/bfabric/src/bfabric/config/base_url.py
+++ b/bfabric/src/bfabric/config/base_url.py
@@ -4,46 +4,12 @@ from __future__ import annotations
 
 from urllib.parse import urlsplit
 
-from pydantic import AnyHttpUrl, GetCoreSchemaHandler, TypeAdapter, ValidationError
+from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
 from pydantic_core import core_schema
-
-_SERVLET = "bfabric"
-"""The path segment every B-Fabric instance is served under.
-
-Already assumed throughout: ``EngineSUDS`` fetches ``{base_url}/{endpoint}?wsdl`` and ``EntityUri``
-rejects a URI whose first path segment is not this, so a base URL that stops short of the servlet
-(or reaches past it) cannot work. Requiring it here turns a later 404 -- or an
-``Unsupported B-Fabric instances`` mismatch against a URI-derived instance -- into one error at
-config load.
-"""
-
-
-def _segments(path: str) -> list[str]:
-    return [segment for segment in path.split("/") if segment]
-
-
-def _nearest_instance_url(canonical: str) -> str:
-    """The instance URL *canonical* was probably meant to be: truncated at its ``bfabric`` segment, else appended.
-
-    Covers the two mistakes actually seen: a bare host, and a URL reaching past the servlet root
-    (a REST endpoint copied out of a log).
-    """
-    parts = urlsplit(canonical)
-    segments = _segments(parts.path)
-    if _SERVLET in segments:
-        segments = segments[: segments.index(_SERVLET) + 1]
-    else:
-        segments.append(_SERVLET)
-    return f"{parts.scheme}://{parts.netloc}/" + "/".join(segments)
 
 
 class BaseUrl(str):
-    """A validated B-Fabric instance base URL, without a trailing slash, e.g. ``https://x.uzh.ch/bfabric``.
-
-    A ``str`` subclass, because the value is interpolated into request URLs and used as a cache key --
-    while still being a type the checker can tell apart from a string that never passed through here.
-    Construction is idempotent, which is what a cache key needs.
-    """
+    """A validated B-Fabric instance URL, of the form ``http[s]://<host>/bfabric``."""
 
     def __new__(cls, value: str) -> BaseUrl:
         if isinstance(value, cls):
@@ -52,21 +18,13 @@ class BaseUrl(str):
             url = TypeAdapter(AnyHttpUrl).validate_python(value)
         except ValidationError as error:
             raise ValueError(f"Not a valid http(s) URL: {value!r}") from error
-        # The strip has to come after validation: AnyHttpUrl re-adds the slash for an empty path.
-        canonical = str(url).rstrip("/")
-        parts = urlsplit(canonical)
-        segments = _segments(parts.path)
-        # The last path segment, not a string suffix -- `https://bfabric` would pass that while
-        # naming a host rather than a servlet. A query or fragment is refused too: it would survive
-        # into every interpolated request URL.
-        if not segments or segments[-1] != _SERVLET or parts.query or parts.fragment:
-            raise ValueError(
-                f"{value!r} is not a B-Fabric instance URL: it must end in {'/' + _SERVLET!r} -- "
-                f"did you mean {_nearest_instance_url(canonical)!r}?"
-            )
-        return super().__new__(cls, canonical)
+        # Check that the URL ends in `/bfabric`.
+        parts = urlsplit(str(url).rstrip("/"))
+        segments = [segment for segment in parts.path.split("/") if segment]
+        if segments[-1:] != ["bfabric"] or parts.query or parts.fragment:
+            raise ValueError(f"{value!r} is not a B-Fabric instance URL: it must end in '/bfabric'")
+        return super().__new__(cls, parts.geturl())
 
     @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: object, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
-        _ = source_type, handler
+    def __get_pydantic_core_schema__(cls, _source: object, _handler: object) -> core_schema.CoreSchema:
         return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())

--- a/bfabric/src/bfabric/config/bfabric_client_config.py
+++ b/bfabric/src/bfabric/config/bfabric_client_config.py
@@ -1,19 +1,10 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Annotated
 
-from pydantic import AfterValidator, AnyHttpUrl, BaseModel, Field, TypeAdapter
+from pydantic import BaseModel, Field
 
-
-def _validate_base_url(value: str) -> str:
-    """Validates that the base URL is indeed a valid HTTP URL and ensures it ends with a slash."""
-    value = value.rstrip("/") + "/"
-    http_url = TypeAdapter(AnyHttpUrl).validate_python(value)
-    return str(http_url)
-
-
-_ValidatedBaseUrl = Annotated[str, AfterValidator(_validate_base_url)]
+from bfabric.config.base_url import BaseUrl
 
 
 class BfabricAPIEngineType(StrEnum):
@@ -28,20 +19,19 @@ class BfabricAPIEngineType(StrEnum):
 class BfabricClientConfig(BaseModel):
     """Holds the configuration for the B-Fabric client for connecting to particular instance of B-Fabric.
 
-    :param base_url: The API base url
     :param application_ids (optional): Map of application names to ids.
     :param job_notification_emails (optional): Space-separated list of email addresses to notify when a job finishes.
     :param engine: The API engine to use (optional).
     """
 
-    base_url: _ValidatedBaseUrl
-    application_ids: Annotated[dict[str, int], Field(default_factory=dict)]
-    job_notification_emails: Annotated[str, Field(default="")]
+    base_url: BaseUrl
+    application_ids: dict[str, int] = Field(default_factory=dict)
+    job_notification_emails: str = ""
     engine: BfabricAPIEngineType = BfabricAPIEngineType.SUDS
 
     def copy_with(
         self,
-        base_url: str | None = None,
+        base_url: BaseUrl | None = None,
         application_ids: dict[str, int] | None = None,
     ) -> BfabricClientConfig:
         """Returns a copy of the configuration with new values applied, if they are not None."""

--- a/bfabric/src/bfabric/config/config_writer.py
+++ b/bfabric/src/bfabric/config/config_writer.py
@@ -1,6 +1,6 @@
 """Write environment entries to the bfabricpy YAML config file.
 
-Note: rewriting the file drops any YAML comments in it (``yaml.dump`` doesn't preserve them).
+Note: rewriting the file drops any YAML comments in it (``yaml.safe_dump`` doesn't preserve them).
 """
 
 from __future__ import annotations
@@ -27,6 +27,13 @@ _AUTH_OWNED_KEYS = frozenset({"login", "password", "pat", "auth_method", "client
 _INLINE_SECRET_KEYS: tuple[str, ...] = ("login", "password", "pat")
 
 
+def _plain(value: object) -> object:
+    """*value* with ``str`` subclasses (e.g. ``BaseUrl``) unwrapped, which ``safe_dump`` rejects."""
+    if isinstance(value, dict):
+        return {key: _plain(item) for key, item in cast("dict[object, object]", value).items()}
+    return str(value) if isinstance(value, str) else value
+
+
 def _read_config_file(config_path: Path) -> dict[str, object]:
     """Raw YAML mapping at *config_path*, empty if it is absent or not a mapping."""
     config_path = Path(config_path).expanduser()
@@ -40,7 +47,7 @@ def _write_config_file(config_path: Path, data: Mapping[str, object]) -> None:
     """Serialize *data* to *config_path* as YAML, mode ``0o600`` (fchmod forces it on existing files)."""
     config_path = Path(config_path).expanduser()
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    serialized = yaml.dump(data, default_flow_style=False, sort_keys=False).encode()
+    serialized = yaml.safe_dump(_plain(data), default_flow_style=False, sort_keys=False).encode()
     fd = os.open(str(config_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
         os.fchmod(fd, 0o600)

--- a/bfabric/src/bfabric/engine/engine_suds.py
+++ b/bfabric/src/bfabric/engine/engine_suds.py
@@ -17,14 +17,14 @@ from bfabric.results.result_container import ResultContainer
 if TYPE_CHECKING:
     from suds.serviceproxy import ServiceProxy
 
-    from bfabric.config import BfabricAuth
+    from bfabric.config import BaseUrl, BfabricAuth
     from bfabric.typing import ApiRequestObjectType
 
 
 class EngineSUDS:
     """B-Fabric API SUDS Engine."""
 
-    def __init__(self, base_url: str, drop_underscores: bool = True) -> None:
+    def __init__(self, base_url: BaseUrl, drop_underscores: bool = True) -> None:
         self._cl = {}
         self._base_url = base_url
         self._drop_underscores = drop_underscores

--- a/bfabric/src/bfabric/entities/core/entity.py
+++ b/bfabric/src/bfabric/entities/core/entity.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any
 
-    from bfabric import Bfabric
+    from bfabric import BaseUrl, Bfabric
     from bfabric.entities.core.references import References
     from bfabric.typing import ApiResponseDataType, ApiResponseObjectType
 
@@ -25,7 +25,7 @@ class Entity(FindMixin):
         self,
         data_dict: ApiResponseObjectType,
         client: Bfabric | None = None,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
     ) -> None:
         # note: client may be removed completely in the future,
         #       as I think it is a design mistake to have put them into these classes
@@ -51,7 +51,7 @@ class Entity(FindMixin):
         return value
 
     @property
-    def bfabric_instance(self) -> str:
+    def bfabric_instance(self) -> BaseUrl:
         """The bfabric instance URL associated with the entity."""
         return self.__bfabric_instance
 
@@ -148,7 +148,7 @@ class Entity(FindMixin):
             yaml.safe_dump(self.__data_dict, file)
 
     @classmethod
-    def load_yaml(cls, path: Path, client: Bfabric | None = None, bfabric_instance: str | None = None) -> Self:
+    def load_yaml(cls, path: Path, client: Bfabric | None = None, bfabric_instance: BaseUrl | None = None) -> Self:
         """Loads an entity from a YAML file."""
         # TODO (#351): to be extended
         import yaml

--- a/bfabric/src/bfabric/entities/core/entity_reader.py
+++ b/bfabric/src/bfabric/entities/core/entity_reader.py
@@ -13,7 +13,7 @@ from bfabric.experimental import MultiQuery
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-    from bfabric import Bfabric
+    from bfabric import BaseUrl, Bfabric
     from bfabric.typing import ApiRequestObjectType, ApiResponseDataType, ApiResponseObjectType
 
 
@@ -144,24 +144,26 @@ class EntityReader:
 
     @overload
     def read_id(
-        self, entity_type: type[EntityT], entity_id: int | str, bfabric_instance: str | None = None
+        self, entity_type: type[EntityT], entity_id: int | str, bfabric_instance: BaseUrl | None = None
     ) -> EntityT | None: ...
     @overload
     def read_id(
         self,
         entity_type: str,
         entity_id: int | str,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         *,
         expected_type: type[EntityT],
     ) -> EntityT | None: ...
     @overload
-    def read_id(self, entity_type: str, entity_id: int | str, bfabric_instance: str | None = None) -> Entity | None: ...
+    def read_id(
+        self, entity_type: str, entity_id: int | str, bfabric_instance: BaseUrl | None = None
+    ) -> Entity | None: ...
     def read_id(
         self,
         entity_type: str | type[EntityT],
         entity_id: int | str,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         *,
         expected_type: type[EntityT] = Entity,
     ) -> EntityT | None:
@@ -191,26 +193,29 @@ class EntityReader:
 
     @overload
     def read_ids(
-        self, entity_type: type[EntityT], entity_ids: Sequence[int | str], bfabric_instance: str | None = None
+        self,
+        entity_type: type[EntityT],
+        entity_ids: Sequence[int | str],
+        bfabric_instance: BaseUrl | None = None,
     ) -> EntityResult[EntityT]: ...
     @overload
     def read_ids(
         self,
         entity_type: str,
         entity_ids: Sequence[int | str],
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         *,
         expected_type: type[EntityT],
     ) -> EntityResult[EntityT]: ...
     @overload
     def read_ids(
-        self, entity_type: str, entity_ids: Sequence[int | str], bfabric_instance: str | None = None
+        self, entity_type: str, entity_ids: Sequence[int | str], bfabric_instance: BaseUrl | None = None
     ) -> EntityResult[Entity]: ...
     def read_ids(
         self,
         entity_type: str | type[EntityT],
         entity_ids: Sequence[int | str],
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         *,
         expected_type: type[EntityT] = Entity,
     ) -> EntityResult[EntityT]:
@@ -239,7 +244,7 @@ class EntityReader:
         self,
         entity_type: type[EntityT],
         obj: ApiRequestObjectType,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         max_results: int | None = 100,
     ) -> dict[EntityUri, EntityT]: ...
     @overload
@@ -247,7 +252,7 @@ class EntityReader:
         self,
         entity_type: str,
         obj: ApiRequestObjectType,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         max_results: int | None = 100,
         *,
         expected_type: type[EntityT],
@@ -257,14 +262,14 @@ class EntityReader:
         self,
         entity_type: str,
         obj: ApiRequestObjectType,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         max_results: int | None = 100,
     ) -> dict[EntityUri, Entity]: ...
     def query(
         self,
         entity_type: str | type[EntityT],
         obj: ApiRequestObjectType,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         max_results: int | None = 100,
         *,
         expected_type: type[EntityT] = Entity,
@@ -310,26 +315,26 @@ class EntityReader:
 
     @overload
     def query_one(
-        self, entity_type: type[EntityT], obj: ApiRequestObjectType, bfabric_instance: str | None = None
+        self, entity_type: type[EntityT], obj: ApiRequestObjectType, bfabric_instance: BaseUrl | None = None
     ) -> EntityT | None: ...
     @overload
     def query_one(
         self,
         entity_type: str,
         obj: ApiRequestObjectType,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         *,
         expected_type: type[EntityT],
     ) -> EntityT | None: ...
     @overload
     def query_one(
-        self, entity_type: str, obj: ApiRequestObjectType, bfabric_instance: str | None = None
+        self, entity_type: str, obj: ApiRequestObjectType, bfabric_instance: BaseUrl | None = None
     ) -> Entity | None: ...
     def query_one(
         self,
         entity_type: str | type[EntityT],
         obj: ApiRequestObjectType,
-        bfabric_instance: str | None = None,
+        bfabric_instance: BaseUrl | None = None,
         *,
         expected_type: type[EntityT] = Entity,
     ) -> EntityT | None:

--- a/bfabric/src/bfabric/entities/core/import_entity.py
+++ b/bfabric/src/bfabric/entities/core/import_entity.py
@@ -4,7 +4,7 @@ import importlib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from bfabric import Bfabric
+    from bfabric import BaseUrl, Bfabric
     from bfabric.entities.core.entity import Entity
     from bfabric.typing import ApiResponseObjectType
 
@@ -36,7 +36,7 @@ def entity_type_of(entity_class: type[Entity]) -> str:
     return entity_class.__name__.lower()
 
 
-def instantiate_entity(data_dict: ApiResponseObjectType, client: Bfabric | None, bfabric_instance: str) -> Entity:
+def instantiate_entity(data_dict: ApiResponseObjectType, client: Bfabric | None, bfabric_instance: BaseUrl) -> Entity:
     """Instantiates an entity given its data dictionary with the most specific class possible."""
     entity_class_name = data_dict["classname"]
     if not isinstance(entity_class_name, str):

--- a/bfabric/src/bfabric/entities/core/mixins/user_created_mixin.py
+++ b/bfabric/src/bfabric/entities/core/mixins/user_created_mixin.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from bfabric import Bfabric
+    from bfabric.config.base_url import BaseUrl
     from bfabric.entities import User
     from bfabric.entities.core.users import Users
     from bfabric.typing import ApiResponseObjectType
@@ -18,7 +19,7 @@ class UserCreatedMixin:
         @property
         def data_dict(self) -> ApiResponseObjectType: ...
         @property
-        def bfabric_instance(self) -> str: ...
+        def bfabric_instance(self) -> BaseUrl: ...
         @property
         def _client(self) -> Bfabric | None: ...
 

--- a/bfabric/src/bfabric/entities/core/references.py
+++ b/bfabric/src/bfabric/entities/core/references.py
@@ -11,7 +11,7 @@ from bfabric.entities.core.import_entity import instantiate_entity
 from bfabric.entities.core.uri import EntityUri
 
 if TYPE_CHECKING:
-    from bfabric import Bfabric
+    from bfabric import BaseUrl, Bfabric
     from bfabric.entities.core.entity import Entity
     from bfabric.typing import ApiResponseDataType, ApiResponseObjectType
 
@@ -34,9 +34,9 @@ class References:
     This class receives a reference to the entity's data dictionary, updating it in-place when references are loaded.
     """
 
-    def __init__(self, client: Bfabric, bfabric_instance: str, data_ref: ApiResponseObjectType) -> None:
+    def __init__(self, client: Bfabric, bfabric_instance: BaseUrl, data_ref: ApiResponseObjectType) -> None:
         self._client: Bfabric = client
-        self._bfabric_instance: str = bfabric_instance
+        self._bfabric_instance: BaseUrl = bfabric_instance
         self._data_ref: ApiResponseObjectType = data_ref
 
         # Retrieve information about all reference fields
@@ -122,7 +122,7 @@ class References:
 
     @classmethod
     def __extract_reference_info(
-        cls, data_ref: ApiResponseObjectType, bfabric_instance: str
+        cls, data_ref: ApiResponseObjectType, bfabric_instance: BaseUrl
     ) -> dict[str, _ReferenceInformation]:
         references: dict[str, _ReferenceInformation] = {}
         for name, value in data_ref.items():
@@ -133,7 +133,7 @@ class References:
 
     @classmethod
     def __extract_reference_info_item(
-        cls, name: str, value: ApiResponseDataType, bfabric_instance: str
+        cls, name: str, value: ApiResponseDataType, bfabric_instance: BaseUrl
     ) -> _ReferenceInformation | None:
         if isinstance(value, dict) and "classname" in value and "id" in value:
             info = cls.__extract_reference_info_item_dict(value, bfabric_instance)
@@ -156,7 +156,7 @@ class References:
 
     @classmethod
     def __extract_reference_info_item_dict(
-        cls, value: ApiResponseDataType, bfabric_instance: str
+        cls, value: ApiResponseDataType, bfabric_instance: BaseUrl
     ) -> dict[str, EntityUri | bool]:
         # value is guaranteed to be a dict by the caller's isinstance check
         value_dict = cast("dict[str, ApiResponseDataType]", value)

--- a/bfabric/src/bfabric/entities/core/uri.py
+++ b/bfabric/src/bfabric/entities/core/uri.py
@@ -9,11 +9,12 @@ from pydantic import (
     AfterValidator,
     BaseModel,
     ConfigDict,
-    HttpUrl,
     StringConstraints,
     TypeAdapter,
 )
 from pydantic_core import core_schema
+
+from bfabric.config.base_url import BaseUrl
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -60,7 +61,7 @@ def _parse_uri_components(uri: str, *, allow_extra_query: bool = False) -> Entit
         raise invalid(f"expected query exactly 'id=<entity_id>' and no fragment; {_NORMALIZE_HINT}")
 
     return EntityUriComponents(
-        bfabric_instance=HttpUrl(f"{parsed.scheme}://{parsed.netloc.lower()}/bfabric/"),
+        bfabric_instance=BaseUrl(f"{parsed.scheme}://{parsed.netloc.lower()}/bfabric"),
         entity_type=segments[1],
         entity_id=int(entity_id),
     )
@@ -98,11 +99,11 @@ class EntityUri(str):
         return instance
 
     @classmethod
-    def from_components(cls, bfabric_instance: str, entity_type: str, entity_id: int) -> EntityUri:
+    def from_components(cls, bfabric_instance: BaseUrl, entity_type: str, entity_id: int) -> EntityUri:
         """Create EntityUri from individual components.
 
         Args:
-            bfabric_instance: B-Fabric instance URL (e.g., "https://fgcz-bfabric.uzh.ch/bfabric/")
+            bfabric_instance: B-Fabric instance URL (e.g., "https://fgcz-bfabric.uzh.ch/bfabric")
             entity_type: Entity type name (e.g., "sample", "project")
             entity_id: Numeric ID of the entity
 
@@ -150,7 +151,7 @@ class EntityUriComponents(BaseModel):
         entity_id: Numeric entity ID (must be positive)
     """
 
-    bfabric_instance: HttpUrl
+    bfabric_instance: BaseUrl
     entity_type: Annotated[str, StringConstraints(pattern=r"^[a-z]+$")]
     entity_id: Annotated[int, annotated_types.Gt(0)]
 
@@ -170,7 +171,7 @@ class GroupedUris(BaseModel):
         """Grouping key for EntityUris."""
 
         model_config = ConfigDict(frozen=True)
-        bfabric_instance: str
+        bfabric_instance: BaseUrl
         entity_type: str
 
     groups: dict[GroupKey, list[EntityUri]] = {}
@@ -191,8 +192,6 @@ class GroupedUris(BaseModel):
         """
         groups = defaultdict(list)
         for uri in uris:
-            key = cls.GroupKey(
-                bfabric_instance=str(uri.components.bfabric_instance), entity_type=uri.components.entity_type
-            )
+            key = cls.GroupKey(bfabric_instance=uri.components.bfabric_instance, entity_type=uri.components.entity_type)
             groups[key].append(uri)
         return cls(groups=dict(groups))

--- a/bfabric/src/bfabric/entities/core/users.py
+++ b/bfabric/src/bfabric/entities/core/users.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-
 if TYPE_CHECKING:
+    from bfabric.config.base_url import BaseUrl
     from bfabric.entities.core.entity_reader import EntityReader
     from bfabric.entities.user import User
 
@@ -15,7 +15,7 @@ class Users:
         self._users: list[User] = []
         self._entity_reader: EntityReader = entity_reader
 
-    def get_by_id(self, bfabric_instance: str, id: int) -> User | None:
+    def get_by_id(self, bfabric_instance: BaseUrl, id: int) -> User | None:
         """Gets a user by their ID."""
         from bfabric.entities.user import User as UserEntity
 
@@ -33,7 +33,7 @@ class Users:
         self._users.append(user)
         return user
 
-    def get_by_login(self, bfabric_instance: str, login: str) -> User | None:
+    def get_by_login(self, bfabric_instance: BaseUrl, login: str) -> User | None:
         """Gets a user by their login name."""
         from bfabric.entities.user import User as UserEntity
 

--- a/bfabric/src/bfabric/experimental/webapp_integration_settings.py
+++ b/bfabric/src/bfabric/experimental/webapp_integration_settings.py
@@ -4,18 +4,21 @@ from typing import Protocol, Self, runtime_checkable
 
 from pydantic import BaseModel, model_validator
 
+from bfabric.config.base_url import BaseUrl
 from bfabric.config.bfabric_auth import BfabricAuth
 
 
 @runtime_checkable
 class TokenValidationSettingsProtocol(Protocol):
-    validation_bfabric_instance: str
-    supported_bfabric_instances: list[str]
+    validation_bfabric_instance: BaseUrl
+    supported_bfabric_instances: list[BaseUrl]
 
 
 class TokenValidationSettings(BaseModel):
-    validation_bfabric_instance: str
-    supported_bfabric_instances: list[str]
+    # Canonicalised on parse, so that the operator's chosen form of a trailing slash never decides
+    # whether an instance is recognised -- neither here nor in the comparisons downstream.
+    validation_bfabric_instance: BaseUrl
+    supported_bfabric_instances: list[BaseUrl]
 
     @model_validator(mode="after")
     def _valid_validation_instance(self) -> Self:
@@ -26,7 +29,7 @@ class TokenValidationSettings(BaseModel):
 
 
 class WebappIntegrationSettings(TokenValidationSettings):
-    feeder_user_credentials: dict[str, BfabricAuth]
+    feeder_user_credentials: dict[BaseUrl, BfabricAuth]
 
     @model_validator(mode="after")
     def _valid_feeder_user_credentials(self) -> Self:

--- a/bfabric/src/bfabric/oauth/_credential_provider.py
+++ b/bfabric/src/bfabric/oauth/_credential_provider.py
@@ -31,6 +31,7 @@ from bfabric.errors import BfabricOAuthError
 from bfabric.oauth._token_cache import TokenCache, compute_token_cache_path
 
 if TYPE_CHECKING:
+    from bfabric.config.base_url import BaseUrl
     from pathlib import Path
 
 
@@ -120,7 +121,7 @@ class OAuthCredentialProvider:
             self._persist()
 
     @classmethod
-    def cache_login_token(cls, base_url: str, *, client_id: str, token: dict[str, object], env_name: str) -> Path:
+    def cache_login_token(cls, base_url: BaseUrl, *, client_id: str, token: dict[str, object], env_name: str) -> Path:
         """Normalize and cache a freshly obtained login *token*, returning its cache path.
 
         Ingesting the token derives its absolute ``expires_at`` (from ``expires_in``) and writes the

--- a/bfabric/src/bfabric/oauth/_device_code.py
+++ b/bfabric/src/bfabric/oauth/_device_code.py
@@ -14,15 +14,19 @@ from __future__ import annotations
 
 import sys
 import time
+from typing import TYPE_CHECKING
 
 import httpx
 from loguru import logger
 
 from bfabric.errors import BfabricOAuthError, raise_if_unavailable
 
+if TYPE_CHECKING:
+    from bfabric.config.base_url import BaseUrl
+
 
 def _request_device_code(
-    base_url: str,
+    base_url: BaseUrl,
     *,
     client_id: str,
     scope: str,
@@ -52,7 +56,7 @@ def _request_device_code(
 
 
 def _poll_for_token(
-    base_url: str,
+    base_url: BaseUrl,
     *,
     device_code: str,
     client_id: str,
@@ -142,7 +146,7 @@ def _poll_for_token(
 
 
 def device_code_login(
-    base_url: str,
+    base_url: BaseUrl,
     *,
     client_id: str,
     scope: str,
@@ -153,14 +157,12 @@ def device_code_login(
     Requests a device code, displays the user code and verification URI,
     then polls until the user authorizes or the request times out.
 
-    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param client_id: OAuth client ID
     :param scope: OAuth scope
     :param timeout: Seconds to wait for the user to authorize
     :returns: Token dict with ``access_token``, ``refresh_token``, etc.
     :raises RuntimeError: On timeout, expired token, or access denied
     """
-    base_url = base_url.rstrip("/")
     logger.debug("Starting device code flow for {}", base_url)
     device_response = _request_device_code(base_url, client_id=client_id, scope=scope)
 

--- a/bfabric/src/bfabric/oauth/_pkce.py
+++ b/bfabric/src/bfabric/oauth/_pkce.py
@@ -14,6 +14,7 @@ import threading
 import webbrowser
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
@@ -21,6 +22,8 @@ from loguru import logger
 
 from bfabric.errors import BfabricOAuthError, raise_if_unavailable
 
+if TYPE_CHECKING:
+    from bfabric.config.base_url import BaseUrl
 
 _REMOTE_HOST_CAVEAT = "On a remote host, use 'bfabric-cli auth device-code' instead."
 
@@ -167,7 +170,7 @@ def _exchange_code(
 
 
 def pkce_login(
-    base_url: str,
+    base_url: BaseUrl,
     *,
     client_id: str,
     scope: str,
@@ -177,14 +180,12 @@ def pkce_login(
 ) -> dict[str, object]:
     """Perform an OAuth 2.0 Authorization Code flow with PKCE.
 
-    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param port: Local port for the callback server (``0`` = auto-assign)
     :param open_browser: If ``False``, or if the browser fails to open, the URL is printed to stderr
     :param timeout: Seconds to wait for the user to complete login
     :returns: Token dict with ``access_token``, ``refresh_token``, etc.
     :raises RuntimeError: On timeout, CSRF state mismatch, or authorization error
     """
-    base_url = base_url.rstrip("/")
     logger.debug("Starting PKCE login flow for {}", base_url)
     verifier = _generate_verifier()
     challenge = _generate_challenge(verifier)

--- a/bfabric/src/bfabric/oauth/_registration.py
+++ b/bfabric/src/bfabric/oauth/_registration.py
@@ -11,6 +11,7 @@ from bfabric.errors import raise_if_unavailable
 
 if TYPE_CHECKING:
     from bfabric.bfabric import Bfabric
+    from bfabric.config.base_url import BaseUrl
     from bfabric.results.result_container import ResultContainer
     from bfabric.typing import ApiRequestDataType
 
@@ -34,7 +35,7 @@ def _default_grant_types(service_user: str | None) -> list[str]:
 
 
 def register_client(
-    base_url: str,
+    base_url: BaseUrl,
     token: str,
     client_name: str,
     redirect_uri: str,
@@ -51,7 +52,6 @@ def register_client(
     ``token-exchange``, ``refresh_token`` and ``authorization_code`` always, plus
     ``client_credentials`` when *service_user* is provided. Pass *grant_types* to override.
 
-    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param token: Employee Bearer token for authorization
     :param client_name: Human-readable name for the client
     :param redirect_uri: OAuth redirect URI for the client
@@ -60,7 +60,7 @@ def register_client(
     :param grant_types: Explicit list of grant types to request (overrides the default)
     :returns: Registration response containing ``client_id``, ``client_secret``, etc.
     """
-    url = f"{base_url.rstrip('/')}/rest/oauth/register"
+    url = f"{base_url}/rest/oauth/register"
     resolved_grant_types = grant_types if grant_types is not None else _default_grant_types(service_user)
     body: dict[str, object] = {
         "client_name": client_name,
@@ -118,10 +118,8 @@ def register_webapp(
     :returns: Dict with ``"oauth"`` (registration response) and ``"application"``
         (save response) keys
     """
-    base_url = client.config.base_url.rstrip("/")
-
     oauth_result = register_client(
-        base_url=base_url,
+        base_url=client.config.base_url,
         token=token,
         client_name=app_name,
         redirect_uri=web_url,

--- a/bfabric/src/bfabric/oauth/_token_cache.py
+++ b/bfabric/src/bfabric/oauth/_token_cache.py
@@ -6,18 +6,22 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
+if TYPE_CHECKING:
+    from bfabric.config.base_url import BaseUrl
 
-def compute_token_cache_path(base_url: str, client_id: str, env_name: str) -> Path:
+
+def compute_token_cache_path(base_url: BaseUrl, client_id: str, env_name: str) -> Path:
     """Return the default token cache path for a given base URL, client ID, and environment name.
 
     The path is ``~/.bfabric/tokens/{hash}.json`` where *hash* is the first 16
     hex characters of the SHA-256 digest of ``base_url + '\\0' + client_id + '\\0' + env_name``.
     This ensures different identities on the same server get separate caches.
     """
-    key = base_url.rstrip("/") + "\0" + client_id + "\0" + env_name
+    key = base_url + "\0" + client_id + "\0" + env_name
     url_hash = hashlib.sha256(key.encode()).hexdigest()[:16]
     return Path("~/.bfabric/tokens") / f"{url_hash}.json"
 

--- a/bfabric/src/bfabric/oauth/_token_exchange.py
+++ b/bfabric/src/bfabric/oauth/_token_exchange.py
@@ -7,6 +7,9 @@ the resulting access token to extract entity context.
 
 from __future__ import annotations
 
+
+from typing import TYPE_CHECKING
+
 import httpx
 from loguru import logger
 
@@ -14,9 +17,12 @@ from bfabric.errors import raise_if_unavailable
 
 from bfabric.oauth._url_token import UrlTokenContext
 
+if TYPE_CHECKING:
+    from bfabric.config.base_url import BaseUrl
+
 
 def exchange_token(
-    base_url: str,
+    base_url: BaseUrl,
     launch_token: str,
     *,
     client_id: str,
@@ -27,14 +33,13 @@ def exchange_token(
     POSTs to ``{base_url}/rest/oauth/token`` with
     ``grant_type=urn:ietf:params:oauth:grant-type:token-exchange``.
 
-    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param launch_token: The short-lived JWT from the launch URL
     :param client_id: OAuth client ID for the webapp
     :param client_secret: OAuth client secret for the webapp
     :returns: Token response dict with ``access_token``, ``refresh_token``, etc.
     :raises httpx.HTTPStatusError: On non-2xx responses
     """
-    url = f"{base_url.rstrip('/')}/rest/oauth/token"
+    url = f"{base_url}/rest/oauth/token"
     logger.debug("Exchanging launch token at {}", url)
     with raise_if_unavailable(base_url):
         response = httpx.post(
@@ -55,7 +60,7 @@ def exchange_token(
 
 
 def introspect_token(
-    base_url: str,
+    base_url: BaseUrl,
     access_token: str,
     *,
     client_id: str,
@@ -66,14 +71,13 @@ def introspect_token(
     POSTs to ``{base_url}/rest/oauth/introspect`` using ``client_secret_basic``
     auth and returns a :class:`UrlTokenContext` with the extracted claims.
 
-    :param base_url: B-Fabric instance URL
     :param access_token: The access token to introspect
     :param client_id: OAuth client ID for the webapp
     :param client_secret: OAuth client secret for the webapp
     :returns: :class:`UrlTokenContext` with entity claims
     :raises httpx.HTTPStatusError: On non-2xx responses
     """
-    url = f"{base_url.rstrip('/')}/rest/oauth/introspect"
+    url = f"{base_url}/rest/oauth/introspect"
     logger.debug("Introspecting token at {}", url)
     with raise_if_unavailable(base_url):
         response = httpx.post(

--- a/bfabric/src/bfabric/oauth/_url_token.py
+++ b/bfabric/src/bfabric/oauth/_url_token.py
@@ -11,6 +11,7 @@ from joserfc import jwt as joserfc_jwt
 from joserfc.jwk import KeySet
 from loguru import logger
 
+from bfabric.config.base_url import BaseUrl
 from bfabric.errors import raise_if_unavailable
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -40,9 +41,13 @@ class UrlTokenContext(BaseModel):
     name: str | None = Field(default=None)
 
     @property
-    def base_url(self) -> str | None:
-        """B-Fabric instance base URL derived from ``iss``, trailing slash stripped."""
-        return self.issuer.rstrip("/") if self.issuer else None
+    def base_url(self) -> BaseUrl | None:
+        """B-Fabric instance base URL derived from ``iss``.
+
+        :raises ValueError: If ``iss`` is present but not an http(s) URL, which would mean the
+            issuer that signed this token named itself with something we cannot call back.
+        """
+        return BaseUrl(self.issuer) if self.issuer else None
 
     @property
     def is_employee(self) -> bool:
@@ -56,7 +61,7 @@ _jwks_lock = threading.Lock()
 _JWKS_CACHE_TTL = 3600  # 1 hour
 
 
-def _fetch_jwks(base_url: str) -> dict[str, object]:
+def _fetch_jwks(base_url: BaseUrl) -> dict[str, object]:
     """Fetch (and cache for 1 hour) the JWKS from the B-Fabric server."""
     now = time.time()
     with _jwks_lock:
@@ -68,7 +73,7 @@ def _fetch_jwks(base_url: str) -> dict[str, object]:
                 return jwks
 
     logger.debug("Fetching JWKS from {}", base_url)
-    url = f"{base_url.rstrip('/')}/rest/oauth/jwks"
+    url = f"{base_url}/rest/oauth/jwks"
     with raise_if_unavailable(base_url):
         response = httpx.get(url, timeout=30)
     _ = response.raise_for_status()
@@ -78,10 +83,9 @@ def _fetch_jwks(base_url: str) -> dict[str, object]:
     return jwks
 
 
-def verify_jwt(base_url: str, token: str) -> dict[str, object]:
+def verify_jwt(base_url: BaseUrl, token: str) -> dict[str, object]:
     """Verify the JWT signature + expiry against the B-Fabric JWKS endpoint.
 
-    :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
     :param token: The raw JWT string
     :returns: The verified claims dictionary
     :raises: ``joserfc.errors.JoseError`` subclasses on invalid/expired tokens

--- a/bfabric/src/bfabric/oauth/_webapp_client.py
+++ b/bfabric/src/bfabric/oauth/_webapp_client.py
@@ -43,7 +43,6 @@ class WebappClient:
         (from the URL) into long-lived access + refresh tokens, then decodes
         the access token JWT locally to extract entity context.
 
-        :param base_url: B-Fabric instance URL (e.g. ``https://bfabric.example.com/bfabric``)
         :param launch_token: The short-lived JWT from the URL ``jwt`` parameter
         :param client_id: OAuth client ID for the webapp
         :param client_secret: OAuth client secret for the webapp
@@ -55,10 +54,10 @@ class WebappClient:
         from bfabric.oauth._credential_provider import OAuthCredentialProvider
         from bfabric.oauth._token_exchange import exchange_token
         from bfabric.oauth._url_token import UrlTokenContext, verify_jwt
-        from bfabric.config import BfabricClientConfig
+        from bfabric.config import BfabricClientConfig, BaseUrl
         from bfabric.config.config_data import ConfigData
 
-        base_url = base_url.rstrip("/")
+        base_url = BaseUrl(base_url)
         token_url = f"{base_url}/rest/oauth/token"
 
         # 1. Exchange the short-lived launch token for access + refresh tokens
@@ -83,7 +82,7 @@ class WebappClient:
             grant_type="refresh_token",
             token_cache_path=user_token_cache_path,
         )
-        config = BfabricClientConfig(base_url=base_url)  # pyright: ignore[reportCallIssue]
+        config = BfabricClientConfig(base_url=base_url)
         user_client = Bfabric(
             config_data=ConfigData(client=config, auth=None),
             _credential_provider=user_provider,

--- a/bfabric/src/bfabric/rest/token_data.py
+++ b/bfabric/src/bfabric/rest/token_data.py
@@ -19,6 +19,7 @@ from pydantic import (
 
 from pydantic import ValidationError
 
+from bfabric.config.base_url import BaseUrl
 from bfabric.entities.core.import_entity import import_entity
 from bfabric.errors import (
     BfabricInstanceNotConfiguredError,
@@ -132,6 +133,7 @@ async def validate_token(
     token_data = await get_token_data_async(
         base_url=settings.validation_bfabric_instance, token=token, http_client=http_client
     )
-    if token_data.caller not in settings.supported_bfabric_instances:
+    supported = {BaseUrl(instance) for instance in settings.supported_bfabric_instances}
+    if BaseUrl(token_data.caller) not in supported:
         raise BfabricInstanceNotConfiguredError(token_data.caller)
     return token_data

--- a/bfabric/src/bfabric/transfer/__init__.py
+++ b/bfabric/src/bfabric/transfer/__init__.py
@@ -56,7 +56,6 @@ from bfabric.transfer.upload import (
     DuplicateResult,
     UploadRestClient,
     UploadTokenResult,
-    api_to_rest_url,
     require_tus,
     tus_sink_for_resource,
 )
@@ -83,7 +82,6 @@ __all__ = [
     "UploadOutcome",
     "UploadRestClient",
     "UploadTokenResult",
-    "api_to_rest_url",
     "check_download_scope",
     "check_upload_scope",
     "collect_file_infos",

--- a/bfabric/src/bfabric/transfer/upload.py
+++ b/bfabric/src/bfabric/transfer/upload.py
@@ -15,7 +15,6 @@ import httpx
 from loguru import logger
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, TypeAdapter, field_validator
 
-from bfabric.config.base_url import BaseUrl
 from bfabric.transfer.errors import BfabricTransferError
 from bfabric.transfer.tokens import check_upload_scope, require_oauth, token_provider
 from bfabric.transfer._generic.sinks import TransferSinkTus
@@ -27,12 +26,6 @@ if TYPE_CHECKING:
     from bfabric.transfer._generic.checksums import FileInfo
 
 _TIMEOUT = 60.0
-
-
-def api_to_rest_url(api_base_url: str) -> BaseUrl:
-    """Derive the B-Fabric REST base URL (``https://host/bfabric``) from the SOAP API base URL."""
-    base = BaseUrl(api_base_url)
-    return BaseUrl(base[: -len("/api")]) if base.endswith("/api") else base
 
 
 def require_tus() -> None:
@@ -152,7 +145,8 @@ class UploadRestClient:
         # password as a bearer token (all REST calls funnel through this client).
         require_oauth(client)
         self._client = client
-        self._rest_base_url = api_to_rest_url(client.config.base_url)
+        # The REST endpoints hang off the servlet root, which is what base_url already is.
+        self._rest_base_url = client.config.base_url
         # require_oauth guarantees an OAuth client, so token_provider never returns None here. The
         # provider reads the token fresh per call, so a long batch survives a mid-run token refresh.
         provider = token_provider(client)

--- a/bfabric/src/bfabric/transfer/upload.py
+++ b/bfabric/src/bfabric/transfer/upload.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, ClassVar, final
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, TypeAdapter
 
+from bfabric.config.base_url import BaseUrl
 from bfabric.transfer.errors import BfabricTransferError
 from bfabric.transfer.tokens import check_upload_scope, require_oauth, token_provider
 from bfabric.transfer._generic.sinks import TransferSinkTus
@@ -27,12 +28,10 @@ if TYPE_CHECKING:
 _TIMEOUT = 60.0
 
 
-def api_to_rest_url(api_base_url: str) -> str:
+def api_to_rest_url(api_base_url: str) -> BaseUrl:
     """Derive the B-Fabric REST base URL (``https://host/bfabric``) from the SOAP API base URL."""
-    base = api_base_url.rstrip("/")
-    if base.endswith("/api"):
-        return base[: -len("/api")]
-    return base
+    base = BaseUrl(api_base_url)
+    return BaseUrl(base[: -len("/api")]) if base.endswith("/api") else base
 
 
 def require_tus() -> None:
@@ -115,7 +114,7 @@ class UploadRestClient:
         # password as a bearer token (all REST calls funnel through this client).
         require_oauth(client)
         self._client = client
-        self._rest_base_url = api_to_rest_url(str(client.config.base_url))
+        self._rest_base_url = api_to_rest_url(client.config.base_url)
         # require_oauth guarantees an OAuth client, so token_provider never returns None here. The
         # provider reads the token fresh per call, so a long batch survives a mid-run token refresh.
         provider = token_provider(client)

--- a/bfabric_asgi_auth/README.md
+++ b/bfabric_asgi_auth/README.md
@@ -25,7 +25,7 @@ token_validator = create_mock_validator()  # Accepts tokens starting with 'valid
 from bfabric_asgi_auth import create_bfabric_validator
 
 token_validator = create_bfabric_validator(
-    validation_instance_url="https://fgcz-bfabric-test.uzh.ch/bfabric/"
+    validation_instance_url="https://fgcz-bfabric-test.uzh.ch/bfabric"
 )
 ```
 

--- a/bfabric_asgi_auth/docs/changelog.md
+++ b/bfabric_asgi_auth/docs/changelog.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Require `starlette>=1.0.1,<2` (was `>=0.50.0,<1`) to keep starlette above the advisory floor ([#505](https://github.com/fgcz/bfabricPy/issues/505)).
 - The README's secret key example uses `secrets.token_urlsafe(64)` and warns about generating random keys ([#434](https://github.com/fgcz/bfabricPy/issues/434)).
+- `SessionData.bfabric_instance` is canonicalised to a `bfabric.BaseUrl` on construction, so `BfabricUser.instance` and `BfabricUser.get_bfabric_client().config.base_url` no longer end with a trailing slash and compare equal to a configured instance spelled either way.
 
 ### Fixed
 
+- A token naming a non-http B-Fabric instance is reported as a failed validation instead of escaping `create_bfabric_validator` as an unhandled `ValueError`.
 - Redirect URL scheme handling: protocol-relative URLs (`//example.com`) and absolute URLs with the wrong scheme are corrected from the `X-Forwarded-Proto` header.
 - `scope["root_path"]` is honoured when the app is mounted behind a reverse-proxy sub-path: landing/logout matching strips a leading `root_path` from `scope["path"]`, and root-relative redirect targets (e.g. `authenticated_path="/"`) are prefixed with `root_path` so the browser lands at the correct public URL.
 

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/middleware.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/middleware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import urllib.parse
 
 from asgiref.typing import ASGI3Application, ASGIReceiveCallable, ASGISendCallable, HTTPScope, Scope, WebSocketScope
+from bfabric.config import BaseUrl
 from loguru import logger
 from pydantic import SecretStr, ValidationError
 
@@ -140,7 +141,7 @@ class BfabricAuthMiddleware:
 
         # Create session data
         session_data = SessionData(
-            bfabric_instance=result.token_data.caller,
+            bfabric_instance=BaseUrl(result.token_data.caller),
             bfabric_auth_login=result.token_data.user,
             bfabric_auth_password=result.token_data.user_ws_password.get_secret_value(),
             entity_class=result.token_data.entity_class,
@@ -180,8 +181,8 @@ class BfabricAuthMiddleware:
             else:
                 logger.debug("Landing callback returned None, redirecting to default authenticated_path.")
 
-        # update the session
-        session["bfabric_session"] = session_data.model_dump()
+        # update the session; json mode so no ``str`` subclass (e.g. ``BaseUrl``) reaches the cookie serializer
+        session["bfabric_session"] = session_data.model_dump(mode="json")
 
         # Send redirect response
         response = RedirectResponse(url=redirect_url, redirect_type="authenticated")

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/session_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from bfabric.config import BaseUrl
 from pydantic import BaseModel
 
 
@@ -19,7 +20,7 @@ class SessionData(BaseModel):
     :ivar application_id: ID of the B-Fabric application
     """
 
-    bfabric_instance: str
+    bfabric_instance: BaseUrl
     bfabric_auth_login: str
     bfabric_auth_password: str
     entity_class: str

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/token_validation/bfabric_strategy.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/token_validation/bfabric_strategy.py
@@ -5,7 +5,7 @@ from bfabric.experimental.webapp_integration_settings import TokenValidationSett
 from bfabric.rest.token_data import validate_token
 from httpx import HTTPError
 from loguru import logger
-from pydantic import SecretStr, ValidationError
+from pydantic import SecretStr
 
 from bfabric_asgi_auth.token_validation.strategy import (
     TokenValidationError,
@@ -25,7 +25,9 @@ def create_bfabric_validator(settings: TokenValidationSettingsProtocol) -> Token
         try:
             # Use async token validation
             token_data = await validate_token(token=token.get_secret_value(), settings=settings)
-        except (HTTPError, ValidationError, BfabricInstanceNotConfiguredError) as e:
+        # ValueError covers pydantic's ValidationError (a subclass) and a caller/instance URL that
+        # BaseUrl rejects -- a rejected instance is a failed validation, not a 500.
+        except (HTTPError, ValueError, BfabricInstanceNotConfiguredError) as e:
             logger.exception("Token validation failed.")
             return TokenValidationError(error=f"Bfabric token validation failed: {str(e)}")
 

--- a/bfabric_asgi_auth/src/bfabric_asgi_auth/user.py
+++ b/bfabric_asgi_auth/src/bfabric_asgi_auth/user.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import override
 
 from bfabric import Bfabric, BfabricClientConfig
-from bfabric.config import BfabricAuth
+from bfabric.config import BaseUrl, BfabricAuth
 from bfabric.config.config_data import ConfigData
 from pydantic import SecretStr
 from starlette.authentication import BaseUser
@@ -39,7 +39,7 @@ class BfabricUser(BaseUser):
         return self._session_data.bfabric_auth_login
 
     @property
-    def instance(self) -> str:
+    def instance(self) -> BaseUrl:
         return self._session_data.bfabric_instance
 
     @property
@@ -61,7 +61,7 @@ class BfabricUser(BaseUser):
     def get_bfabric_client(self) -> Bfabric:
         """Create a Bfabric client authenticated as this user."""
         config = ConfigData(
-            client=BfabricClientConfig.model_validate({"base_url": self._session_data.bfabric_instance}),
+            client=BfabricClientConfig(base_url=self._session_data.bfabric_instance),
             auth=BfabricAuth(
                 login=self._session_data.bfabric_auth_login,
                 password=SecretStr(self._session_data.bfabric_auth_password),

--- a/bfabric_asgi_auth/tests/bdd/conftest.py
+++ b/bfabric_asgi_auth/tests/bdd/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 
+from bfabric.config import BaseUrl
 from bfabric.rest.token_data import TokenData
 import pytest
 import pytest_asyncio
@@ -522,7 +523,7 @@ def session_bfabric_session_has_required_fields(context, client):
 
     # Verify fields are populated correctly from token_data
     token_data = context["token_data"]
-    assert session_data["bfabric_instance"] == token_data.caller
+    assert session_data["bfabric_instance"] == BaseUrl(token_data.caller)
     assert session_data["bfabric_auth_login"] == token_data.user
     # Verify password content matches (not just length)
     assert session_data["bfabric_auth_password"] == token_data.user_ws_password.get_secret_value()

--- a/bfabric_asgi_auth/tests/bdd/features/user_scope.feature
+++ b/bfabric_asgi_auth/tests/bdd/features/user_scope.feature
@@ -16,13 +16,13 @@ Feature: User scope population
     Given I am authenticated with token "valid_test123"
     When I request the user info endpoint
     Then the scope user display_name should be "test123"
-    And the scope user identity should be "test123@https://fgcz-bfabric-test.uzh.ch/bfabric/"
+    And the scope user identity should be "test123@https://fgcz-bfabric-test.uzh.ch/bfabric"
 
   Scenario: login and instance properties return correct values
     Given I am authenticated with token "valid_test123"
     When I request the user info endpoint
     Then the scope user login should be "test123"
-    And the scope user instance should be "https://fgcz-bfabric-test.uzh.ch/bfabric/"
+    And the scope user instance should be "https://fgcz-bfabric-test.uzh.ch/bfabric"
 
   Scenario: Unauthenticated request does not have scope["user"] set
     Given I have no session cookie

--- a/bfabric_asgi_auth/tests/unit/test_bfabric_strategy.py
+++ b/bfabric_asgi_auth/tests/unit/test_bfabric_strategy.py
@@ -1,0 +1,35 @@
+"""Unit tests for the B-Fabric token-validation strategy."""
+
+from __future__ import annotations
+
+import pytest
+from bfabric.errors import BfabricInstanceNotConfiguredError
+from httpx import HTTPError
+from pydantic import SecretStr
+
+from bfabric_asgi_auth.token_validation.bfabric_strategy import create_bfabric_validator
+from bfabric_asgi_auth.token_validation.strategy import TokenValidationError
+
+
+@pytest.fixture
+def settings(mocker):
+    return mocker.MagicMock(name="settings")
+
+
+class TestBfabricValidator:
+    """The happy path is covered end-to-end by the BDD suite; this pins the failure translation."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            HTTPError("boom"),
+            BfabricInstanceNotConfiguredError("https://other.example.com/bfabric"),
+            # A caller the core rejects as a non-http URL: a failed validation, not a 500.
+            ValueError("Not a valid http(s) URL: 'urn:example:nope'"),
+        ],
+    )
+    async def test_reports_a_failure_instead_of_propagating(self, mocker, settings, error):
+        mocker.patch("bfabric_asgi_auth.token_validation.bfabric_strategy.validate_token", side_effect=error)
+        result = await create_bfabric_validator(settings)(SecretStr("mock-token"))
+        assert isinstance(result, TokenValidationError)
+        assert "Bfabric token validation failed" in result.error

--- a/bfabric_asgi_auth/tests/unit/test_user.py
+++ b/bfabric_asgi_auth/tests/unit/test_user.py
@@ -35,13 +35,13 @@ class TestBfabricUser:
         assert user.login == "testuser"
 
     def test_instance(self, user: BfabricUser) -> None:
-        assert user.instance == "https://fgcz-bfabric.uzh.ch/bfabric/"
+        assert user.instance == "https://fgcz-bfabric.uzh.ch/bfabric"
 
     def test_display_name(self, user: BfabricUser) -> None:
         assert user.display_name == "testuser"
 
     def test_identity(self, user: BfabricUser) -> None:
-        assert user.identity == "testuser@https://fgcz-bfabric.uzh.ch/bfabric/"
+        assert user.identity == "testuser@https://fgcz-bfabric.uzh.ch/bfabric"
 
     def test_entity_class(self, user: BfabricUser) -> None:
         assert user.entity_class == "Workunit"
@@ -60,4 +60,4 @@ class TestBfabricUser:
         assert isinstance(client, Bfabric)
         assert client.auth.login == "testuser"
         assert client.auth.password.get_secret_value() == "a" * 32
-        assert str(client.config.base_url) == "https://fgcz-bfabric.uzh.ch/bfabric/"
+        assert str(client.config.base_url) == "https://fgcz-bfabric.uzh.ch/bfabric"

--- a/bfabric_rest_proxy/docs/changelog.md
+++ b/bfabric_rest_proxy/docs/changelog.md
@@ -21,3 +21,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `/validate_token` uses the server-configured `validation_bfabric_instance` instead of the client-provided instance.
 - An empty list `[]` query parameter from R clients is handled (converted to an empty dict `{}`).
+- A `bfabric_instance` request parameter is canonicalised before it is matched against `supported_bfabric_instances`, so a trailing slash no longer makes a configured instance look unknown. `default_bfabric_instance` and the `feeder_user_credentials` keys are canonicalised the same way at startup.
+- `default_bfabric_instance: null`, documented as making the `bfabric_instance` parameter mandatory, no longer fails settings validation.

--- a/bfabric_rest_proxy/src/bfabric_rest_proxy/server.py
+++ b/bfabric_rest_proxy/src/bfabric_rest_proxy/server.py
@@ -14,6 +14,7 @@ from loguru import logger
 from pydantic import BaseModel, Field, SecretStr, model_validator
 
 from bfabric import Bfabric, BfabricAuth, BfabricClientConfig
+from bfabric.config.base_url import BaseUrl
 from bfabric_rest_proxy.feeder_operations.create_workunit import CreateWorkunitRequest, create_workunit
 from bfabric_rest_proxy.settings import ServerSettings
 from bfabric_rest_proxy.feeder_operations.is_employee import is_employee
@@ -34,7 +35,7 @@ def get_bfabric_auth(auth: BfabricAuthParam) -> BfabricAuth:
     return BfabricAuth(login=auth.login, password=auth.webservicepassword)
 
 
-def get_bfabric_instance(settings: ServerSettingsDep, bfabric_instance: str | None = None) -> str:
+def get_bfabric_instance(settings: ServerSettingsDep, bfabric_instance: str | None = None) -> BaseUrl:
     """Specify the B-Fabric instance explicitly. Only configured B-Fabric instances are permitted."""
     if bfabric_instance is None:
         # use the default
@@ -42,21 +43,23 @@ def get_bfabric_instance(settings: ServerSettingsDep, bfabric_instance: str | No
             raise ValueError("server is configured to enforce explicit bfabric_instance parameter")
         return settings.default_bfabric_instance
 
-    # check the specified value
-    if bfabric_instance not in settings.supported_bfabric_instances:
+    # Canonicalise before matching, so a caller's trailing slash does not make a configured instance
+    # look unknown.
+    requested = BaseUrl(bfabric_instance)
+    if requested not in settings.supported_bfabric_instances:
         raise ValueError(f"Unknown bfabric instance: {bfabric_instance}")
 
-    return bfabric_instance
+    return requested
 
 
 def get_bfabric_user_client(bfabric_auth: BfabricAuthDep, bfabric_instance: BfabricInstanceDep) -> Bfabric:
-    client_config = BfabricClientConfig.model_validate({"base_url": bfabric_instance})
+    client_config = BfabricClientConfig(base_url=bfabric_instance)
     config_data = ConfigData(client=client_config, auth=bfabric_auth)
     return Bfabric(config_data)
 
 
 def get_bfabric_feeder_client(settings: ServerSettingsDep, bfabric_instance: BfabricInstanceDep) -> Bfabric:
-    client_config = BfabricClientConfig.model_validate({"base_url": bfabric_instance})
+    client_config = BfabricClientConfig(base_url=bfabric_instance)
     config_data = ConfigData(
         client=client_config,
         auth=settings.feeder_user_credentials[bfabric_instance],
@@ -67,7 +70,7 @@ def get_bfabric_feeder_client(settings: ServerSettingsDep, bfabric_instance: Bfa
 
 ServerSettingsDep = Annotated[ServerSettings, Depends(get_server_settings)]
 BfabricAuthDep = Annotated[BfabricAuth, Depends(get_bfabric_auth)]
-BfabricInstanceDep = Annotated[str, Depends(get_bfabric_instance)]
+BfabricInstanceDep = Annotated[BaseUrl, Depends(get_bfabric_instance)]
 BfabricUserClientDep = Annotated[Bfabric, Depends(get_bfabric_user_client)]
 BfabricFeederClientDep = Annotated[Bfabric, Depends(get_bfabric_feeder_client)]
 

--- a/bfabric_rest_proxy/src/bfabric_rest_proxy/settings.py
+++ b/bfabric_rest_proxy/src/bfabric_rest_proxy/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from bfabric.config.base_url import BaseUrl
 from bfabric.experimental.webapp_integration_settings import WebappIntegrationSettings
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -12,10 +13,13 @@ class ServerSettings(BaseSettings, WebappIntegrationSettings):  # pyright: ignor
     )
 
     # specific to the proxy:
-    default_bfabric_instance: str | None = None
+    default_bfabric_instance: BaseUrl | None = None
+    """``None`` makes the ``bfabric_instance`` request parameter mandatory."""
 
     @model_validator(mode="after")
     def _valid_default_instance(self) -> ServerSettings:
-        if self.default_bfabric_instance not in self.supported_bfabric_instances:
+        if self.default_bfabric_instance is not None and (
+            self.default_bfabric_instance not in self.supported_bfabric_instances
+        ):
             raise ValueError("default_bfabric_instance must be one of supported_bfabric_instances")
         return self

--- a/bfabric_rest_proxy/tests/conftest.py
+++ b/bfabric_rest_proxy/tests/conftest.py
@@ -27,11 +27,11 @@ from bfabric_rest_proxy.settings import ServerSettings
 def mock_settings(mocker):
     """Mock ServerSettings for testing."""
     settings = mocker.MagicMock(spec=ServerSettings)
-    settings.default_bfabric_instance = "https://test.bfabric.example.com/"
-    settings.supported_bfabric_instances = ["https://test.bfabric.example.com/"]
+    settings.default_bfabric_instance = "https://test.bfabric.example.com/bfabric"
+    settings.supported_bfabric_instances = ["https://test.bfabric.example.com/bfabric"]
     # BfabricAuth requires passwords of at least 32 characters
     settings.feeder_user_credentials = {
-        "https://test.bfabric.example.com/": BfabricAuth(login="feeder_user", password=SecretStr("x" * 32))
+        "https://test.bfabric.example.com/bfabric": BfabricAuth(login="feeder_user", password=SecretStr("x" * 32))
     }
     return settings
 
@@ -46,7 +46,7 @@ def mock_bfabric_user_client(mocker):
     client = mocker.MagicMock(spec=Bfabric)
     # BfabricAuth requires passwords of at least 32 characters
     client.auth = BfabricAuth(login="test_user", password=SecretStr("y" * 32))
-    client.config.base_url = "https://test.bfabric.example.com/"
+    client.config.base_url = "https://test.bfabric.example.com/bfabric"
 
     # Mock read() to return a ResultContainer with empty results by default
     client.read.return_value = ResultContainer([], total_pages_api=0, errors=[])
@@ -64,7 +64,7 @@ def mock_bfabric_feeder_client(mocker):
     client = mocker.MagicMock(spec=Bfabric)
     # BfabricAuth requires passwords of at least 32 characters
     client.auth = BfabricAuth(login="feeder_user", password=SecretStr("z" * 32))
-    client.config.base_url = "https://test.bfabric.example.com/"
+    client.config.base_url = "https://test.bfabric.example.com/bfabric"
 
     # Mock save() to return a ResultContainer with mock data by default
     client.save.return_value = ResultContainer([{"id": 1}], total_pages_api=1, errors=[])
@@ -84,7 +84,7 @@ def client(mock_settings, mock_bfabric_user_client, mock_bfabric_feeder_client):
     """
     # Override all dependencies
     app.dependency_overrides[get_server_settings] = lambda: mock_settings
-    app.dependency_overrides[get_bfabric_instance] = lambda: "https://test.bfabric.example.com/"
+    app.dependency_overrides[get_bfabric_instance] = lambda: "https://test.bfabric.example.com/bfabric"
     app.dependency_overrides[get_bfabric_user_client] = lambda: mock_bfabric_user_client
     app.dependency_overrides[get_bfabric_feeder_client] = lambda: mock_bfabric_feeder_client
 
@@ -109,6 +109,6 @@ def mock_token_data():
         user_ws_password=SecretStr("a" * 32),
         token_expires="2025-12-31T23:59:59Z",
         web_service_user="true",
-        caller="https://test.bfabric.example.com/",
+        caller="https://test.bfabric.example.com/bfabric",
         environment="test",
     )

--- a/bfabric_rest_proxy/tests/test_instance_resolution.py
+++ b/bfabric_rest_proxy/tests/test_instance_resolution.py
@@ -1,0 +1,57 @@
+"""Tests for the instance-URL settings and the ``bfabric_instance`` dependency."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from bfabric import BfabricAuth
+from bfabric_rest_proxy.server import get_bfabric_instance
+from bfabric_rest_proxy.settings import ServerSettings
+
+INSTANCE = "https://test.bfabric.example.com/bfabric"
+
+
+def build_settings(**overrides: object) -> ServerSettings:
+    defaults = dict(
+        validation_bfabric_instance=INSTANCE,
+        supported_bfabric_instances=[INSTANCE],
+        feeder_user_credentials={INSTANCE: BfabricAuth(login="feeder", password=SecretStr("x" * 32))},
+        default_bfabric_instance=INSTANCE,
+    )
+    return ServerSettings(**{**defaults, **overrides})  # pyright: ignore[reportCallIssue]
+
+
+class TestServerSettings:
+    @pytest.mark.parametrize("default", [INSTANCE, f"{INSTANCE}/"])
+    def test_accepts_either_default_instance_form(self, default):
+        assert build_settings(default_bfabric_instance=default).default_bfabric_instance == INSTANCE
+
+    def test_rejects_an_unsupported_default_instance(self):
+        with pytest.raises(ValidationError, match="must be one of supported_bfabric_instances"):
+            build_settings(default_bfabric_instance="https://other.example.com/bfabric")
+
+    def test_allows_no_default_instance(self):
+        assert build_settings(default_bfabric_instance=None).default_bfabric_instance is None
+
+
+class TestGetBfabricInstance:
+    @pytest.mark.parametrize("requested", [INSTANCE, f"{INSTANCE}/"])
+    def test_accepts_either_requested_form(self, requested):
+        settings = build_settings()
+        assert get_bfabric_instance(settings, requested) == INSTANCE
+
+    def test_falls_back_to_the_default(self):
+        assert get_bfabric_instance(build_settings(), None) == INSTANCE
+
+    def test_rejects_an_unknown_instance(self):
+        with pytest.raises(ValueError, match="Unknown bfabric instance"):
+            get_bfabric_instance(build_settings(), "https://other.example.com/bfabric")
+
+    def test_rejects_a_malformed_instance(self):
+        with pytest.raises(ValueError, match="Not a valid http"):
+            get_bfabric_instance(build_settings(), "not-a-url")
+
+    def test_requires_an_instance_when_no_default_is_configured(self):
+        with pytest.raises(ValueError, match="explicit bfabric_instance"):
+            get_bfabric_instance(build_settings(default_bfabric_instance=None), None)

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -35,6 +35,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - `auth register-webapp` prints `Error: ...` and exits 1 when the OAuth session cannot be refreshed, instead of a raw traceback.
 - `auth register` no longer prompts for an *Employee Bearer token* when a login exists; it authenticates as the environment in effect.
+- `auth register` canonicalises its `base_url` argument like the other `auth` commands, so a bare host or a trailing slash works and a non-HTTP URL is rejected with a plain message.
 
 ## \[1.16.0\] - 2026-08-03
 

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,6 +10,10 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 ## \[Unreleased\]
 
+### Changed
+
+- `auth login` / `auth pat` complete a bare host with `/bfabric` for any instance, not just the four known ones, so `bfabric-cli login my-instance.example.com` works. A URL whose path is something else is now refused instead of used as given.
+
 ## \[1.17.0\] - 2026-08-20
 
 ### Added

--- a/bfabric_scripts/example/test_webapp_flow.py
+++ b/bfabric_scripts/example/test_webapp_flow.py
@@ -41,7 +41,7 @@ def main() -> None:
     # Connect to B-Fabric
     print("Connecting to B-Fabric...")
     client = Bfabric.connect(config_file_env=config_env)
-    base_url = client.config.base_url.rstrip("/")
+    base_url = client.config.base_url
     bearer_token = client.auth.password.get_secret_value()
     print(f"  base_url: {base_url}")
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/_common.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/_common.py
@@ -14,6 +14,7 @@ import yaml
 from bfabric.config.config_file import ConfigFile, EnvironmentConfig
 from bfabric_scripts.cli.interactive import confirm, is_interactive, select_choice, select_or_input, text_input
 from bfabric_scripts.cli.login._constants import SCOPE_PRESETS, SCOPE_PRESETS_BY_NAME
+from bfabric.config import BaseUrl
 from bfabric_scripts.cli.login._urls import KNOWN_INSTANCES, normalize_base_url
 
 # Interactive-only sentinel: choosing it opens a free-text prompt.
@@ -61,12 +62,12 @@ def _pick_or_type(message: str, labels: dict[str, str], prompt: str) -> str | No
     return text_input(prompt) if picked == _CUSTOM else picked
 
 
-def resolve_base_url(base_url: str | None, env: EnvironmentConfig | None) -> str | None:
+def resolve_base_url(base_url: str | None, env: EnvironmentConfig | None) -> BaseUrl | None:
     """Resolve the instance URL: explicit, else the environment's recorded one, else a picker."""
     if base_url is not None:
         return normalize_base_url(base_url)
     if env is not None:
-        return normalize_base_url(str(env.config.base_url))
+        return env.config.base_url
     if not is_interactive():
         return None
     # First-login picker over the known instances, plus free-text entry.

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/_urls.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/_urls.py
@@ -25,16 +25,21 @@ _BY_HOST: dict[str, tuple[str, BaseUrl]] = {instance_host(url): (name, url) for 
 
 
 def normalize_base_url(raw: str) -> BaseUrl:
-    """Canonicalise a base URL, defaulting the scheme to https and expanding a bare known host.
+    """Canonicalise a base URL, defaulting the scheme to https and completing a bare host with ``/bfabric``.
 
-    :raises ValueError: If *raw* is not an http(s) URL — rejected here, not minutes later inside the
-        browser flow as an opaque ``httpx.InvalidURL``.
+    :raises ValueError: If *raw* is not a usable instance URL — rejected here, not minutes later
+        inside the browser flow as an opaque ``httpx.InvalidURL``.
     """
     candidate = raw.strip()
-    url = BaseUrl(candidate if "//" in candidate else f"https://{candidate}")
-    host = instance_host(url)
-    # Only expand a bare host: rewriting an explicit path would break an unusual deployment.
-    return _BY_HOST[host][1] if not urlsplit(url).path and host in _BY_HOST else url
+    if "//" not in candidate:
+        candidate = f"https://{candidate}"
+    # A bare host is what someone types (`auth login fgcz-bfabric.uzh.ch`), so complete it rather
+    # than making BaseUrl reject it. An explicit path is left for BaseUrl to accept or refuse:
+    # overwriting one would silently point the login at a different instance than the user named.
+    parts = urlsplit(candidate)
+    if parts.netloc and not parts.path.strip("/"):
+        candidate = f"{parts.scheme}://{parts.netloc}/bfabric"
+    return BaseUrl(candidate)
 
 
 def suggest_env_name(base_url: str) -> str:

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/_urls.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/_urls.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlsplit
+
+from bfabric.config import BaseUrl
 
 # Suggested environment name -> instance base URL.
-KNOWN_INSTANCES: dict[str, str] = {
-    "fgcz-prod": "https://fgcz-bfabric.uzh.ch/bfabric",
-    "fgcz-test": "https://fgcz-bfabric-test.uzh.ch/bfabric",
-    "fgcz-demo": "https://fgcz-bfabric-demo.uzh.ch/bfabric",
-    "trace": "https://trace.fgcz.uzh.ch/bfabric",
+KNOWN_INSTANCES: dict[str, BaseUrl] = {
+    "fgcz-prod": BaseUrl("https://fgcz-bfabric.uzh.ch/bfabric"),
+    "fgcz-test": BaseUrl("https://fgcz-bfabric-test.uzh.ch/bfabric"),
+    "fgcz-demo": BaseUrl("https://fgcz-bfabric-demo.uzh.ch/bfabric"),
+    "trace": BaseUrl("https://trace.fgcz.uzh.ch/bfabric"),
 }
 
 
@@ -19,31 +21,20 @@ def instance_host(base_url: str) -> str:
 
 
 # Reverse index of KNOWN_INSTANCES: host -> (suggested name, base URL).
-_BY_HOST: dict[str, tuple[str, str]] = {instance_host(url): (name, url) for name, url in KNOWN_INSTANCES.items()}
+_BY_HOST: dict[str, tuple[str, BaseUrl]] = {instance_host(url): (name, url) for name, url in KNOWN_INSTANCES.items()}
 
 
-def normalize_base_url(raw: str) -> str:
-    """Canonicalise a base URL: default the scheme to https, lowercase the host, drop a trailing
-    slash, and expand a bare known host to that instance's full base URL.
+def normalize_base_url(raw: str) -> BaseUrl:
+    """Canonicalise a base URL, defaulting the scheme to https and expanding a bare known host.
 
-    :raises ValueError: If *raw* is empty or not http(s) — rejected here, not minutes later inside the
+    :raises ValueError: If *raw* is not an http(s) URL — rejected here, not minutes later inside the
         browser flow as an opaque ``httpx.InvalidURL``.
     """
     candidate = raw.strip()
-    if not candidate:
-        raise ValueError("Base URL must not be empty.")
-    if "//" not in candidate:
-        candidate = f"https://{candidate}"
-    parts = urlsplit(candidate)
-    if parts.scheme not in ("http", "https"):
-        raise ValueError(f"Base URL must use http or https, got {parts.scheme!r}.")
-    if not parts.netloc:
-        raise ValueError(f"Base URL {raw!r} has no host.")
-    host = parts.netloc.lower()
+    url = BaseUrl(candidate if "//" in candidate else f"https://{candidate}")
+    host = instance_host(url)
     # Only expand a bare host: rewriting an explicit path would break an unusual deployment.
-    if not parts.path.strip("/") and host in _BY_HOST:
-        return _BY_HOST[host][1]
-    return urlunsplit((parts.scheme, host, parts.path.rstrip("/"), "", ""))
+    return _BY_HOST[host][1] if not urlsplit(url).path and host in _BY_HOST else url
 
 
 def suggest_env_name(base_url: str) -> str:

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/oauth_login.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/oauth_login.py
@@ -25,6 +25,7 @@ from bfabric_scripts.cli.login._common import (
     resolve_set_default,
 )
 from bfabric_scripts.cli.login._constants import DEFAULT_CLIENT_ID
+from bfabric.config import BaseUrl
 from bfabric_scripts.cli.login._urls import normalize_base_url, suggest_env_name
 
 _SCOPE_HELP = (
@@ -43,7 +44,7 @@ class _LoginParams:
     """Everything a login needs, resolved from the command line, config, or a prompt."""
 
     config_env: str
-    base_url: str
+    base_url: BaseUrl
     client_id: str
     scope: str
     set_default: bool

--- a/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/login/register.py
@@ -12,6 +12,7 @@ import cyclopts
 from bfabric.oauth import register_client
 from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric_scripts.cli.login._constants import DEFAULT_REGISTRATION_SCOPE
+from bfabric_scripts.cli.login._urls import normalize_base_url
 
 
 def _resolve_token_from_config(config_env: str | None, config_file: Path) -> tuple[str, str]:
@@ -27,7 +28,7 @@ def _resolve_token_from_config(config_env: str | None, config_file: Path) -> tup
 
     try:
         client = Bfabric.connect(config_file_path=config_file, config_file_env=config_env or "default")
-        return client.auth.password.get_secret_value(), str(client.config.base_url).rstrip("/")
+        return client.auth.password.get_secret_value(), str(client.config.base_url)
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         raise SystemExit(1) from None
@@ -94,7 +95,7 @@ def cmd_login_register(
 
     try:
         result = register_client(
-            base_url=resolved_base_url,
+            base_url=normalize_base_url(resolved_base_url),
             token=resolved_token,
             client_name=client_name,
             redirect_uri=redirect_uri,

--- a/tests/bfabric/config/example_config.yml
+++ b/tests/bfabric/config/example_config.yml
@@ -3,15 +3,15 @@ GENERAL:
 PRODUCTION:
   login: testuser
   password: 01234567890123456789012345678901
-  base_url: https://prod-server.example.com/api
+  base_url: https://prod-server.example.com/bfabric
 TEST:
   login: testuser
   password: 012345678901234567890123456789ff
-  base_url: https://test-server.example.com/api
+  base_url: https://test-server.example.com/bfabric
   application_ids:
     Proteomics/CAT_123: 7
     Proteomics/DOG_552: 6
     Proteomics/DUCK_666: 12
   job_notification_emails: user1@example.com user2@example.com
 STANDBY:
-  base_url: https://standby-server.example.com/api
+  base_url: https://standby-server.example.com/bfabric

--- a/tests/bfabric/config/test_backward_compat.py
+++ b/tests/bfabric/config/test_backward_compat.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel, Field, SecretStr, ValidationError, model_validat
 
 from bfabric.config.config_file import EnvironmentConfig
 
-
 # --- Vendored replica of the bfabric 1.19.0 config schema (do not "fix" to match new code) ---
 
 

--- a/tests/bfabric/config/test_backward_compat.py
+++ b/tests/bfabric/config/test_backward_compat.py
@@ -73,7 +73,7 @@ def test_pat_env_is_parseable_by_legacy_client():
     """A file with a current-shape PAT env plus a normal password env loads on a 1.19.0 client."""
     config = {
         "GENERAL": {"default_config": "PROD"},
-        "PROD": {"base_url": "https://prod.example.com", "login": "user", "password": "x" * 32},
+        "PROD": {"base_url": "https://prod.example.com/bfabric", "login": "user", "password": "x" * 32},
         "OAUTH": _pat_env_shape(),
     }
     legacy = LegacyConfigFile.model_validate(config)
@@ -88,7 +88,7 @@ def test_legacy_client_rejects_old_rc1_pat_shape():
     """Negative control: the rc1 shape (login + inline short password) DID poison the file."""
     config = {
         "GENERAL": {"default_config": "PROD"},
-        "PROD": {"base_url": "https://prod.example.com", "login": "user", "password": "x" * 32},
+        "PROD": {"base_url": "https://prod.example.com/bfabric", "login": "user", "password": "x" * 32},
         "OAUTH": {"base_url": "https://example.com/bfabric", "login": "__oauth__", "password": "short-pat-token"},
     }
     with pytest.raises(ValidationError):

--- a/tests/bfabric/config/test_base_url.py
+++ b/tests/bfabric/config/test_base_url.py
@@ -19,10 +19,6 @@ class TestCanonicalisation:
     def test_drops_trailing_slashes(self, raw):
         assert BaseUrl(raw) == "https://example.com/bfabric"
 
-    def test_host_only_url_keeps_no_slash(self):
-        # AnyHttpUrl re-adds the slash for an empty path, so the strip has to happen after validation.
-        assert BaseUrl("https://example.com") == "https://example.com"
-
     def test_normalizes_host_case_and_default_port(self):
         assert BaseUrl("https://EXAMPLE.com:443/bfabric") == "https://example.com/bfabric"
 
@@ -40,6 +36,58 @@ class TestCanonicalisation:
         # Pydantic wraps a validator's ValueError, so model errors keep their usual shape.
         with pytest.raises(ValidationError):
             BfabricClientConfig.model_validate({"base_url": "not a url"})
+
+
+class TestInstancePath:
+    """The URL has to name the B-Fabric servlet, not just its host.
+
+    Everything downstream already assumes it: the WSDL is ``{base_url}/{endpoint}?wsdl`` and
+    ``EntityUri`` insists on a ``/bfabric`` first path segment, so a host-only URL is a config
+    mistake that used to surface much later as a 404 or an instance mismatch.
+    """
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "https://example.com/bfabric",
+            "https://example.com/lims/bfabric",  # a deployment behind a path prefix
+            "http://localhost:8080/bfabric",
+        ],
+    )
+    def test_accepts_an_instance_url(self, raw):
+        assert BaseUrl(raw).endswith("/bfabric")
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "https://example.com",
+            "https://example.com/",
+            "https://example.com/bfabric/api",
+            "https://example.com/bfabric/rest/upload",
+            "https://example.com/bfabri",
+            "https://example.com/BFabric",  # a servlet context path is case-sensitive
+            "https://example.com/bfabric?env=prod",
+            "https://example.com/bfabric#frag",
+            "https://bfabric",  # a host named bfabric is still missing the servlet path
+        ],
+    )
+    def test_rejects_anything_else(self, raw):
+        with pytest.raises(ValueError, match="not a B-Fabric instance URL"):
+            BaseUrl(raw)
+
+    @pytest.mark.parametrize(
+        ("raw", "suggestion"),
+        [
+            # The two mistakes worth naming a fix for: a bare host, and a URL reaching past the
+            # servlet root (someone pasting a REST endpoint they saw in a log).
+            ("https://example.com", "https://example.com/bfabric"),
+            ("https://example.com/bfabric/api", "https://example.com/bfabric"),
+            ("https://example.com/lims/bfabric/rest/upload", "https://example.com/lims/bfabric"),
+        ],
+    )
+    def test_names_the_corrected_url(self, raw, suggestion):
+        with pytest.raises(ValueError, match=f"did you mean {suggestion!r}"):
+            BaseUrl(raw)
 
 
 class TestBehavesLikeStr:

--- a/tests/bfabric/config/test_base_url.py
+++ b/tests/bfabric/config/test_base_url.py
@@ -1,0 +1,91 @@
+import pickle
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from bfabric.config import BfabricClientConfig, BaseUrl
+
+
+class TestCanonicalisation:
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "https://example.com/bfabric",
+            "https://example.com/bfabric/",
+            "https://example.com/bfabric////",
+        ],
+    )
+    def test_drops_trailing_slashes(self, raw):
+        assert BaseUrl(raw) == "https://example.com/bfabric"
+
+    def test_host_only_url_keeps_no_slash(self):
+        # AnyHttpUrl re-adds the slash for an empty path, so the strip has to happen after validation.
+        assert BaseUrl("https://example.com") == "https://example.com"
+
+    def test_normalizes_host_case_and_default_port(self):
+        assert BaseUrl("https://EXAMPLE.com:443/bfabric") == "https://example.com/bfabric"
+
+    def test_is_idempotent(self):
+        once = BaseUrl("https://example.com/bfabric/")
+        assert BaseUrl(once) == once
+
+    @pytest.mark.parametrize("raw", ["not a url", "", "ftp://example.com/bfabric"])
+    def test_rejects_non_http_url(self, raw):
+        # A plain ValueError, not a pydantic ValidationError: the CLI prints this straight to the user.
+        with pytest.raises(ValueError, match="Not a valid http"):
+            BaseUrl(raw)
+
+    def test_rejection_surfaces_as_a_validation_error_on_a_model(self):
+        # Pydantic wraps a validator's ValueError, so model errors keep their usual shape.
+        with pytest.raises(ValidationError):
+            BfabricClientConfig.model_validate({"base_url": "not a url"})
+
+
+class TestBehavesLikeStr:
+    """The reason this is a ``str`` subclass rather than a wrapper model."""
+
+    def test_interpolates_without_ceremony(self):
+        url = BaseUrl("https://example.com/bfabric")
+        assert f"{url}/rest/oauth/token" == "https://example.com/bfabric/rest/oauth/token"
+
+    def test_compares_and_hashes_as_str(self):
+        url = BaseUrl("https://example.com/bfabric/")
+        assert url == "https://example.com/bfabric"
+        assert {url: 1}["https://example.com/bfabric"] == 1
+
+    def test_survives_pickling(self):
+        url = BaseUrl("https://example.com/bfabric")
+        assert pickle.loads(pickle.dumps(url)) == url
+
+
+class TestOnTheConfigModel:
+    def test_field_is_canonicalised(self):
+        config = BfabricClientConfig(base_url=BaseUrl("https://example.com/bfabric/"))
+        assert config.base_url == "https://example.com/bfabric"
+        assert isinstance(config.base_url, BaseUrl)
+
+    def test_model_validate_accepts_a_plain_string(self):
+        # The config is the boundary where un-canonicalised input legitimately arrives.
+        config = BfabricClientConfig.model_validate({"base_url": "https://example.com/bfabric/"})
+        assert config.base_url == "https://example.com/bfabric"
+
+    def test_json_dump_yields_a_plain_str(self):
+        config = BfabricClientConfig.model_validate({"base_url": "https://example.com/bfabric"})
+        dumped = config.model_dump(mode="json")
+        assert type(dumped["base_url"]) is str
+
+    def test_json_dump_is_yaml_safe_dumpable(self):
+        """Guards the trap: a str subclass reaching a yaml dumper writes an unloadable file.
+
+        ``yaml.safe_dump`` raises on a subclass and plain ``yaml.dump`` silently emits a
+        ``!!python/object/new:`` tag, so anything bound for YAML must go through json-mode dumping.
+        """
+        config = BfabricClientConfig.model_validate({"base_url": "https://example.com/bfabric"})
+        serialized = yaml.safe_dump(config.model_dump(mode="json"))
+        assert yaml.safe_load(serialized)["base_url"] == "https://example.com/bfabric"
+
+    def test_round_trip_dump_reloads(self):
+        config = BfabricClientConfig.model_validate({"base_url": "https://example.com/bfabric"})
+        dumped = config.model_dump(mode="json", round_trip=True)
+        assert BfabricClientConfig.model_validate(dumped) == config

--- a/tests/bfabric/config/test_base_url.py
+++ b/tests/bfabric/config/test_base_url.py
@@ -75,20 +75,6 @@ class TestInstancePath:
         with pytest.raises(ValueError, match="not a B-Fabric instance URL"):
             BaseUrl(raw)
 
-    @pytest.mark.parametrize(
-        ("raw", "suggestion"),
-        [
-            # The two mistakes worth naming a fix for: a bare host, and a URL reaching past the
-            # servlet root (someone pasting a REST endpoint they saw in a log).
-            ("https://example.com", "https://example.com/bfabric"),
-            ("https://example.com/bfabric/api", "https://example.com/bfabric"),
-            ("https://example.com/lims/bfabric/rest/upload", "https://example.com/lims/bfabric"),
-        ],
-    )
-    def test_names_the_corrected_url(self, raw, suggestion):
-        with pytest.raises(ValueError, match=f"did you mean {suggestion!r}"):
-            BaseUrl(raw)
-
 
 class TestBehavesLikeStr:
     """The reason this is a ``str`` subclass rather than a wrapper model."""

--- a/tests/bfabric/config/test_bfabric_client_config.py
+++ b/tests/bfabric/config/test_bfabric_client_config.py
@@ -14,7 +14,7 @@ from bfabric.config.config_file import read_config_file
 @pytest.fixture
 def mock_config() -> BfabricClientConfig:
     return BfabricClientConfig(
-        base_url="https://example.com",
+        base_url="https://example.com/bfabric",
         application_ids={"app": 1},
     )
 
@@ -30,7 +30,7 @@ class TestEngine:
 
     def test_unknown_engine_is_rejected(self):
         with pytest.raises(ValidationError):
-            BfabricClientConfig(base_url="https://example.com", engine="ZEEP")
+            BfabricClientConfig(base_url="https://example.com/bfabric", engine="ZEEP")
 
 
 class TestDefaultParams:
@@ -62,18 +62,18 @@ class TestBaseUrl:
 
     def test_normalizes_host_only_url(self):
         # AnyHttpUrl re-adds the slash for an empty path, so the strip has to happen after validation.
-        config = BfabricClientConfig(base_url="https://example.com")
-        assert config.base_url == "https://example.com"
+        config = BfabricClientConfig(base_url="https://example.com/bfabric")
+        assert config.base_url == "https://example.com/bfabric"
 
 
 def test_bfabric_config_copy_with_overrides(mock_config: BfabricClientConfig) -> None:
     new_config = mock_config.copy_with(
-        base_url="https://example.com/new-url",
+        base_url="https://other.example.com/bfabric",
         application_ids={"new": 2},
     )
-    assert new_config.base_url == "https://example.com/new-url"
+    assert new_config.base_url == "https://other.example.com/bfabric"
     assert new_config.application_ids == {"new": 2}
-    assert mock_config.base_url == "https://example.com"
+    assert mock_config.base_url == "https://example.com/bfabric"
     assert mock_config.application_ids == {"app": 1}
 
 
@@ -81,9 +81,9 @@ def test_bfabric_config_copy_with_replaced_when_none(
     mock_config: BfabricClientConfig,
 ) -> None:
     new_config = mock_config.copy_with(base_url=None, application_ids=None)
-    assert new_config.base_url == "https://example.com"
+    assert new_config.base_url == "https://example.com/bfabric"
     assert new_config.application_ids == {"app": 1}
-    assert mock_config.base_url == "https://example.com"
+    assert mock_config.base_url == "https://example.com/bfabric"
     assert mock_config.application_ids == {"app": 1}
 
 
@@ -101,7 +101,7 @@ def test_bfabric_config_read_yml_bypath_default(mocker: MockerFixture, example_c
     config, auth = read_config_file(example_config_path)
     assert auth.login == "testuser"
     assert auth.password.get_secret_value() == "01234567890123456789012345678901"
-    assert config.base_url == "https://prod-server.example.com/api"
+    assert config.base_url == "https://prod-server.example.com/bfabric"
 
     logot.assert_logged(
         logged.debug(f"Reading configuration from: {str(example_config_path.absolute())} config_env=None")
@@ -118,7 +118,7 @@ def test_bfabric_config_read_yml_bypath_environment_variable(
     config, auth = read_config_file(example_config_path)
     assert auth.login == "testuser"
     assert auth.password.get_secret_value() == "012345678901234567890123456789ff"
-    assert config.base_url == "https://test-server.example.com/api"
+    assert config.base_url == "https://test-server.example.com/bfabric"
 
     logot.assert_logged(
         logged.debug(f"Reading configuration from: {str(example_config_path.absolute())} config_env=None")
@@ -130,7 +130,7 @@ def test_bfabric_config_read_yml_bypath_environment_variable(
 def test_repr(mock_config: BfabricClientConfig, variant) -> None:
     rep = variant(mock_config)
     assert rep == (
-        "BfabricClientConfig(base_url='https://example.com', application_ids={'app': 1}, job_notification_emails='',"
+        "BfabricClientConfig(base_url='https://example.com/bfabric', application_ids={'app': 1}, job_notification_emails='',"
         " engine=BfabricAPIEngineType.SUDS)"
     )
 

--- a/tests/bfabric/config/test_bfabric_client_config.py
+++ b/tests/bfabric/config/test_bfabric_client_config.py
@@ -58,7 +58,12 @@ class TestBaseUrl:
     )
     def test_normalizes_slash(self, base_url):
         config = BfabricClientConfig(base_url=base_url)
-        assert config.base_url == "https://example.com/bfabric/"
+        assert config.base_url == "https://example.com/bfabric"
+
+    def test_normalizes_host_only_url(self):
+        # AnyHttpUrl re-adds the slash for an empty path, so the strip has to happen after validation.
+        config = BfabricClientConfig(base_url="https://example.com")
+        assert config.base_url == "https://example.com"
 
 
 def test_bfabric_config_copy_with_overrides(mock_config: BfabricClientConfig) -> None:
@@ -66,9 +71,9 @@ def test_bfabric_config_copy_with_overrides(mock_config: BfabricClientConfig) ->
         base_url="https://example.com/new-url",
         application_ids={"new": 2},
     )
-    assert new_config.base_url == "https://example.com/new-url/"
+    assert new_config.base_url == "https://example.com/new-url"
     assert new_config.application_ids == {"new": 2}
-    assert mock_config.base_url == "https://example.com/"
+    assert mock_config.base_url == "https://example.com"
     assert mock_config.application_ids == {"app": 1}
 
 
@@ -76,9 +81,9 @@ def test_bfabric_config_copy_with_replaced_when_none(
     mock_config: BfabricClientConfig,
 ) -> None:
     new_config = mock_config.copy_with(base_url=None, application_ids=None)
-    assert new_config.base_url == "https://example.com/"
+    assert new_config.base_url == "https://example.com"
     assert new_config.application_ids == {"app": 1}
-    assert mock_config.base_url == "https://example.com/"
+    assert mock_config.base_url == "https://example.com"
     assert mock_config.application_ids == {"app": 1}
 
 
@@ -96,7 +101,7 @@ def test_bfabric_config_read_yml_bypath_default(mocker: MockerFixture, example_c
     config, auth = read_config_file(example_config_path)
     assert auth.login == "testuser"
     assert auth.password.get_secret_value() == "01234567890123456789012345678901"
-    assert config.base_url == "https://prod-server.example.com/api/"
+    assert config.base_url == "https://prod-server.example.com/api"
 
     logot.assert_logged(
         logged.debug(f"Reading configuration from: {str(example_config_path.absolute())} config_env=None")
@@ -113,7 +118,7 @@ def test_bfabric_config_read_yml_bypath_environment_variable(
     config, auth = read_config_file(example_config_path)
     assert auth.login == "testuser"
     assert auth.password.get_secret_value() == "012345678901234567890123456789ff"
-    assert config.base_url == "https://test-server.example.com/api/"
+    assert config.base_url == "https://test-server.example.com/api"
 
     logot.assert_logged(
         logged.debug(f"Reading configuration from: {str(example_config_path.absolute())} config_env=None")
@@ -125,7 +130,7 @@ def test_bfabric_config_read_yml_bypath_environment_variable(
 def test_repr(mock_config: BfabricClientConfig, variant) -> None:
     rep = variant(mock_config)
     assert rep == (
-        "BfabricClientConfig(base_url='https://example.com/', application_ids={'app': 1}, job_notification_emails='',"
+        "BfabricClientConfig(base_url='https://example.com', application_ids={'app': 1}, job_notification_emails='',"
         " engine=BfabricAPIEngineType.SUDS)"
     )
 

--- a/tests/bfabric/config/test_config_data.py
+++ b/tests/bfabric/config/test_config_data.py
@@ -54,7 +54,7 @@ class TestLoadConfigData:
         loaded_config = load_config_data(
             config_file_path=example_config_path, config_file_env="default", include_auth=include_auth
         )
-        assert loaded_config.client.base_url == "https://prod-server.example.com/api/"
+        assert loaded_config.client.base_url == "https://prod-server.example.com/api"
         if include_auth:
             assert loaded_config.auth.login == "testuser"
         else:
@@ -68,7 +68,7 @@ class TestLoadConfigData:
         loaded_config = load_config_data(
             config_file_path=example_config_path, config_file_env="default", include_auth=include_auth
         )
-        assert loaded_config.client.base_url == "https://test-server.example.com/api/"
+        assert loaded_config.client.base_url == "https://test-server.example.com/api"
         if include_auth:
             assert loaded_config.auth.login == "testuser"
         else:
@@ -82,7 +82,7 @@ class TestLoadConfigData:
         loaded_config = load_config_data(
             config_file_path=example_config_path, config_file_env="TEST", include_auth=include_auth
         )
-        assert loaded_config.client.base_url == "https://test-server.example.com/api/"
+        assert loaded_config.client.base_url == "https://test-server.example.com/api"
         if include_auth:
             assert loaded_config.auth.login == "testuser"
         else:

--- a/tests/bfabric/config/test_config_data.py
+++ b/tests/bfabric/config/test_config_data.py
@@ -9,7 +9,7 @@ from bfabric import BfabricClientConfig, BfabricAuth
 
 @pytest.fixture
 def client_config():
-    return BfabricClientConfig(base_url="https://example.com")
+    return BfabricClientConfig(base_url="https://example.com/bfabric")
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ class TestLoadConfigData:
         loaded_config = load_config_data(
             config_file_path=example_config_path, config_file_env="default", include_auth=include_auth
         )
-        assert loaded_config.client.base_url == "https://prod-server.example.com/api"
+        assert loaded_config.client.base_url == "https://prod-server.example.com/bfabric"
         if include_auth:
             assert loaded_config.auth.login == "testuser"
         else:
@@ -68,7 +68,7 @@ class TestLoadConfigData:
         loaded_config = load_config_data(
             config_file_path=example_config_path, config_file_env="default", include_auth=include_auth
         )
-        assert loaded_config.client.base_url == "https://test-server.example.com/api"
+        assert loaded_config.client.base_url == "https://test-server.example.com/bfabric"
         if include_auth:
             assert loaded_config.auth.login == "testuser"
         else:
@@ -82,7 +82,7 @@ class TestLoadConfigData:
         loaded_config = load_config_data(
             config_file_path=example_config_path, config_file_env="TEST", include_auth=include_auth
         )
-        assert loaded_config.client.base_url == "https://test-server.example.com/api"
+        assert loaded_config.client.base_url == "https://test-server.example.com/bfabric"
         if include_auth:
             assert loaded_config.auth.login == "testuser"
         else:

--- a/tests/bfabric/config/test_config_file.py
+++ b/tests/bfabric/config/test_config_file.py
@@ -62,14 +62,14 @@ def test_general_config(data_with_auth):
 
 def test_environment_config_when_auth(data_with_auth):
     config = EnvironmentConfig.model_validate(data_with_auth["PRODUCTION"])
-    assert config.config.base_url == "https://example.com/"
+    assert config.config.base_url == "https://example.com"
     assert config.auth.login == "test-dummy"
     assert config.auth.password.get_secret_value() == "00000000001111111111222222222233"
 
 
 def test_environment_config_when_no_auth(data_no_auth):
     config = EnvironmentConfig.model_validate(data_no_auth["PRODUCTION"])
-    assert config.config.base_url == "https://example.com/"
+    assert config.config.base_url == "https://example.com"
     assert config.auth is None
 
 
@@ -82,7 +82,7 @@ def test_environment_config_when_pat():
             "pat": "short-pat-token",
         }
     )
-    assert config.config.base_url == "https://example.com/"
+    assert config.config.base_url == "https://example.com"
     assert config.auth_method == "pat"
     assert config.auth.login == OAUTH_LOGIN
     assert config.auth.password.get_secret_value() == "short-pat-token"
@@ -105,7 +105,7 @@ def test_config_file_when_auth(data_with_auth):
     config = ConfigFile.model_validate(data_with_auth)
     assert config.general.default_config == "PRODUCTION"
     assert len(config.environments) == 1
-    assert config.environments["PRODUCTION"].config.base_url == "https://example.com/"
+    assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
     assert config.environments["PRODUCTION"].auth.login == "test-dummy"
     assert config.environments["PRODUCTION"].auth.password.get_secret_value() == "00000000001111111111222222222233"
 
@@ -114,7 +114,7 @@ def test_config_file_when_no_auth(data_no_auth):
     config = ConfigFile.model_validate(data_no_auth)
     assert config.general.default_config == "PRODUCTION"
     assert len(config.environments) == 1
-    assert config.environments["PRODUCTION"].config.base_url == "https://example.com/"
+    assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
     assert config.environments["PRODUCTION"].auth is None
 
 
@@ -122,9 +122,9 @@ def test_config_file_when_multiple(data_multiple):
     config = ConfigFile.model_validate(data_multiple)
     assert config.general.default_config == "PRODUCTION"
     assert len(config.environments) == 2
-    assert config.environments["PRODUCTION"].config.base_url == "https://example.com/"
+    assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
     assert config.environments["PRODUCTION"].auth is None
-    assert config.environments["TEST"].config.base_url == "https://test.example.com/"
+    assert config.environments["TEST"].config.base_url == "https://test.example.com"
     assert config.environments["TEST"].auth.login == "test-dummy"
     assert config.environments["TEST"].auth.password.get_secret_value() == "00000000001111111111222222222233"
 
@@ -181,7 +181,7 @@ class TestConfigNoDefault:
     @staticmethod
     def test_validate(config):
         assert config.general.default_config is None
-        assert config.environments["PRODUCTION"].config.base_url == "https://example.com/"
+        assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
 
     @staticmethod
     def test_get_selected_config_env(config):
@@ -216,14 +216,14 @@ class TestReadConfig:
 
         assert auth.login == "testuser"
         assert auth.password.get_secret_value() == "012345678901234567890123456789ff"
-        assert config.base_url == "https://test-server.example.com/api/"
+        assert config.base_url == "https://test-server.example.com/api"
         assert config.application_ids == applications_dict_ground_truth
         assert config.job_notification_emails == job_notification_emails_ground_truth
 
     def test_when_empty_optional(self, example_config_path: Path, logot: Logot) -> None:
         config, auth = read_config_file(example_config_path, config_env="STANDBY")
         assert auth is None
-        assert config.base_url == "https://standby-server.example.com/api/"
+        assert config.base_url == "https://standby-server.example.com/api"
         assert config.application_ids == {}
         assert config.job_notification_emails == ""
         logot.assert_logged(

--- a/tests/bfabric/config/test_config_file.py
+++ b/tests/bfabric/config/test_config_file.py
@@ -20,7 +20,7 @@ def data_with_auth():
         "PRODUCTION": {
             "login": "test-dummy",
             "password": "00000000001111111111222222222233",
-            "base_url": "https://example.com",
+            "base_url": "https://example.com/bfabric",
         },
     }
 
@@ -30,7 +30,7 @@ def data_no_auth():
     return {
         "GENERAL": {"default_config": "PRODUCTION"},
         "PRODUCTION": {
-            "base_url": "https://example.com",
+            "base_url": "https://example.com/bfabric",
         },
     }
 
@@ -40,10 +40,10 @@ def data_multiple():
     return {
         "GENERAL": {"default_config": "PRODUCTION"},
         "PRODUCTION": {
-            "base_url": "https://example.com",
+            "base_url": "https://example.com/bfabric",
         },
         "TEST": {
-            "base_url": "https://test.example.com",
+            "base_url": "https://test.example.com/bfabric",
             "login": "test-dummy",
             "password": "00000000001111111111222222222233",
         },
@@ -62,14 +62,14 @@ def test_general_config(data_with_auth):
 
 def test_environment_config_when_auth(data_with_auth):
     config = EnvironmentConfig.model_validate(data_with_auth["PRODUCTION"])
-    assert config.config.base_url == "https://example.com"
+    assert config.config.base_url == "https://example.com/bfabric"
     assert config.auth.login == "test-dummy"
     assert config.auth.password.get_secret_value() == "00000000001111111111222222222233"
 
 
 def test_environment_config_when_no_auth(data_no_auth):
     config = EnvironmentConfig.model_validate(data_no_auth["PRODUCTION"])
-    assert config.config.base_url == "https://example.com"
+    assert config.config.base_url == "https://example.com/bfabric"
     assert config.auth is None
 
 
@@ -77,12 +77,12 @@ def test_environment_config_when_pat():
     """A PAT env (``auth_method: pat`` + inline ``pat``) builds an OAuth-style auth."""
     config = EnvironmentConfig.model_validate(
         {
-            "base_url": "https://example.com",
+            "base_url": "https://example.com/bfabric",
             "auth_method": "pat",
             "pat": "short-pat-token",
         }
     )
-    assert config.config.base_url == "https://example.com"
+    assert config.config.base_url == "https://example.com/bfabric"
     assert config.auth_method == "pat"
     assert config.auth.login == OAUTH_LOGIN
     assert config.auth.password.get_secret_value() == "short-pat-token"
@@ -92,7 +92,7 @@ def test_environment_config_when_legacy_oauth_login():
     """The legacy 1.20.0rc1 PAT shape (``login: __oauth__`` + inline ``password``) still reads."""
     config = EnvironmentConfig.model_validate(
         {
-            "base_url": "https://example.com",
+            "base_url": "https://example.com/bfabric",
             "login": OAUTH_LOGIN,
             "password": "short-pat-token",
         }
@@ -105,7 +105,7 @@ def test_config_file_when_auth(data_with_auth):
     config = ConfigFile.model_validate(data_with_auth)
     assert config.general.default_config == "PRODUCTION"
     assert len(config.environments) == 1
-    assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
+    assert config.environments["PRODUCTION"].config.base_url == "https://example.com/bfabric"
     assert config.environments["PRODUCTION"].auth.login == "test-dummy"
     assert config.environments["PRODUCTION"].auth.password.get_secret_value() == "00000000001111111111222222222233"
 
@@ -114,7 +114,7 @@ def test_config_file_when_no_auth(data_no_auth):
     config = ConfigFile.model_validate(data_no_auth)
     assert config.general.default_config == "PRODUCTION"
     assert len(config.environments) == 1
-    assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
+    assert config.environments["PRODUCTION"].config.base_url == "https://example.com/bfabric"
     assert config.environments["PRODUCTION"].auth is None
 
 
@@ -122,9 +122,9 @@ def test_config_file_when_multiple(data_multiple):
     config = ConfigFile.model_validate(data_multiple)
     assert config.general.default_config == "PRODUCTION"
     assert len(config.environments) == 2
-    assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
+    assert config.environments["PRODUCTION"].config.base_url == "https://example.com/bfabric"
     assert config.environments["PRODUCTION"].auth is None
-    assert config.environments["TEST"].config.base_url == "https://test.example.com"
+    assert config.environments["TEST"].config.base_url == "https://test.example.com/bfabric"
     assert config.environments["TEST"].auth.login == "test-dummy"
     assert config.environments["TEST"].auth.password.get_secret_value() == "00000000001111111111222222222233"
 
@@ -156,7 +156,7 @@ def test_get_selected_config(config_with_auth, mocker):
 
 
 def test_reject_env_name_default(mocker, data_no_auth):
-    data_no_auth["default"] = {"base_url": "https://example.com"}
+    data_no_auth["default"] = {"base_url": "https://example.com/bfabric"}
     with pytest.raises(ValueError) as error:
         ConfigFile.model_validate(data_no_auth)
     assert "Environment name 'default' is reserved." in str(error.value)
@@ -169,7 +169,7 @@ class TestConfigNoDefault:
         return {
             "GENERAL": {},
             "PRODUCTION": {
-                "base_url": "https://example.com",
+                "base_url": "https://example.com/bfabric",
             },
         }
 
@@ -181,7 +181,7 @@ class TestConfigNoDefault:
     @staticmethod
     def test_validate(config):
         assert config.general.default_config is None
-        assert config.environments["PRODUCTION"].config.base_url == "https://example.com"
+        assert config.environments["PRODUCTION"].config.base_url == "https://example.com/bfabric"
 
     @staticmethod
     def test_get_selected_config_env(config):
@@ -216,14 +216,14 @@ class TestReadConfig:
 
         assert auth.login == "testuser"
         assert auth.password.get_secret_value() == "012345678901234567890123456789ff"
-        assert config.base_url == "https://test-server.example.com/api"
+        assert config.base_url == "https://test-server.example.com/bfabric"
         assert config.application_ids == applications_dict_ground_truth
         assert config.job_notification_emails == job_notification_emails_ground_truth
 
     def test_when_empty_optional(self, example_config_path: Path, logot: Logot) -> None:
         config, auth = read_config_file(example_config_path, config_env="STANDBY")
         assert auth is None
-        assert config.base_url == "https://standby-server.example.com/api"
+        assert config.base_url == "https://standby-server.example.com/bfabric"
         assert config.application_ids == {}
         assert config.job_notification_emails == ""
         logot.assert_logged(
@@ -235,7 +235,7 @@ class TestEnvironmentConfigOAuth:
     def test_auth_method_oauth(self):
         config = EnvironmentConfig.model_validate(
             {
-                "base_url": "https://example.com",
+                "base_url": "https://example.com/bfabric",
                 "auth_method": "oauth",
                 "client_id": "my-app",
             }
@@ -248,7 +248,7 @@ class TestEnvironmentConfigOAuth:
         """auth_method and client_id should not leak into BfabricClientConfig."""
         config = EnvironmentConfig.model_validate(
             {
-                "base_url": "https://example.com",
+                "base_url": "https://example.com/bfabric",
                 "auth_method": "oauth",
                 "client_id": "my-app",
             }
@@ -259,7 +259,7 @@ class TestEnvironmentConfigOAuth:
     def test_scope_binds(self):
         config = EnvironmentConfig.model_validate(
             {
-                "base_url": "https://example.com",
+                "base_url": "https://example.com/bfabric",
                 "auth_method": "oauth",
                 "client_id": "my-app",
                 "scope": "api:write tus",
@@ -269,19 +269,19 @@ class TestEnvironmentConfigOAuth:
 
     def test_scope_not_in_client_config(self):
         config = EnvironmentConfig.model_validate(
-            {"base_url": "https://example.com", "auth_method": "oauth", "scope": "api:read"}
+            {"base_url": "https://example.com/bfabric", "auth_method": "oauth", "scope": "api:read"}
         )
         assert not hasattr(config.config, "scope")
 
     def test_scope_absent_defaults_to_none(self):
         """An environment written by 1.16.0 has no ``scope`` key; it must still load."""
-        config = EnvironmentConfig.model_validate({"base_url": "https://example.com", "auth_method": "oauth"})
+        config = EnvironmentConfig.model_validate({"base_url": "https://example.com/bfabric", "auth_method": "oauth"})
         assert config.scope is None
 
     def test_backward_compat_without_oauth_fields(self):
         config = EnvironmentConfig.model_validate(
             {
-                "base_url": "https://example.com",
+                "base_url": "https://example.com/bfabric",
                 "login": "user",
                 "password": "x" * 32,
             }

--- a/tests/bfabric/config/test_config_writer.py
+++ b/tests/bfabric/config/test_config_writer.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from bfabric.config import BaseUrl
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
 from bfabric.config.config_file import ConfigFile
 from bfabric.config.config_writer import (
@@ -18,6 +19,16 @@ from bfabric.config.config_writer import (
 
 
 class TestWriteEnvironmentToConfig:
+    def test_writes_a_str_subclass_as_a_plain_scalar(self, tmp_path):
+        """A ``BaseUrl`` needs no coercion by the caller, and must not reach the file as an
+        unloadable ``!!python/object/new:`` tag."""
+        config_path = tmp_path / "config.yml"
+        write_environment_to_config(
+            config_path, "PROD", {"base_url": BaseUrl("https://example.com/bfabric")}, set_default=True
+        )
+        assert "!!python/object" not in config_path.read_text()
+        assert yaml.safe_load(config_path.read_text())["PROD"]["base_url"] == "https://example.com/bfabric"
+
     def test_creates_new_file(self, tmp_path):
         config_path = tmp_path / "config.yml"
         write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com"}, set_default=True)
@@ -189,7 +200,7 @@ class TestRoundTrip:
         assert env.auth is not None
         assert env.auth.login == OAUTH_LOGIN
         assert env.auth.password.get_secret_value() == "secret-pat"
-        assert env.config.base_url == "https://example.com/"
+        assert env.config.base_url == "https://example.com"
 
     def test_oauth_env_round_trips(self, tmp_path):
         config_path = tmp_path / "config.yml"
@@ -204,7 +215,7 @@ class TestRoundTrip:
         assert env.auth is None
         assert env.auth_method == "oauth"
         assert env.client_id == "cid"
-        assert env.config.base_url == "https://example.com/"
+        assert env.config.base_url == "https://example.com"
 
     def test_rejects_unparseable_env(self, tmp_path):
         # base_url is required by BfabricClientConfig; without it the written file would fail to

--- a/tests/bfabric/config/test_config_writer.py
+++ b/tests/bfabric/config/test_config_writer.py
@@ -31,14 +31,14 @@ class TestWriteEnvironmentToConfig:
 
     def test_creates_new_file(self, tmp_path):
         config_path = tmp_path / "config.yml"
-        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com"}, set_default=True)
+        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com/bfabric"}, set_default=True)
         data = yaml.safe_load(config_path.read_text())
         assert data["GENERAL"]["default_config"] == "PROD"
-        assert data["PROD"]["base_url"] == "https://example.com"
+        assert data["PROD"]["base_url"] == "https://example.com/bfabric"
 
     def test_sets_permissions(self, tmp_path):
         config_path = tmp_path / "config.yml"
-        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com"}, set_default=True)
+        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com/bfabric"}, set_default=True)
         mode = stat.S_IMODE(os.stat(config_path).st_mode)
         assert mode == 0o600
 
@@ -53,7 +53,7 @@ class TestWriteEnvironmentToConfig:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "login": "__oauth__", "password": "secret-pat"},
+            {"base_url": "https://example.com/bfabric", "login": "__oauth__", "password": "secret-pat"},
             set_default=True,
         )
         mode = stat.S_IMODE(os.stat(config_path).st_mode)
@@ -65,22 +65,28 @@ class TestWriteEnvironmentToConfig:
             yaml.dump(
                 {
                     "GENERAL": {"default_config": "OLD"},
-                    "OLD": {"base_url": "https://old.example.com"},
+                    "OLD": {"base_url": "https://old.example.com/bfabric"},
                 }
             )
         )
-        write_environment_to_config(config_path, "NEW", {"base_url": "https://new.example.com"}, set_default=True)
+        write_environment_to_config(
+            config_path, "NEW", {"base_url": "https://new.example.com/bfabric"}, set_default=True
+        )
         data = yaml.safe_load(config_path.read_text())
         assert data["GENERAL"]["default_config"] == "NEW"
-        assert data["OLD"]["base_url"] == "https://old.example.com"
-        assert data["NEW"]["base_url"] == "https://new.example.com"
+        assert data["OLD"]["base_url"] == "https://old.example.com/bfabric"
+        assert data["NEW"]["base_url"] == "https://new.example.com/bfabric"
 
     def test_overwrites_supplied_keys_of_existing_env(self, tmp_path):
         config_path = tmp_path / "config.yml"
-        write_environment_to_config(config_path, "PROD", {"base_url": "https://v1.example.com"}, set_default=True)
-        write_environment_to_config(config_path, "PROD", {"base_url": "https://v2.example.com"}, set_default=True)
+        write_environment_to_config(
+            config_path, "PROD", {"base_url": "https://v1.example.com/bfabric"}, set_default=True
+        )
+        write_environment_to_config(
+            config_path, "PROD", {"base_url": "https://v2.example.com/bfabric"}, set_default=True
+        )
         data = yaml.safe_load(config_path.read_text())
-        assert data["PROD"]["base_url"] == "https://v2.example.com"
+        assert data["PROD"]["base_url"] == "https://v2.example.com/bfabric"
 
     def test_preserves_unrelated_keys_of_existing_env(self, tmp_path):
         """A re-login must not wipe hand-written keys the CLI knows nothing about."""
@@ -90,7 +96,7 @@ class TestWriteEnvironmentToConfig:
                 {
                     "GENERAL": {"default_config": "PROD"},
                     "PROD": {
-                        "base_url": "https://v1.example.com",
+                        "base_url": "https://v1.example.com/bfabric",
                         "application_ids": {"app": 123},
                         "job_notification_emails": "me@example.com",
                     },
@@ -100,13 +106,13 @@ class TestWriteEnvironmentToConfig:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://v2.example.com", "auth_method": "oauth", "client_id": "CLI"},
+            {"base_url": "https://v2.example.com/bfabric", "auth_method": "oauth", "client_id": "CLI"},
             set_default=True,
         )
         env = yaml.safe_load(config_path.read_text())["PROD"]
         assert env["application_ids"] == {"app": 123}
         assert env["job_notification_emails"] == "me@example.com"
-        assert env["base_url"] == "https://v2.example.com"
+        assert env["base_url"] == "https://v2.example.com/bfabric"
 
     def test_drops_stale_pat_when_re_login_is_oauth(self, tmp_path):
         """Auth-owned keys are replaced wholesale: a leftover ``pat`` would be resurrected by
@@ -115,13 +121,18 @@ class TestWriteEnvironmentToConfig:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "auth_method": "pat", "pat": "secret-pat"},
+            {"base_url": "https://example.com/bfabric", "auth_method": "pat", "pat": "secret-pat"},
             set_default=True,
         )
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "auth_method": "oauth", "client_id": "CLI", "scope": "api:read"},
+            {
+                "base_url": "https://example.com/bfabric",
+                "auth_method": "oauth",
+                "client_id": "CLI",
+                "scope": "api:read",
+            },
             set_default=True,
         )
         env = yaml.safe_load(config_path.read_text())["PROD"]
@@ -136,7 +147,7 @@ class TestWriteEnvironmentToConfig:
                 {
                     "GENERAL": {},
                     "PROD": {
-                        "base_url": "https://example.com",
+                        "base_url": "https://example.com/bfabric",
                         "login": "someone",
                         "password": "x" * 32,
                     },
@@ -146,7 +157,7 @@ class TestWriteEnvironmentToConfig:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "auth_method": "oauth", "client_id": "CLI"},
+            {"base_url": "https://example.com/bfabric", "auth_method": "oauth", "client_id": "CLI"},
             set_default=False,
         )
         env = yaml.safe_load(config_path.read_text())["PROD"]
@@ -158,29 +169,31 @@ class TestWriteEnvironmentToConfig:
         caught before any write, so the config on disk survives intact."""
         config_path = tmp_path / "config.yml"
         config_path.write_text(
-            yaml.dump({"GENERAL": {}, "PROD": {"base_url": "https://example.com", "engine": "bogus"}})
+            yaml.dump({"GENERAL": {}, "PROD": {"base_url": "https://example.com/bfabric", "engine": "bogus"}})
         )
         before = config_path.read_text()
         with pytest.raises(ValidationError):
             write_environment_to_config(
                 config_path,
                 "PROD",
-                {"base_url": "https://example.com", "auth_method": "oauth", "client_id": "CLI"},
+                {"base_url": "https://example.com/bfabric", "auth_method": "oauth", "client_id": "CLI"},
                 set_default=False,
             )
         assert config_path.read_text() == before
 
     def test_set_default_false(self, tmp_path):
         config_path = tmp_path / "config.yml"
-        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com"}, set_default=True)
-        write_environment_to_config(config_path, "TEST", {"base_url": "https://test.example.com"}, set_default=False)
+        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com/bfabric"}, set_default=True)
+        write_environment_to_config(
+            config_path, "TEST", {"base_url": "https://test.example.com/bfabric"}, set_default=False
+        )
         data = yaml.safe_load(config_path.read_text())
         assert data["GENERAL"]["default_config"] == "PROD"
         assert "TEST" in data
 
     def test_creates_parent_dirs(self, tmp_path):
         config_path = tmp_path / "sub" / "dir" / "config.yml"
-        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com"}, set_default=True)
+        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com/bfabric"}, set_default=True)
         assert config_path.is_file()
 
 
@@ -192,7 +205,7 @@ class TestRoundTrip:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "login": OAUTH_LOGIN, "password": "secret-pat"},
+            {"base_url": "https://example.com/bfabric", "login": OAUTH_LOGIN, "password": "secret-pat"},
             set_default=True,
         )
         config_file = ConfigFile.model_validate(yaml.safe_load(config_path.read_text()))
@@ -200,14 +213,14 @@ class TestRoundTrip:
         assert env.auth is not None
         assert env.auth.login == OAUTH_LOGIN
         assert env.auth.password.get_secret_value() == "secret-pat"
-        assert env.config.base_url == "https://example.com"
+        assert env.config.base_url == "https://example.com/bfabric"
 
     def test_oauth_env_round_trips(self, tmp_path):
         config_path = tmp_path / "config.yml"
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "auth_method": "oauth", "client_id": "cid"},
+            {"base_url": "https://example.com/bfabric", "auth_method": "oauth", "client_id": "cid"},
             set_default=True,
         )
         config_file = ConfigFile.model_validate(yaml.safe_load(config_path.read_text()))
@@ -215,7 +228,7 @@ class TestRoundTrip:
         assert env.auth is None
         assert env.auth_method == "oauth"
         assert env.client_id == "cid"
-        assert env.config.base_url == "https://example.com"
+        assert env.config.base_url == "https://example.com/bfabric"
 
     def test_rejects_unparseable_env(self, tmp_path):
         # base_url is required by BfabricClientConfig; without it the written file would fail to
@@ -230,7 +243,9 @@ class TestRoundTrip:
     def test_does_not_corrupt_existing_file_on_invalid_env(self, tmp_path):
         # A rejected write must leave any pre-existing config untouched.
         config_path = tmp_path / "config.yml"
-        write_environment_to_config(config_path, "GOOD", {"base_url": "https://good.example.com"}, set_default=True)
+        write_environment_to_config(
+            config_path, "GOOD", {"base_url": "https://good.example.com/bfabric"}, set_default=True
+        )
         before = config_path.read_text()
         with pytest.raises((ValueError, TypeError)):
             write_environment_to_config(
@@ -244,7 +259,9 @@ class TestRoundTrip:
         # section, so an environment under either name would never load back.
         config_path = tmp_path / "config.yml"
         with pytest.raises(ValueError):
-            write_environment_to_config(config_path, reserved, {"base_url": "https://example.com"}, set_default=True)
+            write_environment_to_config(
+                config_path, reserved, {"base_url": "https://example.com/bfabric"}, set_default=True
+            )
         assert not config_path.exists()
 
 
@@ -255,8 +272,8 @@ class TestSetDefaultConfig:
             yaml.dump(
                 {
                     "GENERAL": {"default_config": "PROD"},
-                    "PROD": {"base_url": "https://prod.example.com"},
-                    "TEST": {"base_url": "https://test.example.com"},
+                    "PROD": {"base_url": "https://prod.example.com/bfabric"},
+                    "TEST": {"base_url": "https://test.example.com/bfabric"},
                 }
             )
         )
@@ -273,8 +290,8 @@ class TestSetDefaultConfig:
         self._write_two_env_config(config_path)
         set_default_config(config_path, "TEST")
         data = yaml.safe_load(config_path.read_text())
-        assert data["PROD"]["base_url"] == "https://prod.example.com"
-        assert data["TEST"]["base_url"] == "https://test.example.com"
+        assert data["PROD"]["base_url"] == "https://prod.example.com/bfabric"
+        assert data["TEST"]["base_url"] == "https://test.example.com/bfabric"
 
     def test_raises_on_unknown_env_and_leaves_file_unchanged(self, tmp_path):
         config_path = tmp_path / "config.yml"
@@ -307,8 +324,8 @@ class TestRemoveEnvironmentFromConfig:
             yaml.dump(
                 {
                     "GENERAL": {"default_config": default},
-                    "PROD": {"base_url": "https://prod.example.com"},
-                    "TEST": {"base_url": "https://test.example.com"},
+                    "PROD": {"base_url": "https://prod.example.com/bfabric"},
+                    "TEST": {"base_url": "https://test.example.com/bfabric"},
                 }
             )
         )
@@ -319,7 +336,7 @@ class TestRemoveEnvironmentFromConfig:
         remove_environment_from_config(config_path, "TEST")
         data = yaml.safe_load(config_path.read_text())
         assert "TEST" not in data
-        assert data["PROD"]["base_url"] == "https://prod.example.com"
+        assert data["PROD"]["base_url"] == "https://prod.example.com/bfabric"
         # Removing a non-default env leaves the default untouched.
         assert data["GENERAL"]["default_config"] == "PROD"
 
@@ -366,14 +383,14 @@ class TestClearEnvironmentCredentials:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "auth_method": "pat", "pat": "secret-pat"},
+            {"base_url": "https://example.com/bfabric", "auth_method": "pat", "pat": "secret-pat"},
             set_default=True,
         )
         removed = clear_environment_credentials(config_path, "PROD")
         assert removed == ("pat",)
         data = yaml.safe_load(config_path.read_text())
         assert "pat" not in data["PROD"]
-        assert data["PROD"]["base_url"] == "https://example.com"
+        assert data["PROD"]["base_url"] == "https://example.com/bfabric"
         assert data["GENERAL"]["default_config"] == "PROD"
 
     def test_strips_login_and_password(self, tmp_path):
@@ -381,7 +398,7 @@ class TestClearEnvironmentCredentials:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "login": "someone", "password": "x" * 32},
+            {"base_url": "https://example.com/bfabric", "login": "someone", "password": "x" * 32},
             set_default=True,
         )
         removed = clear_environment_credentials(config_path, "PROD")
@@ -397,7 +414,7 @@ class TestClearEnvironmentCredentials:
             config_path,
             "PROD",
             {
-                "base_url": "https://example.com",
+                "base_url": "https://example.com/bfabric",
                 "auth_method": "oauth",
                 "client_id": "CLI",
                 "scope": "api:write tus",
@@ -406,7 +423,7 @@ class TestClearEnvironmentCredentials:
         )
         assert clear_environment_credentials(config_path, "PROD") == ()
         env = yaml.safe_load(config_path.read_text())["PROD"]
-        assert env["base_url"] == "https://example.com"
+        assert env["base_url"] == "https://example.com/bfabric"
         assert env["client_id"] == "CLI"
         assert env["scope"] == "api:write tus"
 
@@ -415,7 +432,7 @@ class TestClearEnvironmentCredentials:
         write_environment_to_config(
             config_path,
             "PROD",
-            {"base_url": "https://example.com", "auth_method": "pat", "pat": "secret-pat"},
+            {"base_url": "https://example.com/bfabric", "auth_method": "pat", "pat": "secret-pat"},
             set_default=True,
         )
         _ = clear_environment_credentials(config_path, "PROD")
@@ -425,12 +442,15 @@ class TestClearEnvironmentCredentials:
     def test_leaves_other_environments_alone(self, tmp_path):
         config_path = tmp_path / "config.yml"
         write_environment_to_config(
-            config_path, "PROD", {"base_url": "https://example.com", "auth_method": "pat", "pat": "p"}, set_default=True
+            config_path,
+            "PROD",
+            {"base_url": "https://example.com/bfabric", "auth_method": "pat", "pat": "p"},
+            set_default=True,
         )
         write_environment_to_config(
             config_path,
             "TEST",
-            {"base_url": "https://test.example.com", "auth_method": "pat", "pat": "t"},
+            {"base_url": "https://test.example.com/bfabric", "auth_method": "pat", "pat": "t"},
             set_default=False,
         )
         _ = clear_environment_credentials(config_path, "PROD")
@@ -439,7 +459,7 @@ class TestClearEnvironmentCredentials:
 
     def test_raises_on_unknown_env_and_leaves_file_unchanged(self, tmp_path):
         config_path = tmp_path / "config.yml"
-        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com"}, set_default=True)
+        write_environment_to_config(config_path, "PROD", {"base_url": "https://example.com/bfabric"}, set_default=True)
         before = config_path.read_text()
         with pytest.raises(ValueError):
             clear_environment_credentials(config_path, "NOPE")
@@ -452,7 +472,10 @@ class TestClearEnvironmentCredentials:
     def test_tightens_permissions(self, tmp_path):
         config_path = tmp_path / "config.yml"
         write_environment_to_config(
-            config_path, "PROD", {"base_url": "https://example.com", "auth_method": "pat", "pat": "p"}, set_default=True
+            config_path,
+            "PROD",
+            {"base_url": "https://example.com/bfabric", "auth_method": "pat", "pat": "p"},
+            set_default=True,
         )
         config_path.chmod(0o644)
         _ = clear_environment_credentials(config_path, "PROD")

--- a/tests/bfabric/conftest.py
+++ b/tests/bfabric/conftest.py
@@ -9,4 +9,4 @@ def pytest_runtest_setup() -> None:
 
 @pytest.fixture
 def bfabric_instance() -> str:
-    return "https://bfabric.example.org/bfabric/"
+    return "https://bfabric.example.org/bfabric"

--- a/tests/bfabric/engine/test_engine_suds.py
+++ b/tests/bfabric/engine/test_engine_suds.py
@@ -14,7 +14,7 @@ from bfabric.results.result_container import ResultContainer
 
 @pytest.fixture
 def engine_suds():
-    return EngineSUDS(base_url="http://example.com/api")
+    return EngineSUDS(base_url="https://example.com/bfabric")
 
 
 @pytest.fixture
@@ -121,9 +121,9 @@ def test_convert_results(engine_suds, mocker):
 
 def test_get_suds_service(mocker, mock_client, mock_suds_service):
     construct_client = mocker.patch("bfabric.engine.engine_suds.Client", return_value=mock_client)
-    engine = EngineSUDS(base_url="http://example.com/api")
+    engine = EngineSUDS(base_url="https://example.com/bfabric")
     service = engine._get_suds_service("sample")
-    construct_client.assert_called_once_with("http://example.com/api/sample?wsdl", cache=None)
+    construct_client.assert_called_once_with("https://example.com/bfabric/sample?wsdl", cache=None)
     assert service == mock_suds_service
 
 
@@ -139,20 +139,20 @@ class TestUnreachableInstance:
             "bfabric.engine.engine_suds.Client",
             side_effect=URLError(ConnectionRefusedError(111, "Connection refused")),
         )
-        engine = EngineSUDS(base_url="http://example.com/api")
+        engine = EngineSUDS(base_url="https://example.com/bfabric")
 
         with pytest.raises(BfabricUnavailableError, match="Could not reach the B-Fabric instance") as exc_info:
             engine._get_suds_service("sample")
 
         assert isinstance(exc_info.value, RuntimeError)
-        assert "http://example.com/api" in str(exc_info.value)
+        assert "https://example.com/bfabric" in str(exc_info.value)
 
     def test_server_error_raises_unavailable(self, mocker):
         mocker.patch(
             "bfabric.engine.engine_suds.Client",
             side_effect=suds.transport.TransportError("Internal Server Error", 500),
         )
-        engine = EngineSUDS(base_url="http://example.com/api")
+        engine = EngineSUDS(base_url="https://example.com/bfabric")
 
         with pytest.raises(BfabricUnavailableError):
             engine._get_suds_service("sample")
@@ -163,7 +163,7 @@ class TestUnreachableInstance:
             "bfabric.engine.engine_suds.Client",
             side_effect=suds.transport.TransportError("Not Found", 404),
         )
-        engine = EngineSUDS(base_url="http://example.com/api")
+        engine = EngineSUDS(base_url="https://example.com/bfabric")
 
         with pytest.raises(BfabricRequestError, match="Non-existent endpoint 'sample'") as exc_info:
             engine._get_suds_service("sample")

--- a/tests/bfabric/entities/core/test_entity.py
+++ b/tests/bfabric/entities/core/test_entity.py
@@ -36,7 +36,7 @@ def test_classname(mock_entity) -> None:
 
 @pytest.mark.parametrize("mock_entity_has_client", [True, False], indirect=True)
 def test_uri(mock_entity, bfabric_instance) -> None:
-    assert mock_entity.uri == f"{bfabric_instance}testendpoint/show.html?id=1"
+    assert mock_entity.uri == f"{bfabric_instance}/testendpoint/show.html?id=1"
 
 
 def test_data_dict(mock_entity, mock_data_dict) -> None:
@@ -225,7 +225,7 @@ def test_repr(mock_entity) -> None:
     assert repr(mock_entity) == (
         "Entity("
         "data_dict={'id': 1, 'name': 'Test Entity', 'classname': 'testendpoint'}, "
-        "bfabric_instance='https://bfabric.example.org/bfabric/'"
+        "bfabric_instance='https://bfabric.example.org/bfabric'"
         ")"
     )
 

--- a/tests/bfabric/entities/core/test_entity_reader.py
+++ b/tests/bfabric/entities/core/test_entity_reader.py
@@ -35,22 +35,22 @@ def mock_instantiate_entity(mocker):
 
 @pytest.fixture
 def uri_project_1(bfabric_instance):
-    return EntityUri(f"{bfabric_instance}project/show.html?id=100")
+    return EntityUri(f"{bfabric_instance}/project/show.html?id=100")
 
 
 @pytest.fixture
 def uri_project_2(bfabric_instance):
-    return EntityUri(f"{bfabric_instance}project/show.html?id=200")
+    return EntityUri(f"{bfabric_instance}/project/show.html?id=200")
 
 
 @pytest.fixture
 def uri_user_1(bfabric_instance):
-    return EntityUri(f"{bfabric_instance}user/show.html?id=1")
+    return EntityUri(f"{bfabric_instance}/user/show.html?id=1")
 
 
 @pytest.fixture
 def uri_user_2(bfabric_instance):
-    return EntityUri(f"{bfabric_instance}user/show.html?id=2")
+    return EntityUri(f"{bfabric_instance}/user/show.html?id=2")
 
 
 @pytest.fixture
@@ -262,7 +262,7 @@ class TestReadUris:
             entity_reader.read_uris([uri_project_1, uri_wrong_instance])
 
         assert "Unsupported B-Fabric instances" in str(exc_info.value)
-        assert "https://other-instance.example.org/bfabric/" in str(exc_info.value)
+        assert "https://other-instance.example.org/bfabric" in str(exc_info.value)
 
 
 class TestReadId:
@@ -307,7 +307,7 @@ class TestReadId:
         mock_entity_project_1,
     ):
         """Test reading with a custom bfabric_instance."""
-        custom_instance = "https://bfabric.example.org/bfabric/"
+        custom_instance = "https://bfabric.example.org/bfabric"
         mock_cache_stack.item_get_all.return_value = {}
         mock_multi_query.read_multi.return_value = [{"id": 100, "classname": "project", "name": "Project 1"}]
         mock_instantiate_entity.return_value = mock_entity_project_1
@@ -391,7 +391,7 @@ class TestReadIds:
 
         result = entity_reader.read_ids(entity_type="project", entity_ids=[100, 999])
 
-        expected_uri_999 = EntityUri(f"{bfabric_instance}project/show.html?id=999")
+        expected_uri_999 = EntityUri(f"{bfabric_instance}/project/show.html?id=999")
         assert result == {uri_project_1: mock_entity_project_1, expected_uri_999: None}
 
     def test_all_missing_entities(self, entity_reader, mock_cache_stack, mock_multi_query, bfabric_instance):
@@ -401,8 +401,8 @@ class TestReadIds:
 
         result = entity_reader.read_ids(entity_type="project", entity_ids=[999, 888])
 
-        expected_uri_999 = EntityUri(f"{bfabric_instance}project/show.html?id=999")
-        expected_uri_888 = EntityUri(f"{bfabric_instance}project/show.html?id=888")
+        expected_uri_999 = EntityUri(f"{bfabric_instance}/project/show.html?id=999")
+        expected_uri_888 = EntityUri(f"{bfabric_instance}/project/show.html?id=888")
         assert result == {expected_uri_999: None, expected_uri_888: None}
 
     def test_empty_list(self, entity_reader, mock_cache_stack):
@@ -423,7 +423,7 @@ class TestReadIds:
         bfabric_instance,
     ):
         """Test reading with a custom bfabric_instance."""
-        custom_instance = "https://bfabric.example.org/bfabric/"
+        custom_instance = "https://bfabric.example.org/bfabric"
         mock_cache_stack.item_get_all.return_value = {}
         mock_multi_query.read_multi.return_value = [{"id": 100, "classname": "project", "name": "Project 1"}]
         mock_instantiate_entity.return_value = mock_entity_project_1
@@ -431,7 +431,7 @@ class TestReadIds:
         result = entity_reader.read_ids(entity_type="project", entity_ids=[100], bfabric_instance=custom_instance)
 
         # Verify URI was constructed with custom instance
-        expected_uri = EntityUri(f"{custom_instance}project/show.html?id=100")
+        expected_uri = EntityUri(f"{custom_instance}/project/show.html?id=100")
         assert expected_uri in result
 
 
@@ -481,7 +481,7 @@ class TestQuery:
 
     def test_instance_mismatch_raises_error(self, entity_reader, mock_client, bfabric_instance):
         """Test that querying a different instance raises ValueError."""
-        different_instance = "https://other-instance.example.org/bfabric/"
+        different_instance = "https://other-instance.example.org/bfabric"
 
         with pytest.raises(ValueError) as exc_info:
             entity_reader.query(entity_type="project", obj={}, bfabric_instance=different_instance, max_results=100)
@@ -621,7 +621,7 @@ class TestEntityResult:
     @pytest.fixture
     def uri(self, bfabric_instance):
         def _make(entity_id: int, entity_type: str = "resource") -> EntityUri:
-            return EntityUri(f"{bfabric_instance}{entity_type}/show.html?id={entity_id}")
+            return EntityUri(f"{bfabric_instance}/{entity_type}/show.html?id={entity_id}")
 
         return _make
 

--- a/tests/bfabric/entities/core/test_has_many.py
+++ b/tests/bfabric/entities/core/test_has_many.py
@@ -75,7 +75,7 @@ class TestFunctionality:
     def test_repr(entity):
         assert (
             repr(entity)
-            == "MockEntity(data_dict={'classname': 'mock', 'id': 1000, 'many': [{'id': 10, 'classname': 'testreferenced', 'name': 'Referenced Entity 10'}, {'id': 20, 'classname': 'testreferenced', 'name': 'Referenced Entity 20'}]}, bfabric_instance='https://bfabric.example.org/bfabric/')"
+            == "MockEntity(data_dict={'classname': 'mock', 'id': 1000, 'many': [{'id': 10, 'classname': 'testreferenced', 'name': 'Referenced Entity 10'}, {'id': 20, 'classname': 'testreferenced', 'name': 'Referenced Entity 20'}]}, bfabric_instance='https://bfabric.example.org/bfabric')"
         )
 
     @staticmethod

--- a/tests/bfabric/entities/core/test_references.py
+++ b/tests/bfabric/entities/core/test_references.py
@@ -52,7 +52,7 @@ def entity_reader(mocker, entity_reader_constructor):
 @pytest.fixture
 def mock_project(mocker, bfabric_instance):
     project = mocker.MagicMock(name="mock_project")
-    project.uri = f"{bfabric_instance}project/show.html?id=3000"
+    project.uri = f"{bfabric_instance}/project/show.html?id=3000"
     project.data_dict = {"id": 3000, "classname": "project", "name": "Mock Project"}
     return project
 
@@ -60,7 +60,7 @@ def mock_project(mocker, bfabric_instance):
 @pytest.fixture
 def mock_user(mocker, bfabric_instance):
     user = mocker.MagicMock(name="mock_user")
-    user.uri = f"{bfabric_instance}user/show.html?id=1"
+    user.uri = f"{bfabric_instance}/user/show.html?id=1"
     user.data_dict = {"id": 1, "classname": "user", "name": "Test User", "email": "test@bfabric.example.org"}
     return user
 

--- a/tests/bfabric/entities/core/test_uri.py
+++ b/tests/bfabric/entities/core/test_uri.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import HttpUrl, BaseModel
+from pydantic import BaseModel
 
 from bfabric.entities.core.uri import EntityUri, EntityUriComponents, GroupedUris
 from bfabric.entities.core.uri import _parse_uri_components
@@ -43,12 +43,12 @@ class TestEntityUri:
         uri = "https://fgcz-bfabric.uzh.ch/bfabric/project/show.html?id=3000"
         entity_uri = EntityUri(uri)
         components = entity_uri.components
-        assert components.bfabric_instance == HttpUrl("https://fgcz-bfabric.uzh.ch/bfabric/")
+        assert components.bfabric_instance == "https://fgcz-bfabric.uzh.ch/bfabric"
         assert components.entity_type == "project"
         assert components.entity_id == 3000
 
     @pytest.mark.parametrize(
-        "bfabric_instance", ["https://bfabric.example.com/bfabric/", "https://bfabric.example.com/bfabric"]
+        "bfabric_instance", ["https://bfabric.example.com/bfabric", "https://bfabric.example.com/bfabric"]
     )
     def test_from_components(self, bfabric_instance: str):
         entity_uri = EntityUri.from_components(bfabric_instance, "dataset", 1234)
@@ -84,7 +84,7 @@ class TestNormalize:
 
     def test_components(self):
         components = EntityUri.normalize(f"{CANONICAL_URI}&tab=details").components
-        assert components.bfabric_instance == HttpUrl("https://fgcz-bfabric.uzh.ch/bfabric/")
+        assert components.bfabric_instance == "https://fgcz-bfabric.uzh.ch/bfabric"
         assert components.entity_type == "workunit"
         assert components.entity_id == 346001
 
@@ -122,15 +122,15 @@ class TestEntityUriComponents:
     @pytest.mark.parametrize(
         "bfabric_instance",
         [
-            "https://fgcz-bfabric.uzh.ch/bfabric/",
-            "https://bfabric.example.com/bfabric/",
-            "http://localhost:8080/bfabric/",
+            "https://fgcz-bfabric.uzh.ch/bfabric",
+            "https://bfabric.example.com/bfabric",
+            "http://localhost:8080/bfabric",
         ],
     )
     def test_valid(self, bfabric_instance):
-        uri = f"{bfabric_instance}project/show.html?id=3000"
+        uri = f"{bfabric_instance}/project/show.html?id=3000"
         parsed = _parse_uri_components(uri)
-        assert parsed.bfabric_instance == HttpUrl(bfabric_instance)
+        assert parsed.bfabric_instance == bfabric_instance
         assert parsed.entity_type == "project"
         assert parsed.entity_id == 3000
 
@@ -148,7 +148,7 @@ class TestEntityUriComponents:
             _parse_uri_components(uri)
 
     @pytest.mark.parametrize(
-        "bfabric_instance", ["https://bfabric.example.com/bfabric/", "https://bfabric.example.com/bfabric"]
+        "bfabric_instance", ["https://bfabric.example.com/bfabric", "https://bfabric.example.com/bfabric"]
     )
     def test_as_uri(self, bfabric_instance):
         components = EntityUriComponents(bfabric_instance=bfabric_instance, entity_type="project", entity_id=3000)
@@ -192,7 +192,7 @@ class TestGroupedUris:
         # Verify groups contain correct URIs
         groups_dict = {(key.bfabric_instance, key.entity_type): uris for key, uris in grouped.items()}
 
-        assert groups_dict[("https://instance1.example.org/bfabric/", "project")] == [uri1, uri2]
-        assert groups_dict[("https://instance1.example.org/bfabric/", "user")] == [uri3]
-        assert groups_dict[("https://instance2.example.org/bfabric/", "project")] == [uri4]
-        assert groups_dict[("https://instance2.example.org/bfabric/", "user")] == [uri5]
+        assert groups_dict[("https://instance1.example.org/bfabric", "project")] == [uri1, uri2]
+        assert groups_dict[("https://instance1.example.org/bfabric", "user")] == [uri3]
+        assert groups_dict[("https://instance2.example.org/bfabric", "project")] == [uri4]
+        assert groups_dict[("https://instance2.example.org/bfabric", "user")] == [uri5]

--- a/tests/bfabric/entities/test_dataset.py
+++ b/tests/bfabric/entities/test_dataset.py
@@ -113,7 +113,7 @@ def test_get_parquet(mock_dataset: Dataset) -> None:
 def test_repr(mock_empty_dataset: Dataset) -> None:
     assert (
         repr(mock_empty_dataset) == "Dataset(data_dict={'id': 1234, 'attribute': [], 'item': []}, "
-        "bfabric_instance='https://bfabric.example.org/bfabric/')"
+        "bfabric_instance='https://bfabric.example.org/bfabric')"
     )
 
 

--- a/tests/bfabric/experimental/test_webapp_integration_settings.py
+++ b/tests/bfabric/experimental/test_webapp_integration_settings.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from bfabric.config.bfabric_auth import BfabricAuth
+from bfabric.experimental.webapp_integration_settings import (
+    TokenValidationSettings,
+    WebappIntegrationSettings,
+)
+
+INSTANCE = "https://example.com/bfabric"
+
+
+@pytest.fixture
+def auth() -> BfabricAuth:
+    return BfabricAuth(login="feeder", password=SecretStr("x" * 32))
+
+
+class TestTokenValidationSettings:
+    def test_canonicalises_instances(self):
+        settings = TokenValidationSettings(
+            validation_bfabric_instance=f"{INSTANCE}/",
+            supported_bfabric_instances=[f"{INSTANCE}//"],
+        )
+        assert settings.validation_bfabric_instance == INSTANCE
+        assert settings.supported_bfabric_instances == [INSTANCE]
+
+    @pytest.mark.parametrize("validation", [INSTANCE, f"{INSTANCE}/"])
+    @pytest.mark.parametrize("supported", [INSTANCE, f"{INSTANCE}/"])
+    def test_accepts_either_form_on_both_sides(self, validation, supported):
+        settings = TokenValidationSettings(
+            validation_bfabric_instance=validation, supported_bfabric_instances=[supported]
+        )
+        assert settings.validation_bfabric_instance in settings.supported_bfabric_instances
+
+    def test_rejects_an_unsupported_instance(self):
+        with pytest.raises(ValidationError, match="must be one of supported_bfabric_instances"):
+            TokenValidationSettings(
+                validation_bfabric_instance="https://other.example.com/bfabric",
+                supported_bfabric_instances=[INSTANCE],
+            )
+
+    def test_rejects_a_non_http_instance(self):
+        with pytest.raises(ValidationError):
+            TokenValidationSettings(validation_bfabric_instance="not-a-url", supported_bfabric_instances=["not-a-url"])
+
+
+class TestWebappIntegrationSettings:
+    def test_canonicalises_feeder_keys(self, auth):
+        settings = WebappIntegrationSettings(
+            validation_bfabric_instance=INSTANCE,
+            supported_bfabric_instances=[f"{INSTANCE}/"],
+            feeder_user_credentials={f"{INSTANCE}/": auth},
+        )
+        assert list(settings.feeder_user_credentials) == [INSTANCE]
+        assert settings.feeder_user_credentials[INSTANCE] is auth
+
+    def test_rejects_a_feeder_key_for_an_unsupported_instance(self, auth):
+        with pytest.raises(ValidationError, match="only supported bfabric instances"):
+            WebappIntegrationSettings(
+                validation_bfabric_instance=INSTANCE,
+                supported_bfabric_instances=[INSTANCE],
+                feeder_user_credentials={"https://other.example.com/bfabric": auth},
+            )

--- a/tests/bfabric/oauth/test_device_code.py
+++ b/tests/bfabric/oauth/test_device_code.py
@@ -316,31 +316,6 @@ class TestDeviceCodeLogin:
         captured = capsys.readouterr()
         assert "https://example.com/device?user_code=WXYZ-9876" in captured.err
 
-    def test_strips_trailing_slash(self, mocker):
-        device_response = {
-            "device_code": "dc_456",
-            "user_code": "CODE",
-            "verification_uri": "https://example.com/device",
-            "interval": 5,
-        }
-
-        mock_request = mocker.patch(
-            "bfabric.oauth._device_code._request_device_code",
-            return_value=device_response,
-        )
-        mock_poll = mocker.patch(
-            "bfabric.oauth._device_code._poll_for_token",
-            return_value={"access_token": "at"},
-        )
-        device_code_login("https://example.com/bfabric///", client_id="test-cli", scope="api:read")
-
-        mock_request.assert_called_once_with(
-            "https://example.com/bfabric",
-            client_id="test-cli",
-            scope="api:read",
-        )
-        assert mock_poll.call_args[0][0] == "https://example.com/bfabric"
-
     def test_default_interval_when_missing(self, mocker):
         device_response = {
             "device_code": "dc_456",

--- a/tests/bfabric/oauth/test_registration.py
+++ b/tests/bfabric/oauth/test_registration.py
@@ -120,7 +120,7 @@ class TestRegisterClient:
 
     def test_normalizes_trailing_slash(self, mock_httpx_post):
         register_client(
-            base_url="https://example.com/bfabric/",
+            base_url="https://example.com/bfabric",
             token="tok",
             client_name="app",
             redirect_uri="http://localhost/cb",
@@ -157,7 +157,7 @@ class TestRegisterWebapp:
     @pytest.fixture
     def mock_client(self, mocker):
         client = mocker.MagicMock(name="bfabric_client")
-        client.config.base_url = "https://example.com/bfabric/"
+        client.config.base_url = "https://example.com/bfabric"
         client.save.return_value = mocker.MagicMock(name="save_result")
         return client
 

--- a/tests/bfabric/oauth/test_token_cache.py
+++ b/tests/bfabric/oauth/test_token_cache.py
@@ -7,6 +7,7 @@ import stat
 import pytest
 
 from bfabric.oauth._token_cache import TokenCache, compute_token_cache_path
+from bfabric.config import BfabricClientConfig
 
 
 @pytest.fixture
@@ -67,10 +68,13 @@ class TestComputeTokenCachePath:
         p2 = compute_token_cache_path("https://example.com/bfabric", "my-client", "PROD")
         assert p1 == p2
 
-    def test_trailing_slash_ignored(self):
-        p1 = compute_token_cache_path("https://example.com/bfabric", "c", "PROD")
-        p2 = compute_token_cache_path("https://example.com/bfabric/", "c", "PROD")
-        assert p1 == p2
+    def test_canonical_base_url_keeps_the_key_stable(self):
+        # The key is not slash-insensitive by itself; canonicalising upstream is what makes a cache
+        # written from a slashed config still resolve, so an existing login survives.
+        config = BfabricClientConfig(base_url="https://example.com/bfabric/")
+        assert compute_token_cache_path(config.base_url, "c", "PROD") == compute_token_cache_path(
+            "https://example.com/bfabric", "c", "PROD"
+        )
 
     def test_different_client_id_gives_different_path(self):
         p1 = compute_token_cache_path("https://example.com/bfabric", "client-a", "PROD")

--- a/tests/bfabric/oauth/test_token_exchange.py
+++ b/tests/bfabric/oauth/test_token_exchange.py
@@ -43,22 +43,6 @@ class TestExchangeToken:
             "token_type": "Bearer",
         }
 
-    def test_strips_trailing_slash(self, mocker):
-        mock_post = mocker.patch("bfabric.oauth._token_exchange.httpx.post")
-        mock_response = mocker.MagicMock()
-        mock_response.json.return_value = {"access_token": "at"}
-        mock_post.return_value = mock_response
-
-        exchange_token(
-            f"{BASE_URL}///",
-            "jwt",
-            client_id="cid",
-            client_secret="cs",
-        )
-
-        url = mock_post.call_args[0][0]
-        assert url == f"{BASE_URL}/rest/oauth/token"
-
     def test_raises_on_http_error(self, mocker):
         import httpx
 
@@ -121,17 +105,6 @@ class TestIntrospectToken:
         assert ctx.entity_id is None
         assert ctx.application_id is None
         assert ctx.subject == "user"
-
-    def test_strips_trailing_slash(self, mocker):
-        mock_post = mocker.patch("bfabric.oauth._token_exchange.httpx.post")
-        mock_response = mocker.MagicMock()
-        mock_response.json.return_value = {"sub": "u"}
-        mock_post.return_value = mock_response
-
-        introspect_token(f"{BASE_URL}///", "at", client_id="cid", client_secret="cs")
-
-        url = mock_post.call_args[0][0]
-        assert url == f"{BASE_URL}/rest/oauth/introspect"
 
     def test_raises_on_http_error(self, mocker):
         import httpx

--- a/tests/bfabric/oauth/test_url_token.py
+++ b/tests/bfabric/oauth/test_url_token.py
@@ -4,7 +4,8 @@ import time
 
 import pytest
 
-from bfabric.oauth._url_token import _jwks_cache, verify_jwt
+from bfabric.config import BaseUrl
+from bfabric.oauth._url_token import UrlTokenContext, _jwks_cache, verify_jwt
 
 
 @pytest.fixture(autouse=True)
@@ -73,5 +74,20 @@ class TestVerifyJwt:
         assert mock_httpx_get.call_count == 2
 
     def test_normalizes_trailing_slash(self, mock_httpx_get, mock_joserfc):
-        verify_jwt("https://example.com/bfabric/", "token")
+        # The slash is dropped by BaseUrl at the boundary, so no doubled slash reaches the JWKS URL.
+        verify_jwt(BaseUrl("https://example.com/bfabric/"), "token")
         mock_httpx_get.assert_called_once_with("https://example.com/bfabric/rest/oauth/jwks", timeout=30)
+
+
+class TestBaseUrlFromIssuer:
+    @pytest.mark.parametrize("issuer", ["https://example.com/bfabric", "https://example.com/bfabric/"])
+    def test_canonicalises_the_issuer(self, issuer):
+        assert UrlTokenContext(iss=issuer).base_url == "https://example.com/bfabric"
+
+    def test_is_none_without_an_issuer(self):
+        assert UrlTokenContext().base_url is None
+
+    def test_rejects_a_non_http_issuer(self):
+        # A verified token naming itself with something we cannot call back is a server-side defect.
+        with pytest.raises(ValueError, match="Not a valid http"):
+            _ = UrlTokenContext(iss="urn:example:issuer").base_url

--- a/tests/bfabric/operations/dataset/test_operations.py
+++ b/tests/bfabric/operations/dataset/test_operations.py
@@ -15,7 +15,7 @@ from bfabric.operations.dataset import (
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.MagicMock(name="Bfabric")
-    client.config.base_url = "https://test.example.com/bfabric/"
+    client.config.base_url = "https://test.example.com/bfabric"
     return client
 
 

--- a/tests/bfabric/operations/workunit/test_create.py
+++ b/tests/bfabric/operations/workunit/test_create.py
@@ -152,7 +152,7 @@ def test_create_workunit_returned_entity_has_usable_uri(mock_client, bfabric_ins
 
     workunit = create_workunit(mock_client, _params())
 
-    assert str(workunit.uri) == f"{bfabric_instance}workunit/show.html?id=42"
+    assert str(workunit.uri) == f"{bfabric_instance}/workunit/show.html?id=42"
 
 
 def test_create_workunit_returns_metadata_only_entity(mock_client):

--- a/tests/bfabric/operations/workunit/test_upload_files.py
+++ b/tests/bfabric/operations/workunit/test_upload_files.py
@@ -32,7 +32,7 @@ WORKUNIT_ID = 555
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.MagicMock(name="Bfabric")
-    client.config.base_url = "https://bfabric.example/"
+    client.config.base_url = "https://bfabric.example/bfabric"
     # Every workunit save (create, complete, mark-failed) returns an indexable [dict]; only
     # create/complete consume result[0] (via Workunit(...).id).
     client.save.return_value = [{"id": WORKUNIT_ID}]

--- a/tests/bfabric/rest/test_token_data.py
+++ b/tests/bfabric/rest/test_token_data.py
@@ -5,8 +5,8 @@ import pytest
 import httpx
 from pydantic import SecretStr, ValidationError
 
-from bfabric.errors import BfabricTokenExpiredError, BfabricTokenInvalidError
-from bfabric.rest.token_data import TokenData, get_token_data, get_token_data_async
+from bfabric.errors import BfabricInstanceNotConfiguredError, BfabricTokenExpiredError, BfabricTokenInvalidError
+from bfabric.rest.token_data import TokenData, get_token_data, get_token_data_async, validate_token
 
 
 @pytest.fixture
@@ -174,3 +174,39 @@ def test_get_token_data(mocker, token_data, base_url):
     call_args = mock_get_token_data_async.call_args
     assert call_args.kwargs["base_url"] == base_url
     assert call_args.kwargs["token"] == "mock-token"
+
+
+class TestValidateToken:
+    """The instance allow-list check.
+
+    The server picks the form of ``caller`` and the operator picks the form of the configured
+    instances, so a trailing slash must not decide whether a token is accepted.
+    """
+
+    @pytest.fixture
+    def settings(self):
+        class MockSettings:
+            validation_bfabric_instance = "https://example.com/bfabric"
+            supported_bfabric_instances = ["https://example.com/bfabric"]
+
+        return MockSettings()
+
+    @pytest.fixture
+    def patched_get(self, mocker, token_data):
+        return mocker.patch("bfabric.rest.token_data.get_token_data_async", return_value=token_data)
+
+    @pytest.mark.parametrize("caller", ["https://example.com/bfabric", "https://example.com/bfabric/"])
+    async def test_accepts_either_caller_form(self, settings, patched_get, token_data, caller):
+        token_data.caller = caller
+        assert await validate_token(token="mock-token", settings=settings) is token_data
+
+    @pytest.mark.parametrize("configured", ["https://example.com/bfabric", "https://example.com/bfabric/"])
+    async def test_accepts_either_configured_form(self, settings, patched_get, token_data, configured):
+        settings.supported_bfabric_instances = [configured]
+        token_data.caller = "https://example.com/bfabric/"
+        assert await validate_token(token="mock-token", settings=settings) is token_data
+
+    async def test_rejects_a_genuinely_different_instance(self, settings, patched_get, token_data):
+        token_data.caller = "https://other.example.com/bfabric"
+        with pytest.raises(BfabricInstanceNotConfiguredError):
+            await validate_token(token="mock-token", settings=settings)

--- a/tests/bfabric/test_bfabric.py
+++ b/tests/bfabric/test_bfabric.py
@@ -19,7 +19,7 @@ _TEST_SCOPE = "api:read api:write"
 
 @pytest.fixture
 def mock_config():
-    return BfabricClientConfig(engine=BfabricAPIEngineType.SUDS, base_url="https://example.com/api")
+    return BfabricClientConfig(engine=BfabricAPIEngineType.SUDS, base_url="https://example.com/bfabric")
 
 
 @pytest.fixture
@@ -95,18 +95,22 @@ def test_connect_pat_env_from_config_file(mocker, tmp_path):
 def test_connect_webapp(mocker, mock_config):
     mock_get_token_data = mocker.patch(
         "bfabric.bfabric.get_token_data",
-        return_value=mocker.MagicMock(user="test_user", user_ws_password="x" * 32, caller="https://example.com/api"),
+        return_value=mocker.MagicMock(
+            user="test_user", user_ws_password="x" * 32, caller="https://example.com/bfabric"
+        ),
     )
     mocker.patch.object(Bfabric, "_log_version_message")
 
-    client, data = Bfabric.connect_webapp(token="test_token", validation_instance_url="https://example.com/validation/")
+    client, data = Bfabric.connect_webapp(
+        token="test_token", validation_instance_url="https://validation.example.com/bfabric"
+    )
 
     assert client.auth.login == "test_user"
     assert client.auth.password == SecretStr("x" * 32)
-    assert client.config.base_url == "https://example.com/api"
+    assert client.config.base_url == "https://example.com/bfabric"
     assert data == mock_get_token_data.return_value
 
-    mock_get_token_data.assert_called_once_with(base_url="https://example.com/validation/", token="test_token")
+    mock_get_token_data.assert_called_once_with(base_url="https://validation.example.com/bfabric", token="test_token")
 
 
 @pytest.fixture
@@ -459,7 +463,7 @@ def test_log_version_message(mocker, bfabric_instance):
 def test_repr(bfabric_instance, variant):
     assert (
         variant(bfabric_instance) == "Bfabric(config_data=ConfigData("
-        "client=BfabricClientConfig(base_url='https://example.com/api', application_ids={}, "
+        "client=BfabricClientConfig(base_url='https://example.com/bfabric', application_ids={}, "
         "job_notification_emails='', engine=BfabricAPIEngineType.SUDS), auth=None, "
         "auth_method=None, client_id=None, env_name=None))"
     )

--- a/tests/bfabric/test_bfabric.py
+++ b/tests/bfabric/test_bfabric.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import SecretStr
 
 from bfabric import Bfabric, BfabricAPIEngineType, BfabricClientConfig, BfabricAuth
+from bfabric.config import BaseUrl
 from bfabric.config import DEFAULT_CONFIG_FILE
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
 from bfabric.config.config_data import ConfigData
@@ -18,7 +19,7 @@ _TEST_SCOPE = "api:read api:write"
 
 @pytest.fixture
 def mock_config():
-    return BfabricClientConfig(engine=BfabricAPIEngineType.SUDS, base_url="https://example.com/api/")
+    return BfabricClientConfig(engine=BfabricAPIEngineType.SUDS, base_url="https://example.com/api")
 
 
 @pytest.fixture
@@ -94,7 +95,7 @@ def test_connect_pat_env_from_config_file(mocker, tmp_path):
 def test_connect_webapp(mocker, mock_config):
     mock_get_token_data = mocker.patch(
         "bfabric.bfabric.get_token_data",
-        return_value=mocker.MagicMock(user="test_user", user_ws_password="x" * 32, caller="https://example.com/api/"),
+        return_value=mocker.MagicMock(user="test_user", user_ws_password="x" * 32, caller="https://example.com/api"),
     )
     mocker.patch.object(Bfabric, "_log_version_message")
 
@@ -102,7 +103,7 @@ def test_connect_webapp(mocker, mock_config):
 
     assert client.auth.login == "test_user"
     assert client.auth.password == SecretStr("x" * 32)
-    assert client.config.base_url == "https://example.com/api/"
+    assert client.config.base_url == "https://example.com/api"
     assert data == mock_get_token_data.return_value
 
     mock_get_token_data.assert_called_once_with(base_url="https://example.com/validation/", token="test_token")
@@ -111,8 +112,8 @@ def test_connect_webapp(mocker, mock_config):
 @pytest.fixture
 def token_validation_settings():
     class MockSettings:
-        validation_bfabric_instance = "https://example.com/bfabric/"
-        supported_bfabric_instances = ["https://example.com/bfabric/"]
+        validation_bfabric_instance = "https://example.com/bfabric"
+        supported_bfabric_instances = ["https://example.com/bfabric"]
 
     return MockSettings()
 
@@ -122,13 +123,13 @@ def mock_validate_token(mocker):
     func = mocker.patch("bfabric.bfabric.validate_token")
     func.return_value.user = "test_user"
     func.return_value.user_ws_password = SecretStr("x" * 32)
-    func.return_value.caller = "https://example.com/bfabric/"
+    func.return_value.caller = "https://example.com/bfabric"
     return func
 
 
 def test_connect_token(mock_config, token_validation_settings, mock_validate_token):
     client, data = Bfabric.connect_token(token="test_token", settings=token_validation_settings)
-    assert client.config.base_url == "https://example.com/bfabric/"
+    assert client.config.base_url == "https://example.com/bfabric"
     assert client.auth.login == "test_user"
     assert client.auth.password == SecretStr("x" * 32)
     assert data == mock_validate_token.return_value
@@ -136,7 +137,7 @@ def test_connect_token(mock_config, token_validation_settings, mock_validate_tok
 
 async def test_connect_token_async(mock_config, token_validation_settings, mock_validate_token):
     client, data = await Bfabric.connect_token_async(token="test_token", settings=token_validation_settings)
-    assert client.config.base_url == "https://example.com/bfabric/"
+    assert client.config.base_url == "https://example.com/bfabric"
     assert client.auth.login == "test_user"
     assert client.auth.password == SecretStr("x" * 32)
     assert data == mock_validate_token.return_value
@@ -423,6 +424,19 @@ def test_upload_resource(bfabric_instance, mocker):
     )
 
 
+class TestEngineUrl:
+    """The URL the default engine builds from a canonicalised ``base_url``."""
+
+    def test_suds_wsdl_url_has_a_single_slash(self, mocker):
+        construct_client = mocker.patch("bfabric.engine.engine_suds.Client")
+        mocker.patch.object(Bfabric, "_log_version_message")
+        client = Bfabric(
+            config_data=ConfigData(client=BfabricClientConfig(base_url="https://example.com/bfabric"), auth=None)
+        )
+        client._engine._get_suds_service("sample")
+        construct_client.assert_called_once_with("https://example.com/bfabric/sample?wsdl", cache=None)
+
+
 def test_get_version_message(mock_config, bfabric_instance):
     mock_config.base_url = "dummy_url"
     line1, line2 = bfabric_instance._get_version_message()
@@ -445,7 +459,7 @@ def test_log_version_message(mocker, bfabric_instance):
 def test_repr(bfabric_instance, variant):
     assert (
         variant(bfabric_instance) == "Bfabric(config_data=ConfigData("
-        "client=BfabricClientConfig(base_url='https://example.com/api/', application_ids={}, "
+        "client=BfabricClientConfig(base_url='https://example.com/api', application_ids={}, "
         "job_notification_emails='', engine=BfabricAPIEngineType.SUDS), auth=None, "
         "auth_method=None, client_id=None, env_name=None))"
     )
@@ -500,7 +514,7 @@ class TestConnectOAuth:
         )
         assert client._credential_provider == mock_provider_cls.return_value
         assert client._auth is None
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
 
     def test_auth_property_uses_provider(self, mocker):
         mocker.patch.object(Bfabric, "_log_version_message")
@@ -525,11 +539,11 @@ class TestConnectOAuth:
         client = Bfabric.connect_oauth(
             client_id="id",
             client_secret="secret",
-            base_url="https://example.com/bfabric/",
+            base_url="https://example.com/bfabric",
             scope=_TEST_SCOPE,
         )
 
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
         call_kwargs = mock_provider_cls.call_args[1]
         assert call_kwargs["token_url"] == "https://example.com/bfabric/rest/oauth/token"
 
@@ -613,7 +627,7 @@ class TestConnectPkce:
         )
         assert client._credential_provider == mock_provider_cls.return_value
         assert client._auth is None
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
 
     def test_parameter_forwarding(self, mocker):
         mocker.patch.object(Bfabric, "_log_version_message")
@@ -657,7 +671,7 @@ class TestConnectPkce:
             scope=_TEST_SCOPE,
         )
 
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
         call_kwargs = mock_provider_cls.call_args[1]
         assert call_kwargs["token_url"] == "https://example.com/bfabric/rest/oauth/token"
 
@@ -696,7 +710,7 @@ class TestConnectDeviceCode:
         )
         assert client._credential_provider == mock_provider_cls.return_value
         assert client._auth is None
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
 
     def test_parameter_forwarding(self, mocker):
         mocker.patch.object(Bfabric, "_log_version_message")
@@ -736,7 +750,7 @@ class TestConnectDeviceCode:
             scope=_TEST_SCOPE,
         )
 
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
         call_kwargs = mock_provider_cls.call_args[1]
         assert call_kwargs["token_url"] == "https://example.com/bfabric/rest/oauth/token"
 
@@ -752,7 +766,7 @@ class TestConnectPat:
 
         assert client.auth.login == OAUTH_LOGIN
         assert client.auth.password.get_secret_value() == "my_personal_access_token"
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
 
     def test_no_credential_provider(self, mocker):
         mocker.patch.object(Bfabric, "_log_version_message")
@@ -772,7 +786,7 @@ class TestConnectPat:
             pat="my_pat",
         )
 
-        assert client.config.base_url == "https://example.com/bfabric/"
+        assert client.config.base_url == "https://example.com/bfabric"
 
     def test_accepts_secret_str(self, mocker):
         mocker.patch.object(Bfabric, "_log_version_message")
@@ -827,3 +841,10 @@ class TestPickling:
         restored = pickle.loads(pickle.dumps(client))  # noqa: S301
         assert restored._credential_provider is None
         assert restored.auth.login == "user"
+
+    def test_canonical_base_url_survives_round_trip(self):
+        """``config.base_url`` is a ``str`` subclass, which pickles by re-calling the constructor."""
+        config = BfabricClientConfig.model_validate({"base_url": "https://example.com/bfabric/"})
+        restored = pickle.loads(pickle.dumps(config))  # noqa: S301
+        assert restored.base_url == "https://example.com/bfabric"
+        assert isinstance(restored.base_url, BaseUrl)

--- a/tests/bfabric/transfer/test_upload.py
+++ b/tests/bfabric/transfer/test_upload.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from bfabric.config import BaseUrl
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
 from bfabric.transfer.errors import BfabricTransferError, ScopeError
 from bfabric.transfer.upload import (
@@ -42,6 +43,9 @@ class TestApiToRestUrl:
 
     def test_no_api_suffix_only_strips_trailing_slash(self):
         assert api_to_rest_url("https://host/bfabric/") == "https://host/bfabric"
+
+    def test_returns_a_base_url(self):
+        assert isinstance(api_to_rest_url("https://host/bfabric/api"), BaseUrl)
 
 
 class TestRequireTus:

--- a/tests/bfabric/transfer/test_upload.py
+++ b/tests/bfabric/transfer/test_upload.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 from logot import logged
 
-from bfabric.config import BaseUrl
 from bfabric.config.bfabric_auth import OAUTH_LOGIN
 from bfabric.transfer.errors import BfabricTransferError, ScopeError
 from bfabric.transfer.upload import (
@@ -13,7 +12,6 @@ from bfabric.transfer.upload import (
     DuplicateResult,
     UploadRestClient,
     UploadTokenResult,
-    api_to_rest_url,
     require_tus,
     tus_sink_for_resource,
 )
@@ -22,7 +20,7 @@ from bfabric.transfer import FileInfo, TransferSinkTus
 
 def _rest_client(mocker, make_jwt, *, scope: str = "api:read tus containers"):
     client = mocker.MagicMock()
-    client.config.base_url = "https://host/bfabric/api/"
+    client.config.base_url = "https://host/bfabric"
     client.auth = mocker.MagicMock(login=OAUTH_LOGIN, password=mocker.MagicMock())
     client.auth.password.get_secret_value.return_value = make_jwt({"scope": scope})
     return UploadRestClient(client)
@@ -38,15 +36,10 @@ def _mock_post(mocker, *, is_success: bool, payload=None, status_code: int = 200
     return mocker.patch("bfabric.transfer.upload.httpx.post", return_value=response)
 
 
-class TestApiToRestUrl:
-    def test_strips_api_suffix_and_trailing_slash(self):
-        assert api_to_rest_url("https://host/bfabric/api/") == "https://host/bfabric"
-
-    def test_no_api_suffix_only_strips_trailing_slash(self):
-        assert api_to_rest_url("https://host/bfabric/") == "https://host/bfabric"
-
-    def test_returns_a_base_url(self):
-        assert isinstance(api_to_rest_url("https://host/bfabric/api"), BaseUrl)
+class TestRestBaseUrl:
+    def test_is_the_configured_instance_url(self, mocker, make_jwt):
+        # The REST endpoints hang off the servlet root, which is what base_url is required to be.
+        assert _rest_client(mocker, make_jwt).rest_base_url == "https://host/bfabric"
 
 
 class TestRequireTus:

--- a/tests/bfabric_app_runner/inputs/resolve/test_resolve_bfabric_annotation_specs.py
+++ b/tests/bfabric_app_runner/inputs/resolve/test_resolve_bfabric_annotation_specs.py
@@ -16,7 +16,7 @@ from bfabric_app_runner.specs.inputs.bfabric_annotation_spec import BfabricAnnot
 
 @pytest.fixture
 def bfabric_instance():
-    return "https://bfabric.example.org/bfabric/"
+    return "https://bfabric.example.org/bfabric"
 
 
 @pytest.fixture

--- a/tests/bfabric_cli/test_cli_api_create.py
+++ b/tests/bfabric_cli/test_cli_api_create.py
@@ -10,7 +10,7 @@ from bfabric_scripts.cli.api.output_format import OutputFormat
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.Mock(spec=Bfabric)
-    client.config.base_url = "http://test-bfabric.com"
+    client.config.base_url = "http://test-bfabric.com/bfabric"
     return client
 
 

--- a/tests/bfabric_cli/test_cli_api_output_format.py
+++ b/tests/bfabric_cli/test_cli_api_output_format.py
@@ -11,7 +11,7 @@ from bfabric_scripts.cli.api.output_format import OutputFormat, _determine_outpu
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.Mock()
-    client.config.base_url = "http://test-bfabric.com"
+    client.config.base_url = "http://test-bfabric.com/bfabric"
     return client
 
 

--- a/tests/bfabric_cli/test_cli_api_read.py
+++ b/tests/bfabric_cli/test_cli_api_read.py
@@ -12,7 +12,7 @@ from bfabric_scripts.cli.api.read import Params, cmd_api_read, perform_query
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.Mock(spec=Bfabric)
-    client.config.base_url = "http://test-bfabric.com"
+    client.config.base_url = "http://test-bfabric.com/bfabric"
     return client
 
 

--- a/tests/bfabric_cli/test_cli_api_update.py
+++ b/tests/bfabric_cli/test_cli_api_update.py
@@ -10,7 +10,7 @@ from bfabric_scripts.cli.api.output_format import OutputFormat
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.Mock(spec=Bfabric)
-    client.config.base_url = "http://test-bfabric.com"
+    client.config.base_url = "http://test-bfabric.com/bfabric"
     return client
 
 

--- a/tests/bfabric_cli/test_cli_dataset_download.py
+++ b/tests/bfabric_cli/test_cli_dataset_download.py
@@ -15,7 +15,7 @@ from pytest_mock import MockFixture
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.Mock(spec=Bfabric)
-    client.config.base_url = "http://test-bfabric.com"
+    client.config.base_url = "http://test-bfabric.com/bfabric"
     return client
 
 

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_activate.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_activate.py
@@ -11,8 +11,8 @@ def _write_config(config_file, default="PROD"):
         yaml.dump(
             {
                 "GENERAL": general,
-                "PROD": {"base_url": "https://prod.example.com", "auth_method": "oauth"},
-                "TEST": {"base_url": "https://test.example.com", "auth_method": "pat", "pat": "tok123"},
+                "PROD": {"base_url": "https://prod.example.com/bfabric", "auth_method": "oauth"},
+                "TEST": {"base_url": "https://test.example.com/bfabric", "auth_method": "pat", "pat": "tok123"},
             }
         )
     )

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_list.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_list.py
@@ -16,8 +16,8 @@ class TestCmdAuthList:
             yaml.dump(
                 {
                     "GENERAL": {"default_config": "TEST"},
-                    "PROD": {"base_url": "https://prod.example.com", "auth_method": "oauth"},
-                    "TEST": {"base_url": "https://test.example.com", "auth_method": "pat", "pat": "tok"},
+                    "PROD": {"base_url": "https://prod.example.com/bfabric", "auth_method": "oauth"},
+                    "TEST": {"base_url": "https://test.example.com/bfabric", "auth_method": "pat", "pat": "tok"},
                 }
             )
         )

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_login.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_login.py
@@ -373,5 +373,5 @@ class TestBaseUrl:
         mock_pkce.assert_not_called()
         assert not config_file.exists()
         err = capsys.readouterr().err
-        assert "http or https" in err
+        assert "Not a valid http(s) URL" in err
         assert "Login aborted." in err

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_login.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_login.py
@@ -139,7 +139,7 @@ class TestCmdAuthLogin:
     def test_refuses_to_run_under_a_config_override(self, tmp_path, mocker, monkeypatch, capsys):
         config_file = tmp_path / "config.yml"
         mock_pkce = mocker.patch("bfabric_scripts.cli.login.oauth_login.pkce_login")
-        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com"}')
+        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com/bfabric"}')
         cmd_auth_login(base_url="https://example.com/bfabric", scope="api:read", config_file=config_file)
         mock_pkce.assert_not_called()
         assert not config_file.exists()

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_logout.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_logout.py
@@ -188,7 +188,7 @@ class TestLogoutTargeting:
     def test_refuses_under_a_config_override(self, tmp_path, monkeypatch, capsys, cache_path):
         config_file = tmp_path / "config.yml"
         _write_oauth_config(config_file)
-        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com"}')
+        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com/bfabric"}')
         cmd_auth_logout(config_file=config_file)
         assert cache_path.exists()
         assert "BFABRICPY_CONFIG_OVERRIDE" in capsys.readouterr().out

--- a/tests/bfabric_scripts/cli/login/test_cmd_auth_pat.py
+++ b/tests/bfabric_scripts/cli/login/test_cmd_auth_pat.py
@@ -31,7 +31,7 @@ class TestCmdAuthPat:
     def test_strips_trailing_slash(self, tmp_path):
         config_file = tmp_path / "config.yml"
         cmd_auth_pat(
-            base_url="https://example.com/bfabric/",
+            base_url="https://example.com/bfabric",
             pat="tok",
             config_env="PROD",
             config_file=config_file,

--- a/tests/bfabric_scripts/cli/login/test_login_common.py
+++ b/tests/bfabric_scripts/cli/login/test_login_common.py
@@ -20,8 +20,8 @@ def _write_config(config_file, default="PROD"):
         yaml.dump(
             {
                 "GENERAL": general,
-                "PROD": {"base_url": "https://prod.example.com", "auth_method": "oauth"},
-                "TEST": {"base_url": "https://test.example.com", "auth_method": "oauth"},
+                "PROD": {"base_url": "https://prod.example.com/bfabric", "auth_method": "oauth"},
+                "TEST": {"base_url": "https://test.example.com/bfabric", "auth_method": "oauth"},
             }
         )
     )
@@ -202,23 +202,23 @@ class TestResolveBaseUrl:
 
 class TestResolveScopeFromEnvironment:
     def test_recorded_scope_is_replayed(self):
-        env = EnvironmentConfig.model_validate({"base_url": "https://example.com", "scope": "api:write tus"})
+        env = EnvironmentConfig.model_validate({"base_url": "https://example.com/bfabric", "scope": "api:write tus"})
         assert resolve_scope(None, env) == "api:write tus"
 
     def test_explicit_scope_wins_over_the_recorded_one(self):
-        env = EnvironmentConfig.model_validate({"base_url": "https://example.com", "scope": "api:read"})
+        env = EnvironmentConfig.model_validate({"base_url": "https://example.com/bfabric", "scope": "api:read"})
         assert resolve_scope("upload", env) == "api:write tus"
 
     def test_env_without_scope_still_prompts(self, mocker):
         """A 1.16.0-era environment has no ``scope``; it prompts once rather than reusing the cached
         *granted* scope, which would bake in a silent server-side drop."""
-        env = EnvironmentConfig.model_validate({"base_url": "https://example.com", "auth_method": "oauth"})
+        env = EnvironmentConfig.model_validate({"base_url": "https://example.com/bfabric", "auth_method": "oauth"})
         mocker.patch("bfabric_scripts.cli.login._common.is_interactive", return_value=True)
         mocker.patch("bfabric_scripts.cli.login._common.select_choice", return_value="read-only")
         assert resolve_scope(None, env) == "api:read"
 
     def test_env_without_scope_headless_returns_none(self, mocker):
-        env = EnvironmentConfig.model_validate({"base_url": "https://example.com", "auth_method": "oauth"})
+        env = EnvironmentConfig.model_validate({"base_url": "https://example.com/bfabric", "auth_method": "oauth"})
         mocker.patch("bfabric_scripts.cli.login._common.is_interactive", return_value=False)
         assert resolve_scope(None, env) is None
 
@@ -229,7 +229,7 @@ class TestRequireMutableConfig:
         assert require_mutable_config() is True
 
     def test_refuses_and_names_the_variable(self, monkeypatch, capsys):
-        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com"}')
+        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com/bfabric"}')
         assert require_mutable_config() is False
         assert "BFABRICPY_CONFIG_OVERRIDE" in capsys.readouterr().out
 
@@ -248,5 +248,5 @@ class TestDescribeActiveReason:
         assert describe_active_reason("PROD", "PROD") == ""
 
     def test_override_pins_everything(self, monkeypatch):
-        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com"}')
+        monkeypatch.setenv("BFABRICPY_CONFIG_OVERRIDE", '{"base_url": "https://example.com/bfabric"}')
         assert describe_active_reason("PROD", "PROD") == "  (config pinned by BFABRICPY_CONFIG_OVERRIDE)"

--- a/tests/bfabric_scripts/cli/login/test_login_urls.py
+++ b/tests/bfabric_scripts/cli/login/test_login_urls.py
@@ -32,12 +32,17 @@ class TestNormalizeBaseUrl:
         ["fgcz-bfabric-demo.uzh.ch", "FGCZ-BFABRIC-DEMO.uzh.ch", "https://fgcz-bfabric-demo.uzh.ch"],
     )
     def test_expands_a_bare_known_host(self, raw):
-        """Host-only matching is what lets a bare host expand to a full base URL."""
         assert normalize_base_url(raw) == "https://fgcz-bfabric-demo.uzh.ch/bfabric"
 
-    def test_keeps_an_explicit_path_on_a_known_host(self):
-        """Canonicalisation may add information, never overwrite a path the user typed."""
-        assert normalize_base_url("https://fgcz-bfabric-demo.uzh.ch/other") == "https://fgcz-bfabric-demo.uzh.ch/other"
+    @pytest.mark.parametrize("raw", ["my-instance.example.com", "https://my-instance.example.com/"])
+    def test_expands_a_bare_unknown_host(self, raw):
+        """Completing a typed host is what the servlet path being fixed buys us; it needn't be a known one."""
+        assert normalize_base_url(raw) == "https://my-instance.example.com/bfabric"
+
+    def test_rejects_an_explicit_non_instance_path(self):
+        """Canonicalisation may add information, never overwrite a path the user typed -- so this is an error."""
+        with pytest.raises(ValueError, match="not a B-Fabric instance URL"):
+            normalize_base_url("https://fgcz-bfabric-demo.uzh.ch/other")
 
     @pytest.mark.parametrize("raw", ["", "   ", "ftp://example.com", "https://"])
     def test_rejects_unusable_input(self, raw):

--- a/tests/bfabric_scripts/cli/workunit/test_cmd_workunit_diff.py
+++ b/tests/bfabric_scripts/cli/workunit/test_cmd_workunit_diff.py
@@ -17,7 +17,7 @@ SAMPLE_URI = "https://fgcz-bfabric.uzh.ch/bfabric/sample/show.html?id=5"
 @pytest.fixture
 def mock_client(mocker):
     client = mocker.Mock(spec=Bfabric)
-    client.config.base_url = "https://fgcz-bfabric.uzh.ch/bfabric/"
+    client.config.base_url = "https://fgcz-bfabric.uzh.ch/bfabric"
     return client
 
 

--- a/tests/bfabric_scripts/feeder/test_path_convention_compms.py
+++ b/tests/bfabric_scripts/feeder/test_path_convention_compms.py
@@ -9,7 +9,7 @@ from bfabric.entities import Storage
 @pytest.fixture
 def mock_storage(mocker):
     data_dict = {"projectfolderprefix": "x", "basepath": "/base/path"}
-    return Storage(data_dict, client=None, bfabric_instance="https://example.com/bfabric/")
+    return Storage(data_dict, client=None, bfabric_instance="https://example.com/bfabric")
 
 
 @pytest.fixture


### PR DESCRIPTION
- **Breaking:** change `BfabricClientConfig.base_url` to be canonicalised *without* a trailing slash, reversing 1.15.0. Config files and `connect_*` arguments still accept one; `bfabric-asgi-auth` sessions and the REST proxy's `bfabric_instance` parameter follow the same form.
- Add `bfabric.BaseUrl`, a `str` subclass holding a validated slash-free instance URL, so an unvalidated base URL is a type error rather than a stray `//` or a token-cache miss. It is now the type of `base_url`, `Entity.bfabric_instance` and `EntityUriComponents.bfabric_instance` (was a pydantic `HttpUrl`). A plain string still validates at runtime; typed callers need `BaseUrl(...)`.
- Fix the doubled slash in the SUDS WSDL URL and in the `show.html` links printed by `bfabric_read` and `bfabric-cli api read`.
- Cached OAuth tokens are unaffected — the cache key is byte-identical, so nobody has to re-login. The integration tests in `bfabricPy-tests` may assert the old trailing-slash form.

Closes #576

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.
