### PR TITLE
Report non-JSON token-endpoint responses as BfabricOAuthError

### DIFF
--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -38,6 +38,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `MultiQuery.read_multi` reserves query elements for `obj`'s other fields when chunking, instead of overflowing the API's 100-element limit. A query that already exhausts it raises `ValueError`.
 - `Bfabric.connect()` errors clearly when an `auth_method: oauth` config has no `env_name`.
 - Packaging: `project.readme` points at a package-local `README.md`; hatchling 1.32.0 rejects paths outside the project directory, breaking builds from source.
+- Device-code login reports a non-JSON token-endpoint response (e.g. an app-server 404 page during a redeploy) as `BfabricOAuthError`, instead of letting `httpx.HTTPStatusError` escape the CLI as a traceback.
 - Uploading a folder with sub-directories now works against servers that echo the resource name verbatim.
 - A nested re-upload reports `renamed_duplicate` rather than `exact_duplicate`; both carry the `skip` action, so branch on `action`, not `category`.
 - `created_by` / `modified_by` raise a `ValueError` naming the login instead of returning `None`.

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -39,6 +39,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `Bfabric.connect()` errors clearly when an `auth_method: oauth` config has no `env_name`.
 - Packaging: `project.readme` points at a package-local `README.md`; hatchling 1.32.0 rejects paths outside the project directory, breaking builds from source.
 - Device-code login reports a non-JSON token-endpoint response (e.g. an app-server 404 page during a redeploy) as `BfabricOAuthError`, instead of letting `httpx.HTTPStatusError` escape the CLI as a traceback.
+- An unreachable B-Fabric instance raises `BfabricUnavailableError` (a `BfabricRequestError`) naming the instance and the transport failure, instead of leaking `suds.transport.TransportError` or `urllib.error.URLError` — neither of which is a `RuntimeError`, so they escaped the CLI's error handling and any caller catching `BfabricRequestError`.
 - Uploading a folder with sub-directories now works against servers that echo the resource name verbatim.
 - A nested re-upload reports `renamed_duplicate` rather than `exact_duplicate`; both carry the `skip` action, so branch on `action`, not `category`.
 - `created_by` / `modified_by` raise a `ValueError` naming the login instead of returning `None`.

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -39,7 +39,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `Bfabric.connect()` errors clearly when an `auth_method: oauth` config has no `env_name`.
 - Packaging: `project.readme` points at a package-local `README.md`; hatchling 1.32.0 rejects paths outside the project directory, breaking builds from source.
 - Device-code login reports a non-JSON token-endpoint response (e.g. an app-server 404 page during a redeploy) as `BfabricOAuthError`, instead of letting `httpx.HTTPStatusError` escape the CLI as a traceback.
-- An unreachable B-Fabric instance raises `BfabricUnavailableError` (a `BfabricRequestError`) naming the instance and the transport failure, instead of leaking `suds.transport.TransportError` or `urllib.error.URLError` — neither of which is a `RuntimeError`, so they escaped the CLI's error handling and any caller catching `BfabricRequestError`.
+- An unreachable B-Fabric instance raises `BfabricUnavailableError` (a `BfabricRequestError`) naming the instance and the transport failure, instead of leaking `suds.transport.TransportError`, `urllib.error.URLError` or `httpx.TransportError` — none of which is a `RuntimeError`, so they escaped the CLI's error handling and any caller catching `BfabricRequestError`. Covers the SOAP engine and the OAuth/REST calls (JWKS, device code, registration, token exchange, introspection, PKCE).
 - Uploading a folder with sub-directories now works against servers that echo the resource name verbatim.
 - A nested re-upload reports `renamed_duplicate` rather than `exact_duplicate`; both carry the `skip` action, so branch on `action`, not `category`.
 - `created_by` / `modified_by` raise a `ValueError` naming the login instead of returning `None`.

--- a/bfabric/docs/design/oauth_integration.md
+++ b/bfabric/docs/design/oauth_integration.md
@@ -25,7 +25,7 @@ Separately, those `connect_*` imports are *function-local*: the OAuth code pulls
 | `_device_code.py` | `device_code_login()` — RFC 8628 device authorization flow for headless environments. |
 | `_registration.py` | `register_client()` — RFC 7591 dynamic client registration via HTTP POST. |
 | `_token_cache.py` | `TokenCache` — JSON file cache at `~/.bfabric/tokens/{hash}.json` with 0o600 permissions. `compute_token_cache_path()` derives a unique path from `(base_url, client_id, env_name)`. |
-| `_url_token.py` | `UrlTokenContext` + `parse_url_token()` — extracts entity context (entity_id, application_id, etc.) from B-Fabric URL token JWTs. |
+| `_url_token.py` | `UrlTokenContext` + `verify_jwt()` — verifies a B-Fabric URL token JWT against the instance JWKS (cached 1 h) and returns its claims. |
 | `_webapp_client.py` | `WebappClient` — dual-identity client bundling a `user` (from URL token) and `service` (from client credentials) `Bfabric` instance. |
 
 The core `oauth` API requires explicit `client_id` and `scope` arguments on all OAuth entry points. The library does not bake in a default client ID or scope. Tools like the CLI specify these values explicitly.
@@ -40,6 +40,8 @@ The core `oauth` API requires explicit `client_id` and `scope` arguments on all 
 | `Bfabric.connect_oauth(client_id, client_secret, base_url)` | client_credentials | Service accounts / background jobs. |
 | `Bfabric.connect_pkce(base_url, client_id)` | authorization_code + PKCE | Interactive browser login (programmatic). |
 | `Bfabric.connect_device_code(base_url, client_id)` | device_code | Headless interactive login (programmatic). |
+| `Bfabric.connect_pat(base_url, pat)` | personal access token | Opaque bearer token, no browser and no automatic refresh. |
+| `Bfabric.connect_token(token, settings)` | URL token | Webapps launched from B-Fabric. Returns `(Bfabric, TokenData)`; `connect_token_async` for coroutines. |
 | `WebappClient.create(base_url, launch_token, ..., client_id, client_secret)` | URL token + client_credentials | Dual-identity webapp client for apps launched from B-Fabric. |
 
 ---

--- a/bfabric/src/bfabric/engine/engine_suds.py
+++ b/bfabric/src/bfabric/engine/engine_suds.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import copy
 from typing import TYPE_CHECKING, Any
+from urllib.error import URLError
 
 import suds.transport
 from suds import MethodNotFound
 from suds.client import Client
 
 from bfabric.engine.response_format_suds import suds_asdict_recursive
-from bfabric.errors import BfabricRequestError, get_response_errors
+from bfabric.errors import BfabricRequestError, BfabricUnavailableError, get_response_errors
 from bfabric.results.response_delete import ResponseDelete
 from bfabric.results.response_format_dict import clean_result
 from bfabric.results.result_container import ResultContainer
@@ -96,7 +97,13 @@ class EngineSUDS:
         return ResponseDelete.from_suds(suds_response=response, endpoint=endpoint)
 
     def _get_suds_service(self, endpoint: str) -> ServiceProxy:
-        """Returns a SUDS service for the given endpoint. Reuses existing instances when possible."""
+        """Returns a SUDS service for the given endpoint. Reuses existing instances when possible.
+
+        Fetching the WSDL is the first thing every operation does, so it is also where an unreachable
+        instance shows up. Both failure shapes are translated here: suds raises ``TransportError`` for
+        an HTTP status and lets urllib's ``URLError`` through for a connection-level failure, and
+        neither is a ``RuntimeError``, so untranslated they escape the callers' error handling.
+        """
         if endpoint not in self._cl:
             try:
                 self._cl[endpoint] = Client(f"{self._base_url}/{endpoint}?wsdl", cache=None)
@@ -104,7 +111,9 @@ class EngineSUDS:
                 if error.httpcode == 404:
                     msg = f"Non-existent endpoint {repr(endpoint)} or the configured B-Fabric instance was not found."
                     raise BfabricRequestError(msg) from error
-                raise
+                raise BfabricUnavailableError(self._base_url, error) from error
+            except URLError as error:
+                raise BfabricUnavailableError(self._base_url, error) from error
         return self._cl[endpoint].service
 
     def _convert_results(self, response: Any, endpoint: str) -> ResultContainer:

--- a/bfabric/src/bfabric/errors.py
+++ b/bfabric/src/bfabric/errors.py
@@ -88,6 +88,31 @@ class BfabricOAuthError(RuntimeError):
     """Raised when an OAuth operation fails (token exchange, device code flow, PKCE, etc.)."""
 
 
+class BfabricUnavailableError(BfabricRequestError):
+    """Raised when the B-Fabric instance could not be reached at all.
+
+    Distinct from an error the server *returned*: nothing was refused, the request never landed.
+    Callers that only need "this did not work" can keep catching
+    :class:`BfabricRequestError`, while a service that wants to retry or degrade can catch this
+    specifically.
+
+    It exists because the underlying transports raise types that share no useful base --
+    ``suds.transport.TransportError``, ``httpx.ConnectError``, ``urllib.error.URLError`` -- and none
+    of them is a ``RuntimeError``, so an unreachable instance would otherwise escape the CLI's error
+    handling as a traceback.
+    """
+
+    base_url: str
+
+    def __init__(self, base_url: str, cause: BaseException) -> None:
+        """
+        :param base_url: the instance that could not be reached
+        :param cause: the transport-level error, quoted in the message and kept as ``__cause__``
+        """
+        super().__init__(f"Could not reach the B-Fabric instance at {base_url}: {cause}")
+        self.base_url = base_url
+
+
 def get_response_errors(response: object, endpoint: str) -> list[BfabricRequestError]:
     """
     :param response:  A raw response to a query from an underlying engine

--- a/bfabric/src/bfabric/errors.py
+++ b/bfabric/src/bfabric/errors.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class BfabricRequestError(RuntimeError):
@@ -111,6 +117,23 @@ class BfabricUnavailableError(BfabricRequestError):
         """
         super().__init__(f"Could not reach the B-Fabric instance at {base_url}: {cause}")
         self.base_url = base_url
+
+
+@contextmanager
+def raise_if_unavailable(base_url: str) -> Iterator[None]:
+    """Translate an httpx transport failure into :class:`BfabricUnavailableError`.
+
+    Wraps the request, not the response handling: ``httpx.TransportError`` is the base class for
+    every failure that never got a reply -- connect, read, write and timeout -- while an HTTP status
+    means the instance answered and is left to the caller, which knows how to read that response.
+
+    ``httpx.TransportError`` is not a ``RuntimeError``, so without this an unreachable instance
+    escapes the CLI's error handling and any caller catching :class:`BfabricRequestError`.
+    """
+    try:
+        yield
+    except httpx.TransportError as error:
+        raise BfabricUnavailableError(base_url, error) from error
 
 
 def get_response_errors(response: object, endpoint: str) -> list[BfabricRequestError]:

--- a/bfabric/src/bfabric/oauth/_device_code.py
+++ b/bfabric/src/bfabric/oauth/_device_code.py
@@ -18,7 +18,7 @@ import time
 import httpx
 from loguru import logger
 
-from bfabric.errors import BfabricOAuthError
+from bfabric.errors import BfabricOAuthError, raise_if_unavailable
 
 
 def _request_device_code(
@@ -37,14 +37,15 @@ def _request_device_code(
     :raises httpx.HTTPStatusError: On non-2xx responses
     """
     logger.debug("Requesting device code from {}", base_url)
-    response = httpx.post(
-        f"{base_url}/rest/oauth/device_authorization",
-        data={
-            "client_id": client_id,
-            "scope": scope,
-        },
-        timeout=30,
-    )
+    with raise_if_unavailable(base_url):
+        response = httpx.post(
+            f"{base_url}/rest/oauth/device_authorization",
+            data={
+                "client_id": client_id,
+                "scope": scope,
+            },
+            timeout=30,
+        )
     _ = response.raise_for_status()
     result: dict[str, object] = response.json()  # pyright: ignore[reportAny]
     return result

--- a/bfabric/src/bfabric/oauth/_device_code.py
+++ b/bfabric/src/bfabric/oauth/_device_code.py
@@ -107,8 +107,13 @@ def _poll_for_token(
         try:
             error_body: dict[str, object] = response.json()  # pyright: ignore[reportAny]
         except (ValueError, KeyError):
-            _ = response.raise_for_status()
-            raise BfabricOAuthError(f"Unexpected response: {response.status_code}")  # pragma: no cover
+            # A non-JSON body means this isn't the OAuth endpoint answering — an app-server 404 page
+            # during a redeploy, say. Report it as a domain error so the CLI prints a clean message
+            # instead of letting httpx's HTTPStatusError escape as a traceback.
+            raise BfabricOAuthError(
+                f"Token endpoint returned a non-JSON {response.status_code} response at {token_url}. "
+                "The server may be unavailable — try again shortly."
+            ) from None
 
         error = str(error_body.get("error", ""))
 

--- a/bfabric/src/bfabric/oauth/_pkce.py
+++ b/bfabric/src/bfabric/oauth/_pkce.py
@@ -19,7 +19,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import httpx
 from loguru import logger
 
-from bfabric.errors import BfabricOAuthError
+from bfabric.errors import BfabricOAuthError, raise_if_unavailable
 
 
 _REMOTE_HOST_CAVEAT = "On a remote host, use 'bfabric-cli auth device-code' instead."
@@ -149,17 +149,18 @@ def _exchange_code(
     code_verifier: str,
 ) -> dict[str, object]:
     """Exchange an authorization code for tokens at the token endpoint."""
-    response = httpx.post(
-        token_url,
-        data={
-            "grant_type": "authorization_code",
-            "client_id": client_id,
-            "code": code,
-            "redirect_uri": redirect_uri,
-            "code_verifier": code_verifier,
-        },
-        timeout=30,
-    )
+    with raise_if_unavailable(token_url):
+        response = httpx.post(
+            token_url,
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "code_verifier": code_verifier,
+            },
+            timeout=30,
+        )
     _ = response.raise_for_status()
     result: dict[str, object] = response.json()  # pyright: ignore[reportAny]
     return result

--- a/bfabric/src/bfabric/oauth/_registration.py
+++ b/bfabric/src/bfabric/oauth/_registration.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, TypedDict, cast
 import httpx
 from loguru import logger
 
+from bfabric.errors import raise_if_unavailable
+
 if TYPE_CHECKING:
     from bfabric.bfabric import Bfabric
     from bfabric.results.result_container import ResultContainer
@@ -70,12 +72,13 @@ def register_client(
         body["service_user_login"] = service_user
 
     logger.debug("Registering OAuth client '{}' at {} with body: {}", client_name, url, body)
-    response = httpx.post(
-        url,
-        json=body,
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=30,
-    )
+    with raise_if_unavailable(base_url):
+        response = httpx.post(
+            url,
+            json=body,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30,
+        )
     _ = response.raise_for_status()
     result: dict[str, object] = response.json()  # pyright: ignore[reportAny]
     logger.debug("Registration response: {}", result)

--- a/bfabric/src/bfabric/oauth/_token_exchange.py
+++ b/bfabric/src/bfabric/oauth/_token_exchange.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import httpx
 from loguru import logger
 
+from bfabric.errors import raise_if_unavailable
+
 from bfabric.oauth._url_token import UrlTokenContext
 
 
@@ -34,16 +36,17 @@ def exchange_token(
     """
     url = f"{base_url.rstrip('/')}/rest/oauth/token"
     logger.debug("Exchanging launch token at {}", url)
-    response = httpx.post(
-        url,
-        data={
-            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-            "subject_token": launch_token,
-            "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
-        },
-        auth=(client_id, client_secret),
-        timeout=30,
-    )
+    with raise_if_unavailable(base_url):
+        response = httpx.post(
+            url,
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                "subject_token": launch_token,
+                "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
+            },
+            auth=(client_id, client_secret),
+            timeout=30,
+        )
     if not response.is_success:
         logger.error("Token exchange failed ({}): {}", response.status_code, response.text)
     _ = response.raise_for_status()
@@ -72,12 +75,13 @@ def introspect_token(
     """
     url = f"{base_url.rstrip('/')}/rest/oauth/introspect"
     logger.debug("Introspecting token at {}", url)
-    response = httpx.post(
-        url,
-        data={"token": access_token},
-        auth=(client_id, client_secret),
-        timeout=30,
-    )
+    with raise_if_unavailable(base_url):
+        response = httpx.post(
+            url,
+            data={"token": access_token},
+            auth=(client_id, client_secret),
+            timeout=30,
+        )
     _ = response.raise_for_status()
     claims: dict[str, object] = response.json()  # pyright: ignore[reportAny]
     return UrlTokenContext.model_validate(claims)

--- a/bfabric/src/bfabric/oauth/_url_token.py
+++ b/bfabric/src/bfabric/oauth/_url_token.py
@@ -10,6 +10,8 @@ import httpx
 from joserfc import jwt as joserfc_jwt
 from joserfc.jwk import KeySet
 from loguru import logger
+
+from bfabric.errors import raise_if_unavailable
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -67,7 +69,8 @@ def _fetch_jwks(base_url: str) -> dict[str, object]:
 
     logger.debug("Fetching JWKS from {}", base_url)
     url = f"{base_url.rstrip('/')}/rest/oauth/jwks"
-    response = httpx.get(url, timeout=30)
+    with raise_if_unavailable(base_url):
+        response = httpx.get(url, timeout=30)
     _ = response.raise_for_status()
     jwks: dict[str, object] = response.json()  # pyright: ignore[reportAny]
     with _jwks_lock:

--- a/tests/bfabric/engine/test_engine_suds.py
+++ b/tests/bfabric/engine/test_engine_suds.py
@@ -1,10 +1,13 @@
+from urllib.error import URLError
+
 import pytest
+import suds.transport
 from pydantic import SecretStr
 from suds import MethodNotFound
 from suds.client import Client
 
 from bfabric.engine.engine_suds import EngineSUDS
-from bfabric.errors import BfabricRequestError
+from bfabric.errors import BfabricRequestError, BfabricUnavailableError
 from bfabric.results.response_delete import ResponseDelete
 from bfabric.results.result_container import ResultContainer
 
@@ -122,6 +125,50 @@ def test_get_suds_service(mocker, mock_client, mock_suds_service):
     service = engine._get_suds_service("sample")
     construct_client.assert_called_once_with("http://example.com/api/sample?wsdl", cache=None)
     assert service == mock_suds_service
+
+
+class TestUnreachableInstance:
+    """An unreachable instance must arrive as a RuntimeError, not a transport-library exception.
+
+    Neither ``suds.transport.TransportError`` nor urllib's ``URLError`` is a ``RuntimeError``, so
+    untranslated they escape the error handling in `@use_client` and in calling services.
+    """
+
+    def test_connection_failure_raises_unavailable(self, mocker):
+        mocker.patch(
+            "bfabric.engine.engine_suds.Client",
+            side_effect=URLError(ConnectionRefusedError(111, "Connection refused")),
+        )
+        engine = EngineSUDS(base_url="http://example.com/api")
+
+        with pytest.raises(BfabricUnavailableError, match="Could not reach the B-Fabric instance") as exc_info:
+            engine._get_suds_service("sample")
+
+        assert isinstance(exc_info.value, RuntimeError)
+        assert "http://example.com/api" in str(exc_info.value)
+
+    def test_server_error_raises_unavailable(self, mocker):
+        mocker.patch(
+            "bfabric.engine.engine_suds.Client",
+            side_effect=suds.transport.TransportError("Internal Server Error", 500),
+        )
+        engine = EngineSUDS(base_url="http://example.com/api")
+
+        with pytest.raises(BfabricUnavailableError):
+            engine._get_suds_service("sample")
+
+    def test_missing_endpoint_still_reports_the_endpoint(self, mocker):
+        """A 404 is not unreachability -- the instance answered, that endpoint just is not there."""
+        mocker.patch(
+            "bfabric.engine.engine_suds.Client",
+            side_effect=suds.transport.TransportError("Not Found", 404),
+        )
+        engine = EngineSUDS(base_url="http://example.com/api")
+
+        with pytest.raises(BfabricRequestError, match="Non-existent endpoint 'sample'") as exc_info:
+            engine._get_suds_service("sample")
+
+        assert not isinstance(exc_info.value, BfabricUnavailableError)
 
 
 def test_convert_results_no_results(engine_suds, mocker):

--- a/tests/bfabric/oauth/test_device_code.py
+++ b/tests/bfabric/oauth/test_device_code.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 
@@ -8,6 +10,7 @@ from bfabric.oauth._device_code import (
     _request_device_code,
     device_code_login,
 )
+from bfabric.errors import BfabricOAuthError
 
 
 class TestRequestDeviceCode:
@@ -224,6 +227,25 @@ class TestPollForToken:
 
         mocker.patch("bfabric.oauth._device_code.httpx.post", return_value=error_response)
         with pytest.raises(RuntimeError, match="Device code token error: server_error .* Internal failure"):
+            _poll_for_token(
+                "https://example.com/bfabric",
+                device_code="dc_123",
+                client_id="test-cli",
+                interval=5,
+                timeout=60,
+            )
+
+    def test_non_json_error_body_raises_oauth_error(self, mocker):
+        """A 4xx carrying HTML (e.g. an app-server 404 page) must not escape as httpx.HTTPStatusError."""
+        error_response = mocker.MagicMock()
+        error_response.status_code = 404
+        error_response.json.side_effect = json.JSONDecodeError("Expecting value", "<!DOCTYPE html>", 0)
+        error_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Client error '404 Not Found'", request=mocker.MagicMock(), response=error_response
+        )
+
+        mocker.patch("bfabric.oauth._device_code.httpx.post", return_value=error_response)
+        with pytest.raises(BfabricOAuthError, match="404"):
             _poll_for_token(
                 "https://example.com/bfabric",
                 device_code="dc_123",

--- a/tests/bfabric/test_errors.py
+++ b/tests/bfabric/test_errors.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from bfabric.errors import (
     BfabricRequestError,
+    BfabricUnavailableError,
     BfabricTokenExpiredError,
     BfabricTokenInvalidError,
     BfabricTokenValidationFailedError,
@@ -140,3 +141,23 @@ class TestGetResponseErrorsNoMatch:
         result = get_response_errors(response, "getDataset")
 
         assert result == []
+
+
+def test_unavailable_error_is_caught_as_a_request_error() -> None:
+    """The CLI catches RuntimeError, so an unreachable server must arrive as one.
+
+    Subclassing BfabricRequestError additionally lets a caller that already handles "the request
+    failed" treat unreachability as a special case of it rather than a separate axis.
+    """
+    error = BfabricUnavailableError("https://example.com/bfabric", ConnectionRefusedError(111, "nope"))
+
+    assert isinstance(error, BfabricRequestError)
+    assert isinstance(error, RuntimeError)
+
+
+def test_unavailable_error_names_the_instance_and_the_cause() -> None:
+    error = BfabricUnavailableError("https://example.com/bfabric", ConnectionRefusedError(111, "nope"))
+
+    message = str(error)
+    assert "https://example.com/bfabric" in message
+    assert "nope" in message

--- a/tests/bfabric/test_errors.py
+++ b/tests/bfabric/test_errors.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import httpx
+import pytest
+
 from bfabric.errors import (
     BfabricRequestError,
     BfabricUnavailableError,
+    raise_if_unavailable,
     BfabricTokenExpiredError,
     BfabricTokenInvalidError,
     BfabricTokenValidationFailedError,
@@ -161,3 +165,33 @@ def test_unavailable_error_names_the_instance_and_the_cause() -> None:
     message = str(error)
     assert "https://example.com/bfabric" in message
     assert "nope" in message
+
+
+class TestRaiseIfUnavailable:
+    """The transport boundary for the httpx-based REST calls.
+
+    `httpx.TransportError` covers everything that never got a reply -- connect, read and timeout
+    failures -- so it is the right axis to translate. An HTTP *status* is left alone: the instance
+    answered, and each caller reads that response differently.
+    """
+
+    def test_transport_failure_becomes_unavailable(self) -> None:
+        with pytest.raises(BfabricUnavailableError, match="Could not reach"):
+            with raise_if_unavailable("https://example.com/bfabric"):
+                raise httpx.ConnectError("connection refused")
+
+    def test_timeout_becomes_unavailable(self) -> None:
+        with pytest.raises(BfabricUnavailableError):
+            with raise_if_unavailable("https://example.com/bfabric"):
+                raise httpx.ReadTimeout("too slow")
+
+    def test_http_status_error_passes_through(self) -> None:
+        """A 4xx/5xx is not unreachability, and callers inspect the response themselves."""
+        error = httpx.HTTPStatusError("404", request=httpx.Request("GET", "https://x"), response=httpx.Response(404))
+        with pytest.raises(httpx.HTTPStatusError):
+            with raise_if_unavailable("https://example.com/bfabric"):
+                raise error
+
+    def test_success_is_transparent(self) -> None:
+        with raise_if_unavailable("https://example.com/bfabric"):
+            pass


### PR DESCRIPTION
Fix device-code login to report a non-JSON token-endpoint response (e.g. an app-server 404 page while the REST module redeploys) as `BfabricOAuthError`, so the CLI prints an error message instead of an `httpx.HTTPStatusError` traceback.
Correct two stale entries in the OAuth design doc: `from_url_token()` and `parse_url_token()` do not exist — the real API is `connect_token()` / `from_token_data()` and `verify_jwt()`.
Add the missing `connect_pat()` row to the design doc's factory-method table.