### PR TITLE
chore: re-enable the mdformat pre-commit hook and reformat markdown

### DIFF
--- a/.github/actions/extract-changelog/test_extract_changelog.py
+++ b/.github/actions/extract-changelog/test_extract_changelog.py
@@ -65,6 +65,28 @@ def test_extract_changelog_entry_with_another_version(mocker):
     assert "## \\[1.1.0\\]" not in result
 
 
+def test_extract_changelog_entry_with_unescaped_brackets(mocker):
+    # mdformat leaves the brackets unescaped, so both forms have to keep working
+    changelog_content = """# Changelog
+
+## [1.1.0] - 2025-04-15
+### Added
+- New feature X
+
+## [1.0.0] - 2025-03-15
+### Added
+- Initial release
+"""
+
+    mocker.patch("os.path.isfile", return_value=True)
+    mocker.patch("builtins.open", mocker.mock_open(read_data=changelog_content))
+
+    result = extract_changelog_entry("fake_path.md", "1.1.0")
+    assert "## [1.1.0]" in result
+    assert "New feature X" in result
+    assert "## [1.0.0]" not in result
+
+
 def test_extract_changelog_entry_with_nonexistent_version(mocker):
     # Sample changelog content with escaped brackets
     changelog_content = """# Changelog

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,12 @@ repos:
     rev: "v0.15.0"
     hooks:
       - id: yamlfmt
-  #- repo: https://github.com/executablebooks/mdformat/
-  #  rev: "1.0.0"
-  #  hooks:
-  #    - id: mdformat
+  - repo: https://github.com/hukkin/mdformat
+    rev: "1.0.0"
+    hooks:
+      - id: mdformat
+        # simple-breaks keeps thematic breaks as `---` instead of a row of 70 underscores
+        additional_dependencies: ["mdformat-gfm==1.0.0", "mdformat-simple-breaks==0.1.0"]
   #- repo: https://github.com/abravalheri/validate-pyproject
   #  rev: "v0.23"
   #  hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,24 +10,26 @@ bfabricPy is a Python client library for [B-Fabric](https://fgcz-bfabric.uzh.ch/
 
 This is a **uv workspace** with 5 packages:
 
-| Package | Purpose | Min Python |
-|---------|---------|------------|
-| `bfabric` | Core client library | 3.11 |
-| `bfabric_scripts` | CLI scripts and utilities | 3.11 |
-| `bfabric_app_runner` | Application runner for workflows | 3.12 |
-| `bfabric_rest_proxy` | FastAPI REST proxy | 3.12 |
-| `bfabric_asgi_auth` | ASGI auth middleware | 3.13 |
+| Package              | Purpose                          | Min Python |
+| -------------------- | -------------------------------- | ---------- |
+| `bfabric`            | Core client library              | 3.11       |
+| `bfabric_scripts`    | CLI scripts and utilities        | 3.11       |
+| `bfabric_app_runner` | Application runner for workflows | 3.12       |
+| `bfabric_rest_proxy` | FastAPI REST proxy               | 3.12       |
+| `bfabric_asgi_auth`  | ASGI auth middleware             | 3.13       |
 
 Each package has its own `pyproject.toml` under its directory. Workspace references mean changes to `bfabric` are immediately available to dependent packages.
 
 ## Common Commands
 
 ### Setup
+
 ```bash
 uv sync --all-packages --all-extras
 ```
 
 ### Testing (nox — recommended)
+
 ```bash
 nox                                    # all test sessions
 nox -s test_bfabric                    # core package only
@@ -38,6 +40,7 @@ nox -s test_bfabric-3.11(lowest-direct) # specific resolution strategy
 ```
 
 ### Testing (pytest — direct, after uv sync)
+
 ```bash
 pytest tests/bfabric                   # core package
 pytest tests/bfabric_scripts           # scripts (also tests/bfabric_cli)
@@ -49,6 +52,7 @@ pytest tests/bfabric -k test_name      # single test
 Run each package's suite in a **separate** `pytest` invocation, as nox does — one invocation over two package trees fails at collection because identically-named test modules collide (see the `__init__.py` convention below).
 
 ### Type Checking
+
 ```bash
 nox -s basedpyright(bfabric)
 nox -s basedpyright(bfabric_scripts)
@@ -56,15 +60,17 @@ nox -s basedpyright(bfabric_app_runner)
 ```
 
 ### Linting and formatting
+
 ```bash
 nox -s code_style                      # ruff lint via nox — lint only, checks no formatting
 ruff check bfabric                     # ruff directly
-pre-commit run --all-files             # the formatter gate (black, and blacken-docs for md code blocks)
+pre-commit run --all-files             # the formatter gate (black, blacken-docs for md code blocks, mdformat for md)
 ```
 
 **black is the formatter — never run `ruff format`.** It disagrees with black on ~15 files and produces a large spurious diff. Since neither `nox -s code_style` nor CI checks formatting, the pre-commit hook rejecting the commit is the only thing that catches a wrong formatter.
 
 ### Docs
+
 ```bash
 nox -s docs                            # build all docs to site/
 cd bfabric/docs && make html           # local preview
@@ -110,13 +116,13 @@ Docs live alongside each package's source; skim the index when working in one. `
 - Line length is 120 (ruff and black). Ruff lint is currently only enforced on the `bfabric` package (scripts, wrapper_creator, tests, noxfile are excluded via per-file-ignores).
 - basedpyright uses per-package baseline files at `.basedpyright/baseline.{package}.json` — **do not edit a baseline to silence a new error**; fix the code or add a targeted `# pyright: ignore[...]` on the offending line. Baselines only exist to grandfather in pre-existing errors.
 - Docstrings use Sphinx `:param:` / `:raises:`; Google-style `Args:` / `Returns:` blocks survive in a few older modules (e.g. `entities/core/uri.py`) — don't add more.
-- Keep docstrings at the lowest useful altitude: one summary line by default, plus a short paragraph only for a contract the signature cannot show (why this exists beside a similar function, a gotcha, an ordering constraint). Skip `Returns:` blocks and `:param:` lines that restate the annotation, and don't restate a default the signature already shows. Do document what a value *means* — a sentinel's runtime resolution (`` ``None`` reads all results ``, `` ``None`` writes to ``./output.yml`` ``) or a magic value (`` ``0`` = auto-assign ``) — phrased as "``None`` does X", not "(default: X)".
+- Keep docstrings at the lowest useful altitude: one summary line by default, plus a short paragraph only for a contract the signature cannot show (why this exists beside a similar function, a gotcha, an ordering constraint). Skip `Returns:` blocks and `:param:` lines that restate the annotation, and don't restate a default the signature already shows. Do document what a value *means* — a sentinel's runtime resolution (`` `None` reads all results ``, `` `None` writes to `./output.yml` ``) or a magic value (`` `0` = auto-assign ``) — phrased as "`None` does X", not "(default: X)".
 - Avoid `>>>` examples: no session collects doctests, so they read as tested without being tested. Put a short example in the prose instead.
 - Exception: a cyclopts command function's docstring **is** its `--help` text — the summary line becomes the command description and each `:param:` line becomes that option's help (see `bfabric-cli workunit not-available --help`). That is user-facing copy: keep it complete and clear, and trim the internal helpers around it instead.
 
 ## Changelog
 
-Each package has its own `docs/changelog.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/): `### Added` / `### Changed` / `### Fixed` / `### Removed` subsections under `## \[Unreleased\]`. Headings escape the brackets — `nox -s changelog` matches `## \[<version>\]` literally.
+Each package has its own `docs/changelog.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/): `### Added` / `### Changed` / `### Fixed` / `### Removed` subsections under `## [Unreleased]`.
 
 - One or two lines per entry: the symbol, and the effect a user sees. No code blocks, no before/after examples, no "previously it did X because Y" — rationale belongs in the commit message.
 - Label an entry **Breaking** only when the API has real external consumers; otherwise just describe it in its new shape.

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ This package implements a Python interface to the [B-Fabric](https://fgcz-bfabri
 Several pieces of functionality are available:
 
 - Python API:
-    - General client for all B-Fabric web service operations (CRUD) and configuration management.
-    - A relational API for low-boilerplate read access to the B-Fabric system.
+  - General client for all B-Fabric web service operations (CRUD) and configuration management.
+  - A relational API for low-boilerplate read access to the B-Fabric system.
 - Scripts: Several scripts we use more or less frequently to interact with the system.
 - A REST API: A REST API to interact with the B-Fabric system. This allows us to interact with B-Fabric from R
-    using [bfabricShiny](https://github.com/cpanse/bfabricShiny).
+  using [bfabricShiny](https://github.com/cpanse/bfabricShiny).
 
 ## Howto cite?
 

--- a/bfabric/docs/advanced_topics/index.md
+++ b/bfabric/docs/advanced_topics/index.md
@@ -10,10 +10,10 @@ data_operations.md
 
 ## Topics Overview
 
-| Topic | Description | Skill Level |
-| ----------------------------------------------------- | -------------------------------------------- | ------------ |
-| **[Workunit Definitions](workunit_definitions/index.md)** | YAML-based workunit configuration | Intermediate |
-| **[Data Operations](data_operations.md)** | Dataset uploads and custom-attribute updates | Advanced |
+| Topic                                                     | Description                                  | Skill Level  |
+| --------------------------------------------------------- | -------------------------------------------- | ------------ |
+| **[Workunit Definitions](workunit_definitions/index.md)** | YAML-based workunit configuration            | Intermediate |
+| **[Data Operations](data_operations.md)**                 | Dataset uploads and custom-attribute updates | Advanced     |
 
 ## Advanced Guides
 

--- a/bfabric/docs/api_reference/bfabric_client/index.md
+++ b/bfabric/docs/api_reference/bfabric_client/index.md
@@ -12,16 +12,16 @@ Complete API reference for the `Bfabric` client class, automatically generated f
 
 The `Bfabric` class provides methods for:
 
-| Category | Methods |
-|----------|---------|
-| Client Creation | `connect()`, `connect_oauth()`, `connect_pkce()`, `connect_device_code()`, `connect_pat()`, `connect_token()`, `from_token_data()` |
-| Read Operations | `read()`, `exists()` |
-| Write Operations | `save()`, `delete()`, `upload_resource()` |
-| Configuration | `config`, `auth`, `config_data` properties |
-| Entity Operations | `reader` property for `EntityReader` |
-| Context Management | `with_auth()` |
+| Category           | Methods                                                                                                                            |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Client Creation    | `connect()`, `connect_oauth()`, `connect_pkce()`, `connect_device_code()`, `connect_pat()`, `connect_token()`, `from_token_data()` |
+| Read Operations    | `read()`, `exists()`                                                                                                               |
+| Write Operations   | `save()`, `delete()`, `upload_resource()`                                                                                          |
+| Configuration      | `config`, `auth`, `config_data` properties                                                                                         |
+| Entity Operations  | `reader` property for `EntityReader`                                                                                               |
+| Context Management | `with_auth()`                                                                                                                      |
 
-______________________________________________________________________
+---
 
 ## Bfabric Class
 

--- a/bfabric/docs/api_reference/entity_types/index.md
+++ b/bfabric/docs/api_reference/entity_types/index.md
@@ -18,29 +18,29 @@ Complete reference for all B-Fabric entity types.
 
 ## Quick Links
 
-| Entity | Description | Special Features |
+| Entity                   | Description              | Special Features                                         |
 | ------------------------ | ------------------------ | -------------------------------------------------------- |
-| **Project** | Top-level project entity | Container for samples and workunits |
-| **Sample** | Sample within a project | Has container relationship (Project/Order) |
-| **Workunit** | Workunit/job entity | Rich parameter access, output folder calculation |
-| **Dataset** | Dataset entity | DataFrame conversion, export methods, column access |
-| **Application** | Application definition | Technology folder name, storage/executable relationships |
-| **Executable** | Executable binary/script | Base64 decoding, parameter definitions |
-| **ExternalJob** | External job reference | Client entity resolution, workunit association |
-| **Resource** | File resource | Path methods, storage/sample/workunit relationships |
-| **Storage** | Storage location | Base path, SCP prefix |
-| **Parameter** | Workunit parameter | Key-value access with special handling |
-| **User** | User entity | Login-based lookup |
-| **Order** | Order entity | Optional project relationship |
-| **Workflow** | Workflow definition | Workflow steps, template association |
-| **WorkflowStep** | Individual workflow step | Container relationship |
-| **WorkflowTemplate** | Workflow template | Template steps definition |
-| **WorkflowTemplateStep** | Template step | Template association |
-| **Plate** | Plate entity | Basic entity |
-| **Run** | Run entity | Basic entity |
-| **Instrument** | Instrument entity | Basic entity |
-| **MultiplexKit** | Multiplex kit | Filtered multiplex IDs |
-| **MultiplexId** | Multiplex ID | Basic entity |
+| **Project**              | Top-level project entity | Container for samples and workunits                      |
+| **Sample**               | Sample within a project  | Has container relationship (Project/Order)               |
+| **Workunit**             | Workunit/job entity      | Rich parameter access, output folder calculation         |
+| **Dataset**              | Dataset entity           | DataFrame conversion, export methods, column access      |
+| **Application**          | Application definition   | Technology folder name, storage/executable relationships |
+| **Executable**           | Executable binary/script | Base64 decoding, parameter definitions                   |
+| **ExternalJob**          | External job reference   | Client entity resolution, workunit association           |
+| **Resource**             | File resource            | Path methods, storage/sample/workunit relationships      |
+| **Storage**              | Storage location         | Base path, SCP prefix                                    |
+| **Parameter**            | Workunit parameter       | Key-value access with special handling                   |
+| **User**                 | User entity              | Login-based lookup                                       |
+| **Order**                | Order entity             | Optional project relationship                            |
+| **Workflow**             | Workflow definition      | Workflow steps, template association                     |
+| **WorkflowStep**         | Individual workflow step | Container relationship                                   |
+| **WorkflowTemplate**     | Workflow template        | Template steps definition                                |
+| **WorkflowTemplateStep** | Template step            | Template association                                     |
+| **Plate**                | Plate entity             | Basic entity                                             |
+| **Run**                  | Run entity               | Basic entity                                             |
+| **Instrument**           | Instrument entity        | Basic entity                                             |
+| **MultiplexKit**         | Multiplex kit            | Filtered multiplex IDs                                   |
+| **MultiplexId**          | Multiplex ID             | Basic entity                                             |
 
 ## See Also
 

--- a/bfabric/docs/api_reference/entity_uri/index.md
+++ b/bfabric/docs/api_reference/entity_uri/index.md
@@ -65,6 +65,7 @@ print(uri.components.entity_id)  # 123
 ```
 
 (normalize-a-web-url)=
+
 ### Normalize a Web URL
 
 A URL copied from the browser usually carries extra query parameters (e.g. the selected tab), which
@@ -131,11 +132,11 @@ entities = reader.read_uris(uris)
 
 ### Component Breakdown
 
-| Component | Description | Example |
-|-----------|-------------|---------|
+| Component          | Description                   | Example                                |
+| ------------------ | ----------------------------- | -------------------------------------- |
 | `bfabric_instance` | Base URL of B-Fabric instance | `https://fgcz-bfabric.uzh.ch/bfabric/` |
-| `entity_type` | Entity name (lowercase) | `sample`, `project`, `workunit` |
-| `entity_id` | Numeric entity ID | `123` |
+| `entity_type`      | Entity name (lowercase)       | `sample`, `project`, `workunit`        |
+| `entity_id`        | Numeric entity ID             | `123`                                  |
 
 ### Supported Entity Types
 

--- a/bfabric/docs/api_reference/index.md
+++ b/bfabric/docs/api_reference/index.md
@@ -19,15 +19,15 @@ This section uses **auto-generated documentation** directly from the Python code
 
 ## Quick Links
 
-| Component | Description |
+| Component                                                 | Description                                        |
 | --------------------------------------------------------- | -------------------------------------------------- |
-| **[Bfabric Client](bfabric_client/index.md)** | Main client class with all read/write methods |
-| **[Entity Types](entity_types/index.md)** | All 20+ entity types with auto-documented features |
-| **[EntityReader](entity_reader/index.md)** | Entity-based reading with caching support |
-| **[EntityUri](entity_uri/index.md)** | Entity identifier across instances |
-| **[ResultContainer](result_container/index.md)** | Query result container with error handling |
-| **[Token Data](token_data/index.md)** | Token authentication data structure |
-| **[Exceptions & Errors](exceptions_and_errors/index.md)** | All exception types and when they're raised |
+| **[Bfabric Client](bfabric_client/index.md)**             | Main client class with all read/write methods      |
+| **[Entity Types](entity_types/index.md)**                 | All 20+ entity types with auto-documented features |
+| **[EntityReader](entity_reader/index.md)**                | Entity-based reading with caching support          |
+| **[EntityUri](entity_uri/index.md)**                      | Entity identifier across instances                 |
+| **[ResultContainer](result_container/index.md)**          | Query result container with error handling         |
+| **[Token Data](token_data/index.md)**                     | Token authentication data structure                |
+| **[Exceptions & Errors](exceptions_and_errors/index.md)** | All exception types and when they're raised        |
 
 ## For Beginners
 
@@ -41,26 +41,26 @@ If you're new to bfabricPy, start with:
 
 ### By Task
 
-| Task | Relevant Documentation |
-| ------------------ | -------------------------------------------------------------------------------------------- |
-| Create a client | [Bfabric Client](bfabric_client/index), [Getting Started](../../getting_started/index) |
-| Query B-Fabric | [Bfabric Client: read()](bfabric_client/index), [EntityReader](entity_reader/index) |
-| Work with entities | [Entity Types](entity_types/index), [EntityReader](entity_reader/index) |
-| Write data | [Bfabric Client: save()](bfabric_client/index) |
-| Handle errors | [Exceptions & Errors](exceptions_and_errors/index) |
+| Task               | Relevant Documentation                                                                 |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| Create a client    | [Bfabric Client](bfabric_client/index), [Getting Started](../../getting_started/index) |
+| Query B-Fabric     | [Bfabric Client: read()](bfabric_client/index), [EntityReader](entity_reader/index)    |
+| Work with entities | [Entity Types](entity_types/index), [EntityReader](entity_reader/index)                |
+| Write data         | [Bfabric Client: save()](bfabric_client/index)                                         |
+| Handle errors      | [Exceptions & Errors](exceptions_and_errors/index)                                     |
 
 ### By Class
 
-| Class | What It Does |
+| Class                 | What It Does                         |
 | --------------------- | ------------------------------------ |
-| `Bfabric` | Main client - all API operations |
-| `Entity` | Base class for all B-Fabric entities |
-| `EntityReader` | Read entities by URI/ID/query |
-| `ResultContainer` | Container for query results |
-| `EntityUri` | Entity identifier across instances |
-| `TokenData` | Token authentication data |
-| `BfabricRequestError` | Server-side errors |
-| `BfabricConfigError` | Configuration errors |
+| `Bfabric`             | Main client - all API operations     |
+| `Entity`              | Base class for all B-Fabric entities |
+| `EntityReader`        | Read entities by URI/ID/query        |
+| `ResultContainer`     | Container for query results          |
+| `EntityUri`           | Entity identifier across instances   |
+| `TokenData`           | Token authentication data            |
+| `BfabricRequestError` | Server-side errors                   |
+| `BfabricConfigError`  | Configuration errors                 |
 
 ## API Stability
 

--- a/bfabric/docs/api_reference/token_data/index.md
+++ b/bfabric/docs/api_reference/token_data/index.md
@@ -15,17 +15,17 @@ Complete reference for the `TokenData` class.
 
 ## Properties
 
-| Property | Type | Description |
+| Property           | Type     | Description                              |
 | ------------------ | -------- | ---------------------------------------- |
-| `user` | str | B-Fabric user login |
-| `user_ws_password` | str | Web service password for the user |
-| `application_id` | int | Application ID |
-| `entity_class` | str | Entity class name |
-| `entity_id` | int | Entity ID |
-| `job_id` | int | External job ID |
-| `caller` | str | B-Fabric instance URL |
-| `token_expires` | datetime | Token expiration time |
-| `web_service_user` | bool | Whether user has web service permissions |
+| `user`             | str      | B-Fabric user login                      |
+| `user_ws_password` | str      | Web service password for the user        |
+| `application_id`   | int      | Application ID                           |
+| `entity_class`     | str      | Entity class name                        |
+| `entity_id`        | int      | Entity ID                                |
+| `job_id`           | int      | External job ID                          |
+| `caller`           | str      | B-Fabric instance URL                    |
+| `token_expires`    | datetime | Token expiration time                    |
+| `web_service_user` | bool     | Whether user has web service permissions |
 
 ## Quick Examples
 

--- a/bfabric/docs/changelog.md
+++ b/bfabric/docs/changelog.md
@@ -7,7 +7,7 @@ Historically, before 1.14.0, a different versioning scheme was used.
 
 Minor breaking changes are still possible in `1.X.Y` but we try to announce them with DeprecationWarnings in the previous `Y-1` release.
 
-## \[Unreleased\]
+## [Unreleased]
 
 ### Added
 
@@ -43,7 +43,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `created_by` / `modified_by` raise a `ValueError` naming the login instead of returning `None`.
 - Internal: owner typing corrected across the `entities/core` descriptors and mixins; `HasMany(bfabric_field=...)` is now required and class-level access raises like `HasOne`.
 
-## \[1.20.0\] - 2026-08-03
+## [1.20.0] - 2026-08-03
 
 - OAuth 2.0 authentication: `connect_oauth` (client-credentials grant, auto-refresh + optional token cache), `connect_pkce` (interactive browser login, PKCE), `connect_device_code` (headless device grant), and `connect_pat` (Personal Access Token). `connect` auto-routes to OAuth when an environment sets `auth_method: oauth`. All three OAuth entry points require an explicit `client_id` and `scope` — the core library bakes in no defaults (those are CLI policy; `bfabric-cli auth …` supplies its own), and `connect()` raises if an `auth_method: oauth` environment has no `client_id`. Token-acquisition failures (expired/revoked refresh token, unreachable token endpoint) raise `BfabricOAuthError` instead of leaking an `authlib`/`requests` traceback, and a failed PKCE login renders a distinct "Login failed" callback page showing the provider's error (e.g. a two-factor-enrollment requirement) rather than always claiming success. Adds the `authlib` / `joserfc` dependencies.
 - `WebappClient` — a dual-identity client pairing a token-derived `user` identity with a `service` (client-credentials) identity, for apps launched from B-Fabric.
@@ -60,16 +60,16 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `flatten_relations` (and `ResultContainer.to_polars(flatten=True)`) recursively flattens nested struct columns instead of only one level, so a nested `b.inner.p` field becomes the `b_inner_p` column. Also shipped as the `1.19.1` hotfix.
 - Internal: `HasOne` descriptors are now generic over their return type, so to-one accesses type-check to the related entity (no more `cast` / `# pyright: ignore`), with no runtime change; class→endpoint inference is centralized in `import_entity.entity_type_of` (the inverse of `import_entity`); removed dead required-relationship guards; ruff now treats `pydantic.BaseModel` as runtime-evaluated (dropping `# noqa: TC00x` workarounds).
 
-## \[1.19.0\] - 2026-06-10
+## [1.19.0] - 2026-06-10
 
 ### Added
 
 - `Job` entity wrapping the B-Fabric `job` endpoint.
 - `BfabricTokenExpiredError` and `BfabricTokenInvalidError` in `bfabric.errors`: specific subclasses of `BfabricTokenValidationFailedError` raised instead of the generic error.
 - `bfabric.operations` module: the canonical location for named write operations against B-Fabric.
-    - `operations.workunit.create_workunit` — creates a workunit with its resources, rolling back on failure; accepts caller-supplied `audit_attributes`.
-    - `operations.dataset` — `create_dataset`, `update_dataset`, `preview_dataset_update`, plus `polars_to_dataset_dict` and `identify_changes`.
-    - `operations.update_custom_attributes`.
+  - `operations.workunit.create_workunit` — creates a workunit with its resources, rolling back on failure; accepts caller-supplied `audit_attributes`.
+  - `operations.dataset` — `create_dataset`, `update_dataset`, `preview_dataset_update`, plus `polars_to_dataset_dict` and `identify_changes`.
+  - `operations.update_custom_attributes`.
 
 ### Deprecated
 
@@ -85,7 +85,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - `User.is_employee` returns `False` when `empdegree` is missing or `None`, instead of raising `ValueError`.
 
-## \[1.18.0\] - 2026-04-20
+## [1.18.0] - 2026-04-20
 
 ### Added
 
@@ -103,15 +103,15 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - `FindMixin.find_all` now correctly handles string IDs.
 
-## \[1.17.0\] - 2026-03-12
+## [1.17.0] - 2026-03-12
 
 ### Added
 
 - Improved token authentication
-    - `bfabric.experimental.webapp_integration_settings`
-    - `Bfabric.connect_token`, `Bfabric.connect_token_async`: this one respects the list of allowed bfabric instances
-    - `bfabric.rest.token_data.validate_token`
-    - `Bfabric.from_token_data`: creates a new Bfabric instance from token data.
+  - `bfabric.experimental.webapp_integration_settings`
+  - `Bfabric.connect_token`, `Bfabric.connect_token_async`: this one respects the list of allowed bfabric instances
+  - `bfabric.rest.token_data.validate_token`
+  - `Bfabric.from_token_data`: creates a new Bfabric instance from token data.
 - `ResultContainer.to_polars` now has a `flatten` parameter to flatten struct columns into individual columns.
 
 ### Deprecated
@@ -129,7 +129,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `References` correctly handles references with extra fields like `_position`.
 - `ResultContainer.to_polars` sets the schema length to `None` to fix bugs in some cases with more than 100 items.
 
-## \[1.16.2\] - 2026-03-02
+## [1.16.2] - 2026-03-02
 
 ### Fixed
 
@@ -139,13 +139,13 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - `BfabricAPIEngineType` is a `StrEnum` now, rather than `str, Enum` subclass.
 
-## \[1.16.1\] - 2025-12-15
+## [1.16.1] - 2025-12-15
 
 ### Fixed
 
 - `Dataset` correctly handles `None` values in items.
 
-## \[1.16.0\] - 2025-12-15
+## [1.16.0] - 2025-12-15
 
 ### Added
 
@@ -157,13 +157,13 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ### Changed
 
 - Type hints have been narrowed in the public interfaces of the following classes:
-    - `Bfabric`
-    - `ResultContainer`
-    - `References`
-    - `Entity`
-    - `EntityReader`
-    - `EngineSuds`
-    - `EngineZeep`
+  - `Bfabric`
+  - `ResultContainer`
+  - `References`
+  - `Entity`
+  - `EntityReader`
+  - `EngineSuds`
+  - `EngineZeep`
 - `Parameter.value` returns `""` for values not specified with `required` = `false`. This solves a few rare compatibility bugs and I do not think having the ability to distinguish between `None` and `""` makes much sense at this level.
 
 ### Removed
@@ -174,19 +174,19 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - `Executable.decoded`: misleading name
 
-## \[1.15.1\] - 2025-12-09
+## [1.15.1] - 2025-12-09
 
 ### Fixed
 
 - Allow `http://localhost` for EntityURIs.
 
-## \[1.15.0\] - 2025-12-09
+## [1.15.0] - 2025-12-09
 
 ### Added
 
 - `TokenData.web_service_user` which indicates whether the user has permission to use webservices API.
 
-## \[1.14.1\] - 2025-12-02
+## [1.14.1] - 2025-12-02
 
 ### Added
 
@@ -196,27 +196,27 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - A few imports within the package were accidentally broken in 1.14.0 which is resolved now. `basedpyright` has been added to identify issues like this earlier.
 
-## \[1.14.0\] - 2025-12-02
+## [1.14.0] - 2025-12-02
 
 - The minimal Python version has been updated to 3.11.
 
 - *bfabric.entities*
 
-    - The read-only API in `bfabric.entities` has been redesigned to support multiple B-Fabric instances cleanly.
-    - In particular, when handling configuration files it should now be obvious how to specify entities by their URI rather than having
-        to specify instance, classname, and id separately.
-    - The main new concept is the `EntityUri` which standardizes the way entities are specified by their URI.
-    - `EntityReader` is a new class which implements the resolution, currently for only one B-Fabric instance, but extensible to support
-        multiple B-Fabric instances in the future.
-    - We also remove the reliance on custom entity classes providing generic functionality to read entities and their references.
-        This is available through the `EntityReader` class which can be accessed through `Bfabric.reader`.
+  - The read-only API in `bfabric.entities` has been redesigned to support multiple B-Fabric instances cleanly.
+  - In particular, when handling configuration files it should now be obvious how to specify entities by their URI rather than having
+    to specify instance, classname, and id separately.
+  - The main new concept is the `EntityUri` which standardizes the way entities are specified by their URI.
+  - `EntityReader` is a new class which implements the resolution, currently for only one B-Fabric instance, but extensible to support
+    multiple B-Fabric instances in the future.
+  - We also remove the reliance on custom entity classes providing generic functionality to read entities and their references.
+    This is available through the `EntityReader` class which can be accessed through `Bfabric.reader`.
 
 - Versioning:
 
-    - The `bfabric` Python package versioning starting with 1.14.0 does not track the B-Fabric server version anymore.
-    - This will allow us to adapt to implement a more semantically meaningful versioning, starting with 1.14.0.
-    - Applications, like `bfabric-scripts` can instead track the particular version of bfabric against which they are tested/developed
-        either in their version (planned for `bfabric-scripts`) or through documentation.
+  - The `bfabric` Python package versioning starting with 1.14.0 does not track the B-Fabric server version anymore.
+  - This will allow us to adapt to implement a more semantically meaningful versioning, starting with 1.14.0.
+  - Applications, like `bfabric-scripts` can instead track the particular version of bfabric against which they are tested/developed
+    either in their version (planned for `bfabric-scripts`) or through documentation.
 
 ### Added
 
@@ -237,19 +237,19 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - `HasMany` retains response order, instead of redundant sorting by ID.
 - `bfabric.entities` allows loading entity references without custom definitions in Python.
 - Internal
-    - `Entity` has a new constructor parameter `bfabric_instance` which in the future will become mandatory.
-    - `BfabricClientConfig.base_url` always ends with exactly one `/` now.
-    - `bfabric.entities` do not define custom constructors anymore, simplifying future changes (and removing tiny inconsistencies).
-    - `TokenData` retrieval uses async httpx internally, but provides a sync interface for compatibility.
+  - `Entity` has a new constructor parameter `bfabric_instance` which in the future will become mandatory.
+  - `BfabricClientConfig.base_url` always ends with exactly one `/` now.
+  - `bfabric.entities` do not define custom constructors anymore, simplifying future changes (and removing tiny inconsistencies).
+  - `TokenData` retrieval uses async httpx internally, but provides a sync interface for compatibility.
 
 ### Removed
 
 - `bfabric.experimental.cache` is removed in favor of `bfabric.entities.cache`.
 - Future deprecations:
-    - `Entity.find`, `Entity.find_all`, `Entity.find_by` will be removed in favor of `EntityReader` methods.
-    - Passing entity class to `cache_context` will be removed in favor of their name (this is because not all entities have custom classes).
+  - `Entity.find`, `Entity.find_all`, `Entity.find_by` will be removed in favor of `EntityReader` methods.
+  - Passing entity class to `cache_context` will be removed in favor of their name (this is because not all entities have custom classes).
 
-## \[1.13.36\] - 2025-10-27
+## [1.13.36] - 2025-10-27
 
 ### Changed
 
@@ -262,25 +262,25 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - A test-only incompatibility with Polars was fixed.
 
-## \[1.13.35\] - 2025-09-22
+## [1.13.35] - 2025-09-22
 
 ### Changed
 
 - Dataset column type detection now supports case-insensitive entity matching (e.g., "resource" is detected as "Resource" type automatically).
 
-## \[1.13.34\] - 2025-09-19
+## [1.13.34] - 2025-09-19
 
 ### Added
 
 - `bfabric.experimental.cache` which implements re-entrant lookup caching for entities (when retrieved by ID).
 - Fields `filename`, `storage_relative_path`, `storage_absolute_path` have been added to `Resource`. This should be used
-    in the future, to ensure path handling is performed consistently
+  in the future, to ensure path handling is performed consistently
 
 ### Removed
 
 - `bfabric.experimental.entity_lookup_cache` has been removed in favor of the new (experimental) API.
 
-## \[1.13.33\] - 2025-08-26
+## [1.13.33] - 2025-08-26
 
 ### Added
 
@@ -291,7 +291,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - Legacy wrapper creator also writes the inputdataset name.
 
-## \[1.13.32\] - 2025-08-26
+## [1.13.32] - 2025-08-26
 
 ### Added
 
@@ -303,13 +303,13 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 - There was an issue in `import_entity.py` which made loading entities with additional uppercase characters in the type fail.
 - Fix compatibility in legacy wrapper creator for dataset-flow workunits.
 
-## \[1.13.31\] - 2025-09-20
+## [1.13.31] - 2025-09-20
 
 ### Changed
 
 - The `Bfabric.connect_webapp` will use the `caller` field from the token data to set the `base_url` of the client.
-    - Existing code should not break, but will emit a deprecation warning as we plan to remove the old parameters.
-    - Theoretically, it changes the semantics, but in practice it should yield the same result for all known use cases.
+  - Existing code should not break, but will emit a deprecation warning as we plan to remove the old parameters.
+  - Theoretically, it changes the semantics, but in practice it should yield the same result for all known use cases.
 
 ### Added
 
@@ -320,19 +320,19 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - Legacy wrapper creator creates `""` rather than `None` for empty parameter values.
 
-## \[1.13.30\] - 2025-08-19
+## [1.13.30] - 2025-08-19
 
 ### Fixed
 
 - Fix legacy wrapper creator for orders without projects.
 
-## \[1.13.29\] - 2025-07-04
+## [1.13.29] - 2025-07-04
 
 ### Changed
 
 - `bfabric.rest.token_data.get_token_data` now only requires the base_url instead of the whole config.
 
-## \[1.13.28\] - 2025-06-27
+## [1.13.28] - 2025-06-27
 
 ### Breaking
 
@@ -341,7 +341,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ### Added
 
 - It is now possible to configure `~/.bfabricpy.yml` without a default environment. In that case it will always be
-    necessary to specify the requested config environment to be used.
+  necessary to specify the requested config environment to be used.
 - `bfabric.entities.Executable` has `parameters` relationship now
 
 ### Removed
@@ -351,9 +351,9 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 ### Changed
 
 - Columns of tables named after B-Fabric entities, containing only integers, will be set as the specified type
-    when saving to B-Fabric (in `experimental.upload_dataset`).
+  when saving to B-Fabric (in `experimental.upload_dataset`).
 
-## \[1.13.27\] - 2025-05-21
+## [1.13.27] - 2025-05-21
 
 ### Added
 
@@ -374,7 +374,7 @@ Minor breaking changes are still possible in `1.X.Y` but we try to announce them
 
 - `Workunit.parameter_values` will be removed in favor of `Workunit.application_parameters` and `Workunit.submitter_parameters` in a future version.
 
-## \[1.13.26\] - 2025-04-26
+## [1.13.26] - 2025-04-26
 
 This release introduces an environment variable `BFABRICPY_CONFIG_OVERRIDE` to configure the `Bfabric` client completely,
 along with a new method for creating an instance of the `Bfabric` client, `Bfabric.connect()`.
@@ -399,18 +399,18 @@ to prevent configuration mix-ups.
 
 - `Bfabric.from_config` is now deprecated in favor of `Bfabric.connect()`
 
-## \[1.13.25\] - 2025-04-22
+## [1.13.25] - 2025-04-22
 
 ### Breaking
 
 - `Bfabric.from_token` returns the `TokenData` in addition to the client instance. While this is breaking, I'm not aware
-    of any existing users of this API and I noticed that this information is going to be needed in this context often.
+  of any existing users of this API and I noticed that this information is going to be needed in this context often.
 
 ### Added
 
 - `bfabric.experimental.upload_dataset.warn_on_trailing_spaces` function used by `bfabric-scripts` to validate
 
-## \[1.13.24\] - 2025-04-08
+## [1.13.24] - 2025-04-08
 
 ### Removed
 
@@ -419,10 +419,10 @@ to prevent configuration mix-ups.
 ### Changed
 
 - `Bfabric` client now does not take `engine` argument anymore, but rather this information comes from `ClientConfig`.
-    For compatibility reasons, the `engine` argument is still accepted in `Bfabric.from_config` and
-    `Bfabric.from_token`.
+  For compatibility reasons, the `engine` argument is still accepted in `Bfabric.from_config` and
+  `Bfabric.from_token`.
 
-## \[1.13.23\] - 2025-03-25
+## [1.13.23] - 2025-03-25
 
 ### Fixed
 
@@ -440,7 +440,7 @@ to prevent configuration mix-ups.
 - Generic functionality in `bfabric.utils.path_safe_name` to validate names for use in paths.
 - `bfabric.entities.Dataset.{write_parquet, get_parquet}` methods for writing parquet
 
-## \[1.13.22\] - 2025-02-19
+## [1.13.22] - 2025-02-19
 
 ### Fixed
 
@@ -450,7 +450,7 @@ to prevent configuration mix-ups.
 
 - `Dataset.types` was renamed to `Dataset.column_types`, since there is only 1 usage and it is recent, this is not considered breaking.
 
-## \[1.13.21\] - 2025-02-19
+## [1.13.21] - 2025-02-19
 
 ### Added
 
@@ -462,7 +462,7 @@ to prevent configuration mix-ups.
 
 - Internally, the user password is now in a `pydantic.SecretStr` until we construct the API call. This should prevent some logging related accidents.
 
-## \[1.13.20\] - 2025-02-10
+## [1.13.20] - 2025-02-10
 
 ### Breaking
 
@@ -473,13 +473,13 @@ to prevent configuration mix-ups.
 - move `use_client` to `bfabric.utils.cli_integration`: this will allow reuse between bfabric-scripts and bfabric-app-runner
 - move functionality from `bfabric.cli_formatting` to `bfabric.utils.cli_integration`
 
-## \[1.13.19\] - 2025-02-06
+## [1.13.19] - 2025-02-06
 
 ### Fixed
 
 - Config: Log messages of app runner are shown by default again.
 
-## \[1.13.18\] - 2025-01-28
+## [1.13.18] - 2025-01-28
 
 ### Changed
 
@@ -489,7 +489,7 @@ to prevent configuration mix-ups.
 
 - Some scripts were not Python 3.9 compatible, which is restored now. However, we can consider increasing the Python requirement soon.
 
-## \[1.13.17\] - 2025-01-23
+## [1.13.17] - 2025-01-23
 
 ### Added
 
@@ -501,7 +501,7 @@ to prevent configuration mix-ups.
 - `Workunit.parameters` and `Workunit.resources` are optional
 - `bfabric-cli` had unmet dependencies, that were not caught by the tests either
 
-## \[1.13.16\] - 2025-01-22
+## [1.13.16] - 2025-01-22
 
 ### Added
 
@@ -514,7 +514,7 @@ to prevent configuration mix-ups.
 
 - `Order.project` is optional
 
-## \[1.13.15\] - 2025-01-15
+## [1.13.15] - 2025-01-15
 
 ### Added
 
@@ -526,7 +526,7 @@ to prevent configuration mix-ups.
 
 - Fix bug in `bfabric_save_fasta.py`.
 
-## \[1.13.14\] - 2025-01-08
+## [1.13.14] - 2025-01-08
 
 ### Changed
 
@@ -536,7 +536,7 @@ to prevent configuration mix-ups.
 
 - Some commands in bfabric-cli are broken because `__future__.annotations` is imported and this breaks cyclopts.
 
-## \[1.13.13\] - 2024-12-18
+## [1.13.13] - 2024-12-18
 
 ### Changed
 
@@ -554,7 +554,7 @@ to prevent configuration mix-ups.
 
 - A bug in bfabric_save_workflowstep.py that crashed the script.
 
-## \[1.13.12\] - 2024-12-17
+## [1.13.12] - 2024-12-17
 
 ### Changed
 
@@ -563,9 +563,9 @@ to prevent configuration mix-ups.
 ### Fixed
 
 - The script `bfabric_setResourceStatus_available.py` and other uses of `report_resource`, correctly search files which
-    have a relative path starting with `/` as in the case of the legacy wrapper creator.
+  have a relative path starting with `/` as in the case of the legacy wrapper creator.
 
-## \[1.13.11\] - 2024-12-13
+## [1.13.11] - 2024-12-13
 
 ### Fixed
 
@@ -575,22 +575,22 @@ to prevent configuration mix-ups.
 
 - `bfabric_setResourceStatus_available.py` calls the `report_resource` function, in general this functionality has been refactored.
 
-## \[1.13.10\] - 2024-12-13
+## [1.13.10] - 2024-12-13
 
 ### Fixed
 
 - If `bfabricpy.yml` contains a root-level key which is not a dictionary, a correct error message is shown instead of raising an exception.
 - A bug introduced while refactoring in `slurm.py` which passed `Path` objects to `subprocess` instead of strings.
 - Submitter
-    - does not use unset `JOB_ID` environment variable anymore.
-    - does not set unused `STAMP` environment variable anymore.
+  - does not use unset `JOB_ID` environment variable anymore.
+  - does not set unused `STAMP` environment variable anymore.
 - Fix `bfabric_save_workflowstep.py` bugs from refactoring.
 
 ### Added
 
 - Experimental bfabric-cli interface. Please do not use it in production yet as it will need a lot of refinement.
 
-## \[1.13.9\] - 2024-12-10
+## [1.13.9] - 2024-12-10
 
 From this release onwards, the experimental app runner is not part of the main bfabric package and
 instead a separate Python package with its individual changelog.
@@ -616,7 +616,7 @@ instead a separate Python package with its individual changelog.
 - `bfabric_legacy.py` has been removed.
 - `math_helper.py` has been removed.
 
-## \[1.13.8\] - 2024-10-03
+## [1.13.8] - 2024-10-03
 
 This release contains mainly internal changes and ongoing development on the experimental app interface functionality.
 
@@ -637,10 +637,10 @@ This release contains mainly internal changes and ongoing development on the exp
 - `bfabric.scripts` has been moved into a namespace package `bfabric_scripts` so we can later split it off.
 - (internal) migrate to src layout
 - (experimental) the former `process` step of the app runner has been split into a `process` and `collect` step where,
-    the collect step is responsible for generating the `output.yml` file that will then be used to register the results.
+  the collect step is responsible for generating the `output.yml` file that will then be used to register the results.
 - (experimental) app runner apps by default reuse the default resource
 
-## \[1.13.7\] - 2024-09-17
+## [1.13.7] - 2024-09-17
 
 ### Fixed
 
@@ -649,12 +649,12 @@ This release contains mainly internal changes and ongoing development on the exp
 ### Added
 
 - Script logging configuration
-    - If `BFABRICPY_DEBUG` environment variable is set, log messages in scripts will be set to debug mode.
-    - Log messages from `__main__` will also be shown by default.
+  - If `BFABRICPY_DEBUG` environment variable is set, log messages in scripts will be set to debug mode.
+  - Log messages from `__main__` will also be shown by default.
 - `bfabric.entities.MultiplexKit` to extract multiplex kit information.
 - `bfabric.entities.Workunit.store_output_folder` implements the old rule, but more deterministically and reusable.
 - (Experimental) `bfabric.experimental.app_interface` core functionality is implemented
-    - This can be used as a building block to standardize the input preparation for applications.
+  - This can be used as a building block to standardize the input preparation for applications.
 
 ### Changed
 
@@ -664,7 +664,7 @@ This release contains mainly internal changes and ongoing development on the exp
 
 - `bfabric.entities.Resource` association `application` has been removed as it does not exist
 
-## \[1.13.6\] - 2024-08-29
+## [1.13.6] - 2024-08-29
 
 ### Added
 
@@ -680,25 +680,25 @@ This release contains mainly internal changes and ongoing development on the exp
 
 - `bfabric.endpoints` list is deleted, since it was out of date and generally not so useful.
 
-## \[1.13.5\] - 2024-08-13
+## [1.13.5] - 2024-08-13
 
 ### Added
 
 - The `Bfabric` instance is now pickleable.
 - Entities mapping:
-    - Add `Entity.id` and `Entity.web_url` properties.
-    - Add `Entity.__getitem__` and `Entity.get` to access fields from the data dictionary directly.
-    - Add `Entity.find_by` to find entities by a query.
-    - More types and relationships
-    - Relationships defer imports to descriptor call, i.e. circular relationships are possible now.
-    - `HasOne` and `HasMany` allow defining `optional=True` to indicate fields which can be missing under some circumstances.
+  - Add `Entity.id` and `Entity.web_url` properties.
+  - Add `Entity.__getitem__` and `Entity.get` to access fields from the data dictionary directly.
+  - Add `Entity.find_by` to find entities by a query.
+  - More types and relationships
+  - Relationships defer imports to descriptor call, i.e. circular relationships are possible now.
+  - `HasOne` and `HasMany` allow defining `optional=True` to indicate fields which can be missing under some circumstances.
 - Add `nodelist` column and application name to `bfabric_list_not_available_proteomics_workunits.py` output.
 
 ### Changed
 
 - `Entity.find_all` supports more than 100 IDs now by using the experimental MultiQuery API.
 
-## \[1.13.4\] - 2024-08-05
+## [1.13.4] - 2024-08-05
 
 ### Added
 
@@ -712,35 +712,35 @@ This release contains mainly internal changes and ongoing development on the exp
 - Most messages are now logged to debug level.
 - The old verbose version information is now always logged, to INFO level, since it could entail useful information for error reporting.
 
-## \[1.13.3\] - 2024-07-18
+## [1.13.3] - 2024-07-18
 
 ### Added
 
 - Flask
-    - New endpoint `GET /config/remote_base_url` for testing
+  - New endpoint `GET /config/remote_base_url` for testing
 
 ### Changed
 
 - Flask
-    - Simplify logging by using loguru only.
-    - Simplified setup logic since the production use case should use a WSGI server.
+  - Simplify logging by using loguru only.
+  - Simplified setup logic since the production use case should use a WSGI server.
 
 ### Fixed
 
 - `bfabric_save_csv2dataset.py` had an undeclared dependency on numpy and a few bugs which was improved.
 
-## \[1.13.2\] - 2024-07-11
+## [1.13.2] - 2024-07-11
 
 ### Added
 
 - Add `bfabric.entities.Dataset` to easily read datasets.
 - Pydantic-based configuration parsing
-    - The config format did not change.
-    - The code is easier to maintain now.
-    - Additionally, there is a lot more validation of the configuration file now, that should catch errors early.
+  - The config format did not change.
+  - The code is easier to maintain now.
+  - Additionally, there is a lot more validation of the configuration file now, that should catch errors early.
 - Make host and port configurable in `bfabric_flask.py` (currently only dev mode).
 
-## \[1.13.1\] - 2024-07-02
+## [1.13.1] - 2024-07-02
 
 ### Changed
 
@@ -756,16 +756,16 @@ This release contains mainly internal changes and ongoing development on the exp
 
 - Pandas is no longer a dependency, and has been replaced by polars.
 
-## \[1.13.0\] - 2024-05-24
+## [1.13.0] - 2024-05-24
 
 This is a major release refactoring bfabricPy's API.
 
 ### Changed
 
 - The `Bfabric` class operations now return `ResultContainer` objects.
-    - These provide a list-like interface to access individual items or iterate over them.
-    - Individual items are a dictionary, potentially nested, and not specific to suds/zeep anymore.
-    - Convenience conversions, e.g. to a polars DataFrame, can be provided there.
+  - These provide a list-like interface to access individual items or iterate over them.
+  - Individual items are a dictionary, potentially nested, and not specific to suds/zeep anymore.
+  - Convenience conversions, e.g. to a polars DataFrame, can be provided there.
 - Configuration is now defined in `~/.bfabricpy.yml` and supports multiple configurations, which can be selected by the `BFABRICPY_CONFIG_ENV` environment variable. Please consult the README for an example configuration.
 - Use `pyproject.toml` for package configuration.
 - Scripts have been refactored on a case-by-case basis.

--- a/bfabric/docs/design/index.md
+++ b/bfabric/docs/design/index.md
@@ -13,8 +13,8 @@ oauth_usage_and_troubleshooting
 
 ## Pages
 
-| Topic | Scope |
-| --- | --- |
-| **[`bfabric.operations` Module](operations_module.md)** | Conventions and worked examples for named write capabilities (`create_workunit`, `create_dataset`, …), including the failure-cleanup pattern and the audit-vs-authorization split. |
-| **[OAuth Integration](oauth_integration.md)** | The `bfabric.oauth` module and OAuth 2.0 flows (PKCE, device code, client credentials, URL token, PAT), the `Bfabric.connect_*` factory methods, `bfabric-cli auth` commands, and the config/scope model. |
+| Topic                                                                   | Scope                                                                                                                                                                                                                      |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[`bfabric.operations` Module](operations_module.md)**                 | Conventions and worked examples for named write capabilities (`create_workunit`, `create_dataset`, …), including the failure-cleanup pattern and the audit-vs-authorization split.                                         |
+| **[OAuth Integration](oauth_integration.md)**                           | The `bfabric.oauth` module and OAuth 2.0 flows (PKCE, device code, client credentials, URL token, PAT), the `Bfabric.connect_*` factory methods, `bfabric-cli auth` commands, and the config/scope model.                  |
 | **[OAuth Usage & Troubleshooting](oauth_usage_and_troubleshooting.md)** | Task-oriented: obtaining a working token, access_token vs id_token, the `containers` claim for file/download access, `.well-known` discovery, and PKCE gotchas (loopback redirect, public-only clients, remote notebooks). |

--- a/bfabric/docs/design/oauth_integration.md
+++ b/bfabric/docs/design/oauth_integration.md
@@ -18,15 +18,15 @@ The package root is the entire public surface: every submodule is underscore-pre
 
 Separately, those `connect_*` imports are *function-local*: the OAuth code pulls `authlib` and `joserfc`, and `import bfabric` must stay free of both. Note that targeting a submodule does not by itself avoid this — importing `bfabric.oauth.<anything>` executes `__init__` first — so laziness, not module choice, is what keeps the base import clean.
 
-| File | Purpose |
-|------|---------|
-| `_credential_provider.py` | `OAuthCredentialProvider` — thread-safe token management with automatic refresh and disk caching. Supports both `client_credentials` and `refresh_token` grant types. |
-| `_pkce.py` | `pkce_login()` — browser-based PKCE flow. Starts a local HTTP server, opens the browser, exchanges the authorization code for tokens. |
-| `_device_code.py` | `device_code_login()` — RFC 8628 device authorization flow for headless environments. |
-| `_registration.py` | `register_client()` — RFC 7591 dynamic client registration via HTTP POST. |
-| `_token_cache.py` | `TokenCache` — JSON file cache at `~/.bfabric/tokens/{hash}.json` with 0o600 permissions. `compute_token_cache_path()` derives a unique path from `(base_url, client_id, env_name)`. |
-| `_url_token.py` | `UrlTokenContext` + `parse_url_token()` — extracts entity context (entity_id, application_id, etc.) from B-Fabric URL token JWTs. |
-| `_webapp_client.py` | `WebappClient` — dual-identity client bundling a `user` (from URL token) and `service` (from client credentials) `Bfabric` instance. |
+| File                      | Purpose                                                                                                                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `_credential_provider.py` | `OAuthCredentialProvider` — thread-safe token management with automatic refresh and disk caching. Supports both `client_credentials` and `refresh_token` grant types.                |
+| `_pkce.py`                | `pkce_login()` — browser-based PKCE flow. Starts a local HTTP server, opens the browser, exchanges the authorization code for tokens.                                                |
+| `_device_code.py`         | `device_code_login()` — RFC 8628 device authorization flow for headless environments.                                                                                                |
+| `_registration.py`        | `register_client()` — RFC 7591 dynamic client registration via HTTP POST.                                                                                                            |
+| `_token_cache.py`         | `TokenCache` — JSON file cache at `~/.bfabric/tokens/{hash}.json` with 0o600 permissions. `compute_token_cache_path()` derives a unique path from `(base_url, client_id, env_name)`. |
+| `_url_token.py`           | `UrlTokenContext` + `parse_url_token()` — extracts entity context (entity_id, application_id, etc.) from B-Fabric URL token JWTs.                                                    |
+| `_webapp_client.py`       | `WebappClient` — dual-identity client bundling a `user` (from URL token) and `service` (from client credentials) `Bfabric` instance.                                                 |
 
 The core `oauth` API requires explicit `client_id` and `scope` arguments on all OAuth entry points. The library does not bake in a default client ID or scope. Tools like the CLI specify these values explicitly.
 
@@ -34,13 +34,13 @@ The core `oauth` API requires explicit `client_id` and `scope` arguments on all 
 
 ## New: Factory methods on `Bfabric`
 
-| Method | Grant type | Use case |
-|--------|-----------|----------|
-| `Bfabric.connect()` | auto-detect | Unchanged API. Now auto-detects `auth_method: "oauth"` in config and loads cached tokens. |
-| `Bfabric.connect_oauth(client_id, client_secret, base_url)` | client_credentials | Service accounts / background jobs. |
-| `Bfabric.connect_pkce(base_url, client_id)` | authorization_code + PKCE | Interactive browser login (programmatic). |
-| `Bfabric.connect_device_code(base_url, client_id)` | device_code | Headless interactive login (programmatic). |
-| `WebappClient.create(base_url, launch_token, ..., client_id, client_secret)` | URL token + client_credentials | Dual-identity webapp client for apps launched from B-Fabric. |
+| Method                                                                       | Grant type                     | Use case                                                                                  |
+| ---------------------------------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `Bfabric.connect()`                                                          | auto-detect                    | Unchanged API. Now auto-detects `auth_method: "oauth"` in config and loads cached tokens. |
+| `Bfabric.connect_oauth(client_id, client_secret, base_url)`                  | client_credentials             | Service accounts / background jobs.                                                       |
+| `Bfabric.connect_pkce(base_url, client_id)`                                  | authorization_code + PKCE      | Interactive browser login (programmatic).                                                 |
+| `Bfabric.connect_device_code(base_url, client_id)`                           | device_code                    | Headless interactive login (programmatic).                                                |
+| `WebappClient.create(base_url, launch_token, ..., client_id, client_secret)` | URL token + client_credentials | Dual-identity webapp client for apps launched from B-Fabric.                              |
 
 ---
 
@@ -48,18 +48,18 @@ The core `oauth` API requires explicit `client_id` and `scope` arguments on all 
 
 All commands registered under `bfabric-cli auth` via cyclopts.
 
-| Command | File | Description |
-|---------|------|-------------|
-| `auth login [base_url]` | `cli/login/oauth_login.py` | Browser-based OAuth login. Caches tokens + writes config. Also registered top-level as `bfabric-cli login`. |
-| `auth device-code [base_url]` | `cli/login/oauth_login.py` | Headless OAuth login. |
-| `auth pat <base_url>` | `cli/login/pat.py` | Personal Access Token login. |
-| `auth register <client_name> <redirect_uri>` | `cli/login/register.py` | RFC 7591 dynamic client registration. Outputs JSON. |
-| `auth register-webapp <client_name> <redirect_uri>` | `cli/login/register_webapp.py` | Registration preset for webapps (OIDC-inclusive scope). |
-| `auth status` | `cli/login/manage.py` | Show auth status for an environment. |
-| `auth list` | `cli/login/manage.py` | List environments grouped by instance, with scope / expiry / why-active. |
-| `auth activate [env]` | `cli/login/manage.py` | Make an environment the config default. |
-| `auth logout [env]` | `cli/login/manage.py` | Remove stored credentials for this machine, keeping the environment. `--all` for every environment. |
-| `auth remove [env]` | `cli/login/manage.py` | Delete an environment: config entry plus cached tokens. |
+| Command                                             | File                           | Description                                                                                                 |
+| --------------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `auth login [base_url]`                             | `cli/login/oauth_login.py`     | Browser-based OAuth login. Caches tokens + writes config. Also registered top-level as `bfabric-cli login`. |
+| `auth device-code [base_url]`                       | `cli/login/oauth_login.py`     | Headless OAuth login.                                                                                       |
+| `auth pat <base_url>`                               | `cli/login/pat.py`             | Personal Access Token login.                                                                                |
+| `auth register <client_name> <redirect_uri>`        | `cli/login/register.py`        | RFC 7591 dynamic client registration. Outputs JSON.                                                         |
+| `auth register-webapp <client_name> <redirect_uri>` | `cli/login/register_webapp.py` | Registration preset for webapps (OIDC-inclusive scope).                                                     |
+| `auth status`                                       | `cli/login/manage.py`          | Show auth status for an environment.                                                                        |
+| `auth list`                                         | `cli/login/manage.py`          | List environments grouped by instance, with scope / expiry / why-active.                                    |
+| `auth activate [env]`                               | `cli/login/manage.py`          | Make an environment the config default.                                                                     |
+| `auth logout [env]`                                 | `cli/login/manage.py`          | Remove stored credentials for this machine, keeping the environment. `--all` for every environment.         |
+| `auth remove [env]`                                 | `cli/login/manage.py`          | Delete an environment: config entry plus cached tokens.                                                     |
 
 See [the CLI authentication guide](../user_guides/bfabric-cli/authentication.md) for the user-facing
 view; this section covers only what is not visible from the outside.
@@ -168,6 +168,7 @@ Both models gained `auth_method` (`"password"` | `"oauth"` | `"pat"`) and `clien
 ## Scope enforcement (server-side)
 
 B-Fabric now enforces OAuth scopes at the API level:
+
 - `api:read` required for SOAP read operations
 - `api:write` required for SOAP write operations
 - Additional scopes (e.g. `tus`, `download`) can be requested and are enforced by their respective endpoints

--- a/bfabric/docs/design/oauth_usage_and_troubleshooting.md
+++ b/bfabric/docs/design/oauth_usage_and_troubleshooting.md
@@ -23,12 +23,12 @@ jwt = client.auth.password.get_secret_value()  # the OAuth access token, always 
 
 Both are JWTs in the OIDC token response, but they are for different audiences:
 
-| | access_token | id_token |
-|---|---|---|
-| `aud` | `bfabric-api` (the resource server) | `<client_id>`, e.g. `bfabric-cli` |
-| purpose | authorize API / resource-server calls | tell *your app* who the user is |
-| send to a resource server (API, file/download)? | **yes** | **no — it will be rejected** |
-| tell-tale claims | `scope`, `jti`, `containers` | `at_hash`, `name`, `email`, `given_name` |
+|                                                 | access_token                          | id_token                                 |
+| ----------------------------------------------- | ------------------------------------- | ---------------------------------------- |
+| `aud`                                           | `bfabric-api` (the resource server)   | `<client_id>`, e.g. `bfabric-cli`        |
+| purpose                                         | authorize API / resource-server calls | tell *your app* who the user is          |
+| send to a resource server (API, file/download)? | **yes**                               | **no — it will be rejected**             |
+| tell-tale claims                                | `scope`, `jti`, `containers`          | `at_hash`, `name`, `email`, `given_name` |
 
 **`client.auth.password` gives you the access token — that is the one to send to servers.**
 The id_token is *never* the right thing to hand to the file/download server; its `aud` is the
@@ -60,11 +60,11 @@ Use this to see which scopes an instance offers before requesting them. `token_e
 
 ## 3. Choosing a connect method
 
-| Method | Grant | Identity | When |
-|--------|-------|----------|------|
-| `Bfabric.connect_oauth(client_id, client_secret, base_url, scope=…)` | client_credentials | **service** (no user `sub`) | background jobs, servers |
-| `Bfabric.connect_pkce(base_url, client_id=…, scope=…, port=…)` | authorization_code + PKCE | **user** | interactive, local machine |
-| `Bfabric.connect_device_code(base_url, client_id=…, scope=…)` | device_code | **user** | headless / remote / notebooks |
+| Method                                                               | Grant                     | Identity                    | When                          |
+| -------------------------------------------------------------------- | ------------------------- | --------------------------- | ----------------------------- |
+| `Bfabric.connect_oauth(client_id, client_secret, base_url, scope=…)` | client_credentials        | **service** (no user `sub`) | background jobs, servers      |
+| `Bfabric.connect_pkce(base_url, client_id=…, scope=…, port=…)`       | authorization_code + PKCE | **user**                    | interactive, local machine    |
+| `Bfabric.connect_device_code(base_url, client_id=…, scope=…)`        | device_code               | **user**                    | headless / remote / notebooks |
 
 Key identity difference: **client_credentials tokens carry no user `sub` and no user-scoped claims
 like `containers`.** If a resource server authorizes by *your* container membership, a service
@@ -151,18 +151,21 @@ is the cause.
 4. Catches `?code=…` on the callback, then POSTs to the token endpoint to exchange it.
 
 ### It is blocking, but can feel instant
+
 The call blocks until the redirect arrives. If your browser already has an active B-Fabric session
 (and the client has consent skipped), `/authorize` redirects back immediately with no login/consent
 UI, so the whole thing completes in a fraction of a second and *looks* non-blocking. Logged out,
 you'd see the cell hang on the login page.
 
 ### Redirect URI must match exactly — `127.0.0.1`, not `localhost`, and the right port
+
 `pkce_login` builds its redirect as `http://127.0.0.1:{port}/callback`. If you register a fixed
 redirect URI on the OAuth client, it must be **`http://127.0.0.1:8000/callback`** (127.0.0.1, not
 `localhost`) and you must call `connect_pkce(..., port=8000)` so the port matches. With `port=0` the
 port is random and cannot match a fixed registration.
 
 ### Loopback redirect fails on remote/hosted notebooks
+
 The callback server listens on the *notebook host's* `127.0.0.1`. If the browser runs on a different
 machine (a remote/hosted marimo, Jupyter on a server, SSH), the redirect to `127.0.0.1` hits the
 *user's* machine where nothing is listening, so the code is never caught and PKCE times out.
@@ -182,6 +185,7 @@ make the flow work remotely. See the
 hatches.
 
 ### `connect_pkce` only supports **public** clients (tentative on the 401 cause)
+
 `_exchange_code` sends only `client_id` + PKCE `code_verifier` at the token endpoint — **no
 `client_secret`**. So it works with *public* clients (like `bfabric-cli`) but not with a
 **confidential** client that has a secret and requires client authentication.
@@ -195,6 +199,7 @@ hatches.
 > token-endpoint response instead of calling `raise_for_status()`.
 
 ### Reactive-notebook caveat
+
 `connect_pkce` runs the full browser round-trip on **every** call — it does not load-and-skip from a
 cache (the `token_cache_path` cache is only used for *refresh after* login). In a reactive notebook
 (marimo), re-running that cell re-triggers auth. Silent/fast when the session is warm, but it is a

--- a/bfabric/docs/getting_started/installation.md
+++ b/bfabric/docs/getting_started/installation.md
@@ -7,7 +7,7 @@ bfabricPy consists of two main packages:
 
 Choose your installation method based on how you plan to use bfabricPy.
 
-______________________________________________________________________
+---
 
 ## Installing the Core Library (`bfabric`)
 
@@ -49,7 +49,7 @@ pip install bfabric
 uv pip install bfabric
 ```
 
-______________________________________________________________________
+---
 
 ## Installing Command-Line Tools (`bfabric-scripts`)
 
@@ -76,28 +76,28 @@ uv tool upgrade bfabric-scripts
 
 This makes `bfabric-cli` available system-wide and simplifies upgrades.
 
-______________________________________________________________________
+---
 
 ## Which Should You Install?
 
 bfabricPy provides two components that are installed separately:
 
-| Component | Type | Install Method | Best For |
-|-----------|------|----------------|-----------|
-| **bfabric** | Python package | `pip install bfabric` or `uv pip install bfabric` | Python projects, scripts, applications |
-| **bfabric-scripts** | CLI tool | `uv tool install bfabric-scripts` | Command-line usage, quick tasks, shell scripts |
+| Component           | Type           | Install Method                                    | Best For                                       |
+| ------------------- | -------------- | ------------------------------------------------- | ---------------------------------------------- |
+| **bfabric**         | Python package | `pip install bfabric` or `uv pip install bfabric` | Python projects, scripts, applications         |
+| **bfabric-scripts** | CLI tool       | `uv tool install bfabric-scripts`                 | Command-line usage, quick tasks, shell scripts |
 
 **Install both if:** You plan to use both Python programming and command-line tools.
 
 **Note:** `bfabric` is a Python package dependency. `bfabric-scripts` is a CLI tool installed separately using `uv tool`.
 
-______________________________________________________________________
+---
 
 ## Development Installation
 
 For contributing to bfabricPy, see the [Contributing Guide](https://github.com/fgcz/bfabricPy/blob/main/CONTRIBUTING.md).
 
-______________________________________________________________________
+---
 
 ## Verifying Installation
 
@@ -118,7 +118,7 @@ bfabric-cli --help
 
 This should display the CLI version and available commands.
 
-______________________________________________________________________
+---
 
 ## About bfabric-cli
 
@@ -132,7 +132,7 @@ ______________________________________________________________________
 
 For comprehensive `bfabric-cli` documentation, see the [bfabric-cli User Guide](../user_guides/bfabric-cli/index).
 
-______________________________________________________________________
+---
 
 ## System Requirements
 
@@ -141,7 +141,7 @@ ______________________________________________________________________
 
 The `bfabric` package and `bfabric-scripts` share the same Python version requirements.
 
-______________________________________________________________________
+---
 
 ## Next Steps
 
@@ -152,7 +152,7 @@ After installing the packages:
    - For Python usage: [Quick Start Tutorial](quick_start)
    - For CLI usage: [bfabric-cli User Guide](../user_guides/bfabric-cli/index)
 
-______________________________________________________________________
+---
 
 ## Related Documentation
 

--- a/bfabric/docs/getting_started/quick_start.md
+++ b/bfabric/docs/getting_started/quick_start.md
@@ -9,7 +9,7 @@ Before starting, make sure you have:
 1. **Installed bfabricPy**: Follow [Installation Guide](installation.md)
 2. **Logged in**: run `bfabric-cli login`, or see the [Configuration Guide](configuration.md) for the other options
 
-______________________________________________________________________
+---
 
 ## Your First Script
 
@@ -50,7 +50,7 @@ Found 5 recent workunit(s):
   - ID: 321798, Status: FINISHED
 ```
 
-______________________________________________________________________
+---
 
 ## What Just Happened?
 
@@ -83,7 +83,7 @@ Iterate over results like a list.
 
 **Note:** By default, queries raise an error automatically if they fail. See [Error Handling](../user_guides/error_handling.md) to learn about error handling options.
 
-______________________________________________________________________
+---
 
 ## Explore the API
 
@@ -97,19 +97,19 @@ bfabric-cli api inspect dataset
 
 See [API Inspection Guide](../user_guides/bfabric-cli/api_inspection) for complete documentation on using the inspect command.
 
-______________________________________________________________________
+---
 
 ## What's Next?
 
 Now that you've seen the basics, explore further:
 
-| Want to... | Read this guide |
-| ------------------------------------- | ---------------------------------------------------------------------- |
-| Understand client authentication | [Connecting](../user_guides/connecting/index.md) |
-| Query and retrieve data efficiently | [Reading Data](../user_guides/reading_data/index.md) |
-| Create, update, delete entities | [Writing Data](../user_guides/writing_data/index) |
+| Want to...                            | Read this guide                                                     |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| Understand client authentication      | [Connecting](../user_guides/connecting/index.md)                    |
+| Query and retrieve data efficiently   | [Reading Data](../user_guides/reading_data/index.md)                |
+| Create, update, delete entities       | [Writing Data](../user_guides/writing_data/index)                   |
 | Use typed entities with relationships | [Working with Entities](../user_guides/working_with_entities/index) |
-| Explore API endpoints | [API Inspection Guide](../user_guides/bfabric-cli/api_inspection) |
+| Explore API endpoints                 | [API Inspection Guide](../user_guides/bfabric-cli/api_inspection)   |
 
 ## See Also
 

--- a/bfabric/docs/getting_started/troubleshooting.md
+++ b/bfabric/docs/getting_started/troubleshooting.md
@@ -171,13 +171,13 @@ Still stuck?
 
 ## Common Mistakes
 
-| Mistake | Symptom | Fix |
-|----------|-----------|-----|
-| Using login password instead of web service password | "Invalid login or password" | Use web service password from B-Fabric profile |
-| Config file in wrong location | "Configuration file not found" | Ensure `~/.bfabricpy.yml` (not `.bfabric.yml`) |
-| Wrong environment variable | Querying wrong instance | Check `BFABRICPY_CONFIG_ENV` value |
-| Missing default_config | "No default_config found" | Add `default_config` field under `GENERAL` section |
-| Typos in filter names | No results or errors | Use `bfabric-cli api inspect` to check valid parameter names |
+| Mistake                                              | Symptom                        | Fix                                                          |
+| ---------------------------------------------------- | ------------------------------ | ------------------------------------------------------------ |
+| Using login password instead of web service password | "Invalid login or password"    | Use web service password from B-Fabric profile               |
+| Config file in wrong location                        | "Configuration file not found" | Ensure `~/.bfabricpy.yml` (not `.bfabric.yml`)               |
+| Wrong environment variable                           | Querying wrong instance        | Check `BFABRICPY_CONFIG_ENV` value                           |
+| Missing default_config                               | "No default_config found"      | Add `default_config` field under `GENERAL` section           |
+| Typos in filter names                                | No results or errors           | Use `bfabric-cli api inspect` to check valid parameter names |
 
 ## Next Steps
 

--- a/bfabric/docs/resources/good_to_know.md
+++ b/bfabric/docs/resources/good_to_know.md
@@ -60,14 +60,14 @@ This removes time stamps and line numbers, unless `BFABRICPY_LOG_LEVEL=DEBUG` is
 
 The logging level can be controlled via the `BFABRICPY_LOG_LEVEL` environment variable:
 
-| Value | Effect |
-|-------|--------|
-| `DEBUG` | Show all log messages including debug output (with full loguru format) |
-| `INFO` | Show INFO and above (default) |
-| `WARNING` | Show WARNING and above |
-| `ERROR` | Show ERROR and above |
-| `CRITICAL` | Show CRITICAL only |
-| `OFF` or `0` | Disable all logging completely |
+| Value        | Effect                                                                 |
+| ------------ | ---------------------------------------------------------------------- |
+| `DEBUG`      | Show all log messages including debug output (with full loguru format) |
+| `INFO`       | Show INFO and above (default)                                          |
+| `WARNING`    | Show WARNING and above                                                 |
+| `ERROR`      | Show ERROR and above                                                   |
+| `CRITICAL`   | Show CRITICAL only                                                     |
+| `OFF` or `0` | Disable all logging completely                                         |
 
 Invalid values fall back silently to `INFO`.
 

--- a/bfabric/docs/resources/index.md
+++ b/bfabric/docs/resources/index.md
@@ -14,11 +14,11 @@ good_to_know
 
 This section contains resources to help you use bfabricPy effectively:
 
-| Resource | Description | For |
-| -------------------------------------------- | ---------------------------------------------------- | --------------------------- |
-| **[Good to Know](good_to_know)** | Useful tips and important notes | All users |
-| **[Contributing](https://github.com/fgcz/bfabricPy/blob/main/CONTRIBUTING.md)** | How to contribute to bfabricPy | Contributors |
-| **[Changelog](../changelog)** | Version history and changes | All users |
+| Resource                                                                        | Description                     | For          |
+| ------------------------------------------------------------------------------- | ------------------------------- | ------------ |
+| **[Good to Know](good_to_know)**                                                | Useful tips and important notes | All users    |
+| **[Contributing](https://github.com/fgcz/bfabricPy/blob/main/CONTRIBUTING.md)** | How to contribute to bfabricPy  | Contributors |
+| **[Changelog](../changelog)**                                                   | Version history and changes     | All users    |
 
 ## Quick Links
 

--- a/bfabric/docs/user_guides/bfabric-cli/api_operations.md
+++ b/bfabric/docs/user_guides/bfabric-cli/api_operations.md
@@ -12,13 +12,13 @@ Use the CLI when you need quick one-off operations, want to test API calls, or p
 bfabric-cli api --help
 ```
 
-| Subcommand | Purpose |
+| Subcommand | Purpose                     |
 | ---------- | --------------------------- |
-| `create` | Create new entities |
-| `read` | Query and retrieve entities |
-| `update` | Modify existing entities |
-| `delete` | Remove entities |
-| `inspect` | Inspect SOAP API structure |
+| `create`   | Create new entities         |
+| `read`     | Query and retrieve entities |
+| `update`   | Modify existing entities    |
+| `delete`   | Remove entities             |
+| `inspect`  | Inspect SOAP API structure  |
 
 ## Reading Entities
 
@@ -30,14 +30,14 @@ bfabric-cli api read [ENDPOINT] [QUERY] [OPTIONS]
 
 ### Parameters
 
-| Parameter | Required | Description |
+| Parameter   | Required | Description                                                         |
 | ----------- | -------- | ------------------------------------------------------------------- |
-| `endpoint` | Yes | Entity type (e.g., `resource`, `sample`, `workunit`, `dataset`) |
-| `query` | No | Key-value pairs to filter results |
-| `--format` | No | Output: `json`, `yaml`, `tsv`, `table-rich` (default: `table-rich`) |
-| `--limit` | No | Maximum results (default: 100) |
-| `--columns` | No | Comma-separated columns to display |
-| `--file` | No | Write output to file |
+| `endpoint`  | Yes      | Entity type (e.g., `resource`, `sample`, `workunit`, `dataset`)     |
+| `query`     | No       | Key-value pairs to filter results                                   |
+| `--format`  | No       | Output: `json`, `yaml`, `tsv`, `table-rich` (default: `table-rich`) |
+| `--limit`   | No       | Maximum results (default: 100)                                      |
+| `--columns` | No       | Comma-separated columns to display                                  |
+| `--file`    | No       | Write output to file                                                |
 
 ### Examples
 
@@ -133,17 +133,17 @@ bfabric-cli api inspect [ENDPOINT] [METHOD]
 
 ## Common Entity Types
 
-| Endpoint | Description |
+| Endpoint         | Description             |
 | ---------------- | ----------------------- |
-| `resource` | File resources |
-| `sample` | Samples |
-| `workunit` | Workunits/jobs |
-| `dataset` | Datasets |
-| `project` | Projects |
-| `container` | Containers |
-| `application` | Applications |
-| `executable` | Application executables |
-| `importresource` | Import resources |
+| `resource`       | File resources          |
+| `sample`         | Samples                 |
+| `workunit`       | Workunits/jobs          |
+| `dataset`        | Datasets                |
+| `project`        | Projects                |
+| `container`      | Containers              |
+| `application`    | Applications            |
+| `executable`     | Application executables |
+| `importresource` | Import resources        |
 
 ## Tips
 

--- a/bfabric/docs/user_guides/bfabric-cli/authentication.md
+++ b/bfabric/docs/user_guides/bfabric-cli/authentication.md
@@ -43,11 +43,11 @@ prod-rw   oauth · api:write · present, expires in ~7h  (active via BFABRICPY_C
 
 A scope is the set of permissions the token carries. Pass a preset or a raw scope string:
 
-| Preset | Scope | For |
-| ------------ | --------------- | -------------------------------------------- |
-| `read-only` | `api:read` | reading data |
-| `read-write` | `api:write` | creating and updating (includes reading) |
-| `upload` | `api:write tus` | uploading files (includes read and write) |
+| Preset       | Scope           | For                                       |
+| ------------ | --------------- | ----------------------------------------- |
+| `read-only`  | `api:read`      | reading data                              |
+| `read-write` | `api:write`     | creating and updating (includes reading)  |
+| `upload`     | `api:write tus` | uploading files (includes read and write) |
 
 ```bash
 bfabric-cli auth login --scope upload
@@ -71,12 +71,12 @@ bfabric-cli login --config-env test-rw
 The CLI knows these instances, so a bare host expands to the full URL and the environment name is
 suggested for you:
 
-| Name | URL |
-| ----------- | ------------------------------------------- |
-| `fgcz-prod` | `https://fgcz-bfabric.uzh.ch/bfabric` |
+| Name        | URL                                        |
+| ----------- | ------------------------------------------ |
+| `fgcz-prod` | `https://fgcz-bfabric.uzh.ch/bfabric`      |
 | `fgcz-test` | `https://fgcz-bfabric-test.uzh.ch/bfabric` |
 | `fgcz-demo` | `https://fgcz-bfabric-demo.uzh.ch/bfabric` |
-| `trace` | `https://trace.fgcz.uzh.ch/bfabric` |
+| `trace`     | `https://trace.fgcz.uzh.ch/bfabric`        |
 
 Any other URL works too — the list is a convenience, not a restriction.
 

--- a/bfabric/docs/user_guides/bfabric-cli/datasets.md
+++ b/bfabric/docs/user_guides/bfabric-cli/datasets.md
@@ -10,13 +10,13 @@ bfabric-cli dataset --help
 
 Available subcommands:
 
-| Subcommand | Purpose |
+| Subcommand | Purpose               |
 | ---------- | --------------------- |
-| `show` | View dataset details |
+| `show`     | View dataset details  |
 | `download` | Download dataset data |
-| `upload` | Upload new datasets |
+| `upload`   | Upload new datasets   |
 
-______________________________________________________________________
+---
 
 ## Showing Datasets
 
@@ -30,10 +30,10 @@ bfabric-cli dataset show [DATASET_ID] [OPTIONS]
 
 ### Parameters
 
-| Parameter | Required | Description |
+| Parameter    | Required | Description                                                         |
 | ------------ | -------- | ------------------------------------------------------------------- |
-| `dataset_id` | Yes | ID of the dataset to view |
-| `--format` | No | Output format: `json`, `yaml`, `table-rich` (default: `table-rich`) |
+| `dataset_id` | Yes      | ID of the dataset to view                                           |
+| `--format`   | No       | Output format: `json`, `yaml`, `table-rich` (default: `table-rich`) |
 
 ### Examples
 
@@ -65,7 +65,7 @@ The output includes:
 - File details
 - Creation/modification timestamps
 
-______________________________________________________________________
+---
 
 ## Downloading Datasets
 
@@ -79,11 +79,11 @@ bfabric-cli dataset download [DATASET_ID] [OUTPUT_FILE] [OPTIONS]
 
 ### Parameters
 
-| Parameter | Required | Description |
-| ------------- | -------- | ----------------------------------------------- |
-| `dataset_id` | Yes | ID of the dataset to download |
-| `output_file` | Yes | Local file path for output |
-| `--format` | No | Format for output file: `auto`, `csv`, `tsv`, `parquet`, `excel` (default: `auto`) |
+| Parameter     | Required | Description                                                                        |
+| ------------- | -------- | ---------------------------------------------------------------------------------- |
+| `dataset_id`  | Yes      | ID of the dataset to download                                                      |
+| `output_file` | Yes      | Local file path for output                                                         |
+| `--format`    | No       | Format for output file: `auto`, `csv`, `tsv`, `parquet`, `excel` (default: `auto`) |
 
 ### Examples
 
@@ -174,7 +174,7 @@ print(df.head())
   ```
 - Supported extensions for auto format: `.csv`, `.tsv`, `.parquet`, `.xlsx`
 
-______________________________________________________________________
+---
 
 ## Uploading Datasets
 
@@ -190,20 +190,20 @@ bfabric-cli dataset upload [FORMAT] [INPUT_FILE] [OPTIONS]
 
 Available upload formats:
 
-| Format | Command | Description |
+| Format  | Command          | Description              |
 | ------- | ---------------- | ------------------------ |
-| CSV | `upload csv` | Upload from CSV file |
-| TSV | `upload tsv` | Upload from TSV file |
+| CSV     | `upload csv`     | Upload from CSV file     |
+| TSV     | `upload tsv`     | Upload from TSV file     |
 | Parquet | `upload parquet` | Upload from Parquet file |
 
 ### Common Parameters
 
-| Parameter | Required | Description |
+| Parameter        | Required | Description                       |
 | ---------------- | -------- | --------------------------------- |
-| `input_file` | Yes | Path to local file to upload |
-| `--container-id` | Yes | Container ID to attach dataset to |
-| `--name` | No | Dataset name (default: filename) |
-| `--description` | No | Dataset description |
+| `input_file`     | Yes      | Path to local file to upload      |
+| `--container-id` | Yes      | Container ID to attach dataset to |
+| `--name`         | No       | Dataset name (default: filename)  |
+| `--description`  | No       | Dataset description               |
 
 ### Examples
 
@@ -238,9 +238,9 @@ bfabric-cli dataset upload csv [INPUT_FILE] [OPTIONS]
 
 CSV-specific options:
 
-| Option | Description |
+| Option         | Description                                 |
 | -------------- | ------------------------------------------- |
-| `--delimiter` | Column delimiter (default: `,`) |
+| `--delimiter`  | Column delimiter (default: `,`)             |
 | `--has-header` | Whether first row is header (default: true) |
 
 #### Upload Parquet
@@ -259,7 +259,7 @@ bfabric-cli dataset upload tsv [INPUT_FILE] [OPTIONS]
 
 TSV-specific options:
 
-| Option | Description |
+| Option         | Description                                 |
 | -------------- | ------------------------------------------- |
 | `--has-header` | Whether first row is header (default: true) |
 
@@ -285,7 +285,7 @@ https://<bfabric-url>/project/show.html?id=<container-id>&tab=datasets
 - Upload progress is displayed
 - The dataset ID is returned after successful upload
 
-______________________________________________________________________
+---
 
 ## Workflow Example
 
@@ -305,7 +305,7 @@ bfabric-cli dataset upload parquet processed.parquet \
     --description "Processed version of dataset 12345"
 ```
 
-______________________________________________________________________
+---
 
 ## Tips and Best Practices
 
@@ -344,7 +344,7 @@ for dataset_id in 12345 12346 12347; do
 done
 ```
 
-______________________________________________________________________
+---
 
 ## Common Issues
 
@@ -377,7 +377,7 @@ bfabric-cli dataset show <dataset-id>
 2. Uploading during off-peak hours
 3. Contacting B-Fabric admin for size limits
 
-______________________________________________________________________
+---
 
 ## See Also
 

--- a/bfabric/docs/user_guides/bfabric-cli/executables.md
+++ b/bfabric/docs/user_guides/bfabric-cli/executables.md
@@ -10,13 +10,13 @@ bfabric-cli executable --help
 
 Available subcommands:
 
-| Subcommand | Purpose |
+| Subcommand | Purpose                               |
 | ---------- | ------------------------------------- |
-| `show` | View executable details |
-| `upload` | Upload new executables (experimental) |
-| `dump` | Dump executable contents |
+| `show`     | View executable details               |
+| `upload`   | Upload new executables (experimental) |
+| `dump`     | Dump executable contents              |
 
-______________________________________________________________________
+---
 
 ## Showing Executables
 
@@ -30,9 +30,9 @@ bfabric-cli executable show [EXECUTABLE_ID]
 
 ### Parameters
 
-| Parameter | Required | Description |
+| Parameter       | Required | Description                  |
 | --------------- | -------- | ---------------------------- |
-| `executable_id` | Yes | ID of the executable to view |
+| `executable_id` | Yes      | ID of the executable to view |
 
 ### Examples
 
@@ -60,7 +60,7 @@ The output includes:
 - Parameters and configuration
 - Creation/modification information
 
-______________________________________________________________________
+---
 
 ## Uploading Executables
 
@@ -74,10 +74,10 @@ bfabric-cli executable upload [YAML_FILE] [OPTIONS]
 
 ### Parameters
 
-| Parameter | Required | Description |
+| Parameter   | Required | Description                                        |
 | ----------- | -------- | -------------------------------------------------- |
-| `yaml_file` | Yes | Path to YAML file containing executable definition |
-| `--force` | No | Force upload even if validation warnings exist |
+| `yaml_file` | Yes      | Path to YAML file containing executable definition |
+| `--force`   | No       | Force upload even if validation warnings exist     |
 
 ### Example
 
@@ -115,7 +115,7 @@ After uploading, verify the executable:
 bfabric-cli executable show <NEW_EXECUTABLE_ID>
 ```
 
-______________________________________________________________________
+---
 
 ## Dumping Executables
 
@@ -129,9 +129,9 @@ bfabric-cli executable dump [EXECUTABLE_ID]
 
 ### Parameters
 
-| Parameter | Required | Description |
+| Parameter       | Required | Description                  |
 | --------------- | -------- | ---------------------------- |
-| `executable_id` | Yes | ID of the executable to dump |
+| `executable_id` | Yes      | ID of the executable to dump |
 
 ### Example
 
@@ -154,7 +154,7 @@ The dump command is useful for:
 
 The dumped output shows the internal structure of the executable, including all configuration parameters, encoded content, and metadata.
 
-______________________________________________________________________
+---
 
 ## Workflow Example
 
@@ -177,7 +177,7 @@ bfabric-cli executable upload new_executable.yml
 bfabric-cli executable show <NEW_EXECUTABLE_ID>
 ```
 
-______________________________________________________________________
+---
 
 ## Working with Executables
 
@@ -207,7 +207,7 @@ bfabric-cli api read executable --limit 10 \
 bfabric-cli api read executable --format json --file executables.json
 ```
 
-______________________________________________________________________
+---
 
 ## Tips and Best Practices
 
@@ -256,7 +256,7 @@ name: "My Analysis Script v1.1"
 name: "My Analysis Script v2.0"
 ```
 
-______________________________________________________________________
+---
 
 ## Common Issues
 
@@ -287,13 +287,13 @@ bfabric-cli api read executable id <executable-id>
 
 **Explanation**: Executables are stored in encoded format for transport. This is expected behavior. Use `show` for a more readable representation.
 
-______________________________________________________________________
+---
 
 ## Integration with bfabric-app-runner
 
 Executables uploaded via the CLI can be used with `bfabric-app-runner`. For more information on using executables in workflows, refer to the bfabric-app-runner documentation.
 
-______________________________________________________________________
+---
 
 ## See Also
 

--- a/bfabric/docs/user_guides/bfabric-cli/feeder.md
+++ b/bfabric/docs/user_guides/bfabric-cli/feeder.md
@@ -10,11 +10,11 @@ bfabric-cli feeder --help
 
 Available subcommands:
 
-| Subcommand | Purpose |
+| Subcommand              | Purpose                                       |
 | ----------------------- | --------------------------------------------- |
 | `create-importresource` | Create importresources for files in a storage |
 
-______________________________________________________________________
+---
 
 ## Creating Importresources
 
@@ -28,10 +28,10 @@ bfabric-cli feeder create-importresource [STORAGE_ID] [FILES]...
 
 ### Parameters
 
-| Parameter | Required | Description |
+| Parameter    | Required | Description                                          |
 | ------------ | -------- | ---------------------------------------------------- |
-| `storage_id` | Yes | ID of the target storage |
-| `files` | Yes | One or more file paths to create importresources for |
+| `storage_id` | Yes      | ID of the target storage                             |
+| `files`      | Yes      | One or more file paths to create importresources for |
 
 ### Examples
 
@@ -92,7 +92,7 @@ The command provides feedback on:
 - **Updates**: "Importresource X updated for file /path/to/file.raw" (if an importresource already exists)
 - **Errors**: "Application Y not found in B-Fabric. Skipping file /path/to/file.raw"
 
-______________________________________________________________________
+---
 
 ## Workflow Examples
 
@@ -130,7 +130,7 @@ for storage_id in 1 2 3; do
 done
 ```
 
-______________________________________________________________________
+---
 
 ## Finding Storage Information
 
@@ -156,7 +156,7 @@ The storage information will show:
 - Base URL/path
 - Path convention type (e.g., CompMS)
 
-______________________________________________________________________
+---
 
 ## Working with Importresources
 
@@ -182,7 +182,7 @@ bfabric-cli api read importresource createdafter 2024-12-01 --limit 20
 bfabric-cli api read importresource id 12345
 ```
 
-______________________________________________________________________
+---
 
 ## Tips and Best Practices
 
@@ -232,7 +232,7 @@ bfabric-cli feeder create-importresource 1 /data/test/*.raw
 bfabric-cli feeder create-importresource 1 /data/production/*.raw
 ```
 
-______________________________________________________________________
+---
 
 ## Common Issues
 
@@ -285,7 +285,7 @@ bfabric-cli api read storage id <storage-id>
 tree /data/
 ```
 
-______________________________________________________________________
+---
 
 ## Integration with Data Ingestion Workflows
 
@@ -328,7 +328,7 @@ mv "$SOURCE_DIR"/*.raw "$PROCESSED_DIR/"
 echo "Ingestion complete!"
 ```
 
-______________________________________________________________________
+---
 
 ## See Also
 

--- a/bfabric/docs/user_guides/bfabric-cli/index.md
+++ b/bfabric/docs/user_guides/bfabric-cli/index.md
@@ -21,18 +21,18 @@ bfabric-cli organizes commands by functionality:
 
 ### Core Commands
 
-| Command | Purpose |
+| Command                  | Purpose                                                |
 | ------------------------ | ------------------------------------------------------ |
-| `bfabric-cli auth` | Log in and manage instances / credentials |
-| `bfabric-cli api` | Generic CRUD operations on B-Fabric entities |
-| `bfabric-cli dataset` | Dataset-specific operations (read, upload, download) |
-| `bfabric-cli executable` | Executable operations (show, upload, dump) |
-| `bfabric-cli workunit` | Workunit operations (check status, export definitions) |
-| `bfabric-cli feeder` | Feeder operations for creating importresources |
+| `bfabric-cli auth`       | Log in and manage instances / credentials              |
+| `bfabric-cli api`        | Generic CRUD operations on B-Fabric entities           |
+| `bfabric-cli dataset`    | Dataset-specific operations (read, upload, download)   |
+| `bfabric-cli executable` | Executable operations (show, upload, dump)             |
+| `bfabric-cli workunit`   | Workunit operations (check status, export definitions) |
+| `bfabric-cli feeder`     | Feeder operations for creating importresources         |
 
 ### Legacy/Deprecated
 
-| Command | Status |
+| Command                    | Status                                         |
 | -------------------------- | ---------------------------------------------- |
 | `bfabric-cli external-job` | Transitory - will be removed in future release |
 

--- a/bfabric/docs/user_guides/bfabric-cli/workunits.md
+++ b/bfabric/docs/user_guides/bfabric-cli/workunits.md
@@ -10,13 +10,13 @@ bfabric-cli workunit --help
 
 Available subcommands:
 
-| Subcommand | Purpose |
+| Subcommand          | Purpose                                                                     |
 | ------------------- | --------------------------------------------------------------------------- |
-| `upload` | Upload files to a workunit over tus (resumable) |
-| `not-available` | Check for workunits with missing results (commonly failed CompMS workunits) |
-| `export-definition` | Export workunit definition to a YAML file |
+| `upload`            | Upload files to a workunit over tus (resumable)                             |
+| `not-available`     | Check for workunits with missing results (commonly failed CompMS workunits) |
+| `export-definition` | Export workunit definition to a YAML file                                   |
 
-______________________________________________________________________
+---
 
 ## Checking for Pending Workunits
 
@@ -63,7 +63,7 @@ The output lists workunits that are in a "not available" state, typically showin
 
 This command can return many results in production environments. Consider filtering or limiting the output for large deployments.
 
-______________________________________________________________________
+---
 
 ## Exporting Workunit Definitions
 
@@ -77,10 +77,10 @@ bfabric-cli workunit export-definition [WORKUNIT_ID] [OPTIONS]
 
 ### Parameters
 
-| Parameter | Required | Description |
+| Parameter     | Required | Description                                           |
 | ------------- | -------- | ----------------------------------------------------- |
-| `workunit_id` | Yes | ID of the workunit to export |
-| `--file` | No | Output file path (default: `workunit_definition.yml`) |
+| `workunit_id` | Yes      | ID of the workunit to export                          |
+| `--file`      | No       | Output file path (default: `workunit_definition.yml`) |
 
 ### Examples
 
@@ -132,7 +132,7 @@ The exported YAML file can be used to run the same analysis:
 bfabric-app-runner run workunit_definition.yml
 ```
 
-______________________________________________________________________
+---
 
 ## Uploading Files
 
@@ -165,16 +165,16 @@ mark the workunit `available`.
 
 ### Parameters
 
-| Parameter | Required | Description |
-| ---------------------- | -------- | ----------------------------------------------------------------------- |
-| `FILE...` | Yes | Files and/or directories to upload (positional; directories recurse) |
-| `--container-id` | \* | Container to create the workunit in |
-| `--application-id` | \* | Application the workunit belongs to |
-| `--workunit-id` | \* | Upload into this existing workunit instead of creating one |
-| `--workunit-name` | No | Name for the created workunit (default "File upload") |
-| `--on-duplicate` | No | `upload` (default), `skip` or `link` content already in the container |
-| `--track-job` | No | Create a `UPLOAD` job; the server flips it to DONE/FAILED |
-| `--no-progress` | No | Disable the live progress bar (auto-off when stderr is not a terminal) |
+| Parameter          | Required | Description                                                            |
+| ------------------ | -------- | ---------------------------------------------------------------------- |
+| `FILE...`          | Yes      | Files and/or directories to upload (positional; directories recurse)   |
+| `--container-id`   | \*       | Container to create the workunit in                                    |
+| `--application-id` | \*       | Application the workunit belongs to                                    |
+| `--workunit-id`    | \*       | Upload into this existing workunit instead of creating one             |
+| `--workunit-name`  | No       | Name for the created workunit (default "File upload")                  |
+| `--on-duplicate`   | No       | `upload` (default), `skip` or `link` content already in the container  |
+| `--track-job`      | No       | Create a `UPLOAD` job; the server flips it to DONE/FAILED              |
+| `--no-progress`    | No       | Disable the live progress bar (auto-off when stderr is not a terminal) |
 
 \* Provide either `--workunit-id` (existing workunit) **or** both `--container-id` and
 `--application-id` (new workunit); the two modes are mutually exclusive.
@@ -273,7 +273,7 @@ A file whose transfer fails is recorded in `summary.failures` rather than raisin
 (bad auth, missing scope, resource-creation errors) raise `BfabricTransferError`, and the workunit is
 flipped to `failed` (never deleted) so the partial state stays diagnosable.
 
-______________________________________________________________________
+---
 
 ## Finding Workunits
 
@@ -333,7 +333,7 @@ bfabric-cli api read workunit id 12345
 bfabric-cli api read workunit --limit 100 --format json --file workunits.json
 ```
 
-______________________________________________________________________
+---
 
 ## Working with Workunit Resources
 
@@ -353,7 +353,7 @@ bfabric-cli api read resource workunitid 12345
 bfabric-cli api read dataset workunitid 12345
 ```
 
-______________________________________________________________________
+---
 
 ## Workflow Examples
 
@@ -401,7 +401,7 @@ cat workunits.json | jq -r '.[].id' | while read id; do
 done
 ```
 
-______________________________________________________________________
+---
 
 ## Tips and Best Practices
 
@@ -442,7 +442,7 @@ Set up regular monitoring for failed workunits:
 BFABRICPY_CONFIG_ENV=PRODUCTION bfabric-cli workunit not-available > pending_$(date +%Y%m%d).txt
 ```
 
-______________________________________________________________________
+---
 
 ## Common Issues
 
@@ -486,7 +486,7 @@ bfabric-cli api read workunit id <workunit-id>
 3. Ensure the workunit has all required components
 4. Try exporting a different workunit to compare
 
-______________________________________________________________________
+---
 
 ## Integration with Other Tools
 
@@ -526,7 +526,7 @@ definition.description = "Modified description"
 definition.to_yaml(Path("modified_definition.yml"))
 ```
 
-______________________________________________________________________
+---
 
 ## See Also
 

--- a/bfabric/docs/user_guides/connecting/index.md
+++ b/bfabric/docs/user_guides/connecting/index.md
@@ -10,13 +10,13 @@ server_webapp_usage
 
 ## Choose Your Approach
 
-| Use Case | Method | Documentation |
+| Use Case                                   | Method                                                     | Documentation                                               |
 | ------------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------- |
-| Scripts, local tools, interactive sessions | `bfabric-cli login` once, then `Bfabric.connect()` | [Interactive/Scripted Usage](interactive_scripted_usage.md) |
-| Logging in from Python, without the CLI | `Bfabric.connect_pkce()` / `Bfabric.connect_device_code()` | [Interactive/Scripted Usage](interactive_scripted_usage.md) |
-| Non-interactive token | `Bfabric.connect_pat()` | [Interactive/Scripted Usage](interactive_scripted_usage.md) |
-| Background jobs, service accounts | `Bfabric.connect_oauth()` | [Server/Webapp Usage](server_webapp_usage.md) |
-| Webapps launched from B-Fabric | `Bfabric.connect_token()` / `WebappClient.create()` | [Server/Webapp Usage](server_webapp_usage.md) |
+| Scripts, local tools, interactive sessions | `bfabric-cli login` once, then `Bfabric.connect()`         | [Interactive/Scripted Usage](interactive_scripted_usage.md) |
+| Logging in from Python, without the CLI    | `Bfabric.connect_pkce()` / `Bfabric.connect_device_code()` | [Interactive/Scripted Usage](interactive_scripted_usage.md) |
+| Non-interactive token                      | `Bfabric.connect_pat()`                                    | [Interactive/Scripted Usage](interactive_scripted_usage.md) |
+| Background jobs, service accounts          | `Bfabric.connect_oauth()`                                  | [Server/Webapp Usage](server_webapp_usage.md)               |
+| Webapps launched from B-Fabric             | `Bfabric.connect_token()` / `WebappClient.create()`        | [Server/Webapp Usage](server_webapp_usage.md)               |
 
 ## Next Steps
 

--- a/bfabric/docs/user_guides/connecting/server_webapp_usage.md
+++ b/bfabric/docs/user_guides/connecting/server_webapp_usage.md
@@ -7,11 +7,11 @@ B-Fabric, where there is no config file to log in from interactively.
 
 Three situations, three methods:
 
-| Situation | Method |
-| ----------------------------------------------------------- | ------------------------------------------------- |
-| A background job or server acting as itself, with no user | [`connect_oauth()`](#service-accounts) |
-| A webapp launched from B-Fabric, acting for the current user | [`WebappClient.create()`](#apps-launched-from-b-fabric) |
-| A webapp receiving a B-Fabric webapp token | [`connect_token()`](#token-based-authentication-methods) |
+| Situation                                                    | Method                                                   |
+| ------------------------------------------------------------ | -------------------------------------------------------- |
+| A background job or server acting as itself, with no user    | [`connect_oauth()`](#service-accounts)                   |
+| A webapp launched from B-Fabric, acting for the current user | [`WebappClient.create()`](#apps-launched-from-b-fabric)  |
+| A webapp receiving a B-Fabric webapp token                   | [`connect_token()`](#token-based-authentication-methods) |
 
 ## Service Accounts
 

--- a/bfabric/docs/user_guides/index.md
+++ b/bfabric/docs/user_guides/index.md
@@ -14,14 +14,14 @@ error_handling
 
 ## Guides Overview
 
-| Guide | Description | Skill Level |
+| Guide                                                   | Description                                    | Skill Level  |
 | ------------------------------------------------------- | ---------------------------------------------- | ------------ |
-| [Connecting](connecting/index.md) | Set up authentication for scripts and web apps | Beginner |
-| [Reading Data](reading_data/index.md) | Query B-Fabric and retrieve data | Beginner |
-| [Writing Data](writing_data/index.md) | Create, update, and delete entities | Intermediate |
-| [Working with Entities](working_with_entities/index.md) | Use typed entities and relationships | Intermediate |
-| [bfabric-cli](bfabric-cli/index.md) | Command-line interface for bfabric-cli | All Levels |
-| [Error Handling](error_handling.md) | Error types, patterns, and handling strategies | All Levels |
+| [Connecting](connecting/index.md)                       | Set up authentication for scripts and web apps | Beginner     |
+| [Reading Data](reading_data/index.md)                   | Query B-Fabric and retrieve data               | Beginner     |
+| [Writing Data](writing_data/index.md)                   | Create, update, and delete entities            | Intermediate |
+| [Working with Entities](working_with_entities/index.md) | Use typed entities and relationships           | Intermediate |
+| [bfabric-cli](bfabric-cli/index.md)                     | Command-line interface for bfabric-cli         | All Levels   |
+| [Error Handling](error_handling.md)                     | Error types, patterns, and handling strategies | All Levels   |
 
 ## Common Workflows
 

--- a/bfabric/docs/user_guides/reading_data/index.md
+++ b/bfabric/docs/user_guides/reading_data/index.md
@@ -13,22 +13,22 @@ caching_for_performance
 
 bfabricPy provides two complementary APIs for reading data:
 
-| Approach | Primary Class | Best For | Documentation |
+| Approach                | Primary Class             | Best For                                        | Documentation                                 |
 | ----------------------- | ------------------------- | ----------------------------------------------- | --------------------------------------------- |
-| **ResultContainer API** | `ResultContainer` | Simple queries, data analysis, DataFrame export | [ResultContainer API](resultcontainer_api.md) |
-| **Entity API** | `Entity` / `EntityReader` | Typed entities, relationships, URI access | [Entity API](entity_api.md) |
+| **ResultContainer API** | `ResultContainer`         | Simple queries, data analysis, DataFrame export | [ResultContainer API](resultcontainer_api.md) |
+| **Entity API**          | `Entity` / `EntityReader` | Typed entities, relationships, URI access       | [Entity API](entity_api.md)                   |
 
 ## Quick Comparison
 
-| Feature | ResultContainer API | Entity API |
+| Feature           | ResultContainer API           | Entity API                           |
 | ----------------- | ----------------------------- | ------------------------------------ |
-| **Entry Point** | `client.read(endpoint, obj)` | `client.reader` |
-| **Return Type** | Dictionaries (raw data) | Entity objects (typed) |
-| **Relationships** | Manual handling | Lazy-loading via `entity.refs` |
-| **Caching** | Manual | Automatic (via `cache_entities()`) |
-| **URI Support** | Limited | Full URI-based access |
-| **Data Export** | Polars DataFrames | Via `data_dict` |
-| **Use Case** | Simple queries, data analysis | Working with entities, relationships |
+| **Entry Point**   | `client.read(endpoint, obj)`  | `client.reader`                      |
+| **Return Type**   | Dictionaries (raw data)       | Entity objects (typed)               |
+| **Relationships** | Manual handling               | Lazy-loading via `entity.refs`       |
+| **Caching**       | Manual                        | Automatic (via `cache_entities()`)   |
+| **URI Support**   | Limited                       | Full URI-based access                |
+| **Data Export**   | Polars DataFrames             | Via `data_dict`                      |
+| **Use Case**      | Simple queries, data analysis | Working with entities, relationships |
 
 ## See Also
 

--- a/bfabric/docs/user_guides/working_with_entities/index.md
+++ b/bfabric/docs/user_guides/working_with_entities/index.md
@@ -10,15 +10,15 @@ bfabricPy provides typed entity classes with type-specific features like Dataset
 
 For complete API documentation, see [API Reference: Entity Types](../../api_reference/entity_types/index.md).
 
-| Entity | Special Features |
-| ------- | ---------------- |
-| **Dataset** | DataFrame conversion, CSV/Parquet export |
-| **Workunit** | Parameter access, output folder calculation |
-| **Resource** | Path methods, storage access |
-| **Application** | Technology folder name |
-| **Executable** | Base64 decoding |
-| **Parameter** | Key-value access |
-| **User** | Login-based lookup |
+| Entity          | Special Features                            |
+| --------------- | ------------------------------------------- |
+| **Dataset**     | DataFrame conversion, CSV/Parquet export    |
+| **Workunit**    | Parameter access, output folder calculation |
+| **Resource**    | Path methods, storage access                |
+| **Application** | Technology folder name                      |
+| **Executable**  | Base64 decoding                             |
+| **Parameter**   | Key-value access                            |
+| **User**        | Login-based lookup                          |
 
 ## Datasets
 

--- a/bfabric/docs/user_guides/writing_data/index.md
+++ b/bfabric/docs/user_guides/writing_data/index.md
@@ -198,17 +198,17 @@ print(f"Deleted {len(result)} samples")
 
 ## Common Writable Endpoints
 
-| Endpoint | Description | Common Fields |
-| -------- | ----------- | ------------- |
-| `sample` | Biological samples | `name`, `containerid`, `type`, `description` |
-| `project` | Projects | `name`, `description` |
-| `order` | Orders | `name`, `description` |
-| `container` | Projects and orders | `name`, `description` |
-| `workunit` | Workunits | `name`, `applicationid`, `containerid`, `status` |
-| `resource` | Resources | `name`, `workunitid`, `base64` (content), `relativepath` |
-| `importresource` | Import resources | `name`, `containerid`, `relativepath`, `filechecksum`, `size` |
-| `workflow` | Workflows | `containerid`, `workflowtemplateid` |
-| `workflowstep` | Workflow steps | `workflowid`, `workflowtemplatestepid`, `workunitid` |
+| Endpoint         | Description         | Common Fields                                                 |
+| ---------------- | ------------------- | ------------------------------------------------------------- |
+| `sample`         | Biological samples  | `name`, `containerid`, `type`, `description`                  |
+| `project`        | Projects            | `name`, `description`                                         |
+| `order`          | Orders              | `name`, `description`                                         |
+| `container`      | Projects and orders | `name`, `description`                                         |
+| `workunit`       | Workunits           | `name`, `applicationid`, `containerid`, `status`              |
+| `resource`       | Resources           | `name`, `workunitid`, `base64` (content), `relativepath`      |
+| `importresource` | Import resources    | `name`, `containerid`, `relativepath`, `filechecksum`, `size` |
+| `workflow`       | Workflows           | `containerid`, `workflowtemplateid`                           |
+| `workflowstep`   | Workflow steps      | `workflowid`, `workflowtemplatestepid`, `workunitid`          |
 
 Use `bfabric-cli api inspect <endpoint>` to see complete field lists.
 

--- a/bfabric_app_runner/docs/_design_notes/_app_definition.md
+++ b/bfabric_app_runner/docs/_design_notes/_app_definition.md
@@ -14,5 +14,5 @@
 
 - Version ranges: Maybe we could use semver, but it would need to be a standardized flavor thereof.
 - Allow to provide a folder (or set of YAML files) with multiple app definitions, to be pooled together.
-    If there are any version conflicts an error should be raised.
-    There probably should be a tool to check the available versions easily.
+  If there are any version conflicts an error should be raised.
+  There probably should be a tool to check the available versions easily.

--- a/bfabric_app_runner/docs/_design_notes/_input_staging.md
+++ b/bfabric_app_runner/docs/_design_notes/_input_staging.md
@@ -5,9 +5,9 @@
 Limitations:
 
 - The current logic will simply put all "StaticFile" content into RAM, which is generally fine for now, but might
-    need to be extended with a TempFile mechanism to specify a local file instead (i guess we would create a separate class).
+  need to be extended with a TempFile mechanism to specify a local file instead (i guess we would create a separate class).
 - Laziness would complicate the logic, and would only help for the list operation. Check will anyways need the Listing
-    and file preparation will need it too. If necessary, one could filter the specs before processing them further and for
-    this file name resolution would be necessary, which is a bit limiting. So for now I would say we don't support any
-    form of laziness.
+  and file preparation will need it too. If necessary, one could filter the specs before processing them further and for
+  this file name resolution would be necessary, which is a bit limiting. So for now I would say we don't support any
+  form of laziness.
 -

--- a/bfabric_app_runner/docs/_design_notes/_scheduling.md
+++ b/bfabric_app_runner/docs/_design_notes/_scheduling.md
@@ -1,14 +1,14 @@
 ## Open questions
 
 - Inter-chunk dependencies (assuming some chunks are different from others)
-    - Should chunks be standardized somehow
+  - Should chunks be standardized somehow
 - How to transfer a chunk (which is a folder) reasonably across different scheduler systems? -> tar or shared folder (needs config...)
 - Ideally: first version allows relatively flexible slurm configuration
 
 ## Future possibilities
 
 - The initial version is concerned about submitting one job to a (SLURM) scheduler. However, at a later time multi-node
-    jobs could be introduced by this job submitting then further jobs to the scheduler. Ideally, it could reuse the same
-    scheduling interface code as is used for the single-node jobs.
-    - Internally, we could prepare by making the app runner code that executes the individual chunks more generic.
+  jobs could be introduced by this job submitting then further jobs to the scheduler. Ideally, it could reuse the same
+  scheduling interface code as is used for the single-node jobs.
+  - Internally, we could prepare by making the app runner code that executes the individual chunks more generic.
 - Parallel execution of chunks could be introduced. This is actually very similar to the previous point.

--- a/bfabric_app_runner/docs/api_reference/index.md
+++ b/bfabric_app_runner/docs/api_reference/index.md
@@ -19,10 +19,10 @@ runner/index
 
 ## Where to look
 
-| To… | See |
-| --- | --- |
-| Define an app's versions and commands (`app.yml`) | [App specification](../specs/app_specification.md) |
-| Declare and fetch input files (`inputs.yml`) | [Input specification](../specs/input_specification.md) |
+| To…                                               | See                                                      |
+| ------------------------------------------------- | -------------------------------------------------------- |
+| Define an app's versions and commands (`app.yml`) | [App specification](../specs/app_specification.md)       |
+| Declare and fetch input files (`inputs.yml`)      | [Input specification](../specs/input_specification.md)   |
 | Register outputs back to B-Fabric (`outputs.yml`) | [Output specification](../specs/output_specification.md) |
-| Run the lifecycle from the shell | [CLI Reference](../user_guides/cli_reference.md) |
-| Drive the lifecycle from Python | [Python runner API](runner/index.md) |
+| Run the lifecycle from the shell                  | [CLI Reference](../user_guides/cli_reference.md)         |
+| Drive the lifecycle from Python                   | [Python runner API](runner/index.md)                     |

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## \[Unreleased\]
+## [Unreleased]
 
 ### Added
 
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - A failing app command reports a single `Error: Command failed with exit code N: <command>` line instead of ~10 frames of app-runner boilerplate ([#231](https://github.com/fgcz/bfabricPy/issues/231)).
 - `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory.
 
-## \[0.7.0\] - 2026-08-03
+## [0.7.0] - 2026-08-03
 
 - `SaveDatasetSpec` (the `bfabric_dataset` output) gains a `format` field (`csv` default, or `parquet`), so an output dataset can be registered from Parquet; `separator` is now optional (csv-only) ([#359](https://github.com/fgcz/bfabricPy/issues/359)).
 - `BfabricResourceSpec` gains an `access` field (`ssh`/`http`); `access: http` streams from the storage's HTTP endpoint (needs an OAuth client whose token carries the `containers` scope). The generic `file` spec also gained an HTTP source.
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Python-environment provisioning output (`uv venv` / `uv pip install`) is now logged at DEBUG instead of printed (quiet INFO runs); failures are logged in full at ERROR.
 - Internal: all read-path call sites migrated off the deprecated `Entity.find`/`find_all`/`find_by` (`FindMixin`) API onto `client.reader` (`read_id`/`read_ids`/`query_one`), with no behavior change; ruff `flake8-type-checking` now treats `pydantic.BaseModel` / `FromConfigFile` as runtime-evaluated (dropping `# noqa: TC00x` and blanket per-file ignores).
 
-## \[0.6.1\] - 2026-06-11
+## [0.6.1] - 2026-06-11
 
 ### Changed
 
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `command_docker.py` no longer imports `bfabric.config.DEFAULT_CONFIG_FILE`, which is not present in published bfabric 1.19.0; it uses the literal `Path("~/.bfabricpy.yml")` again (the value `DEFAULT_CONFIG_FILE` is defined as). This fixes an `ImportError` when constructing docker commands and during release validation.
 
-## \[0.6.0\] - 2026-04-20
+## [0.6.0] - 2026-04-20
 
 ### Added
 
@@ -66,13 +66,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `ResolveBfabricResourceArchiveSpecs` no longer raises a `ValidationError` when resolving resource archives ([#432](https://github.com/fgcz/bfabricPy/issues/432)).
 - `BfabricResourceArchiveSpec` zip output is no longer written to a doubled path when `filename` contains a subdirectory component ([#323](https://github.com/fgcz/bfabricPy/issues/323)).
 
-## \[0.5.1\] - 2026-03-02
+## [0.5.1] - 2026-03-02
 
 ### Fixed
 
 - `DispatchIndividualResources` now correctly handles resource lookups by using `read_ids` instead of `find_all`.
 
-## \[0.5.0\] - 2025-12-15
+## [0.5.0] - 2025-12-15
 
 ### Added
 
@@ -88,25 +88,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `ResolveBfabricAnnotationSpec` previously failed, when a resource was not linked with a sample.
 
-## \[0.4.0\] - 2025-09-26
+## [0.4.0] - 2025-09-26
 
 ### Added
 
 - **New Input Type**: `BfabricResourceDatasetSpec`
-    - Specifies a dataset which links `Resource` entities with a particular column
-    - Copies all files into a directory (the spec's `filename` field)
-    - Writes the dataset file into the same directory, adding a `File` column (configurable) with the filenames
+  - Specifies a dataset which links `Resource` entities with a particular column
+  - Copies all files into a directory (the spec's `filename` field)
+  - Writes the dataset file into the same directory, adding a `File` column (configurable) with the filenames
 
 ### Changed
 
 - Automatic Workflow Step Creation moved from `dispatch` action to `stage` action
-    - Prevents creating workflowsteps for failed workunits
-    - Note: This decision may be revisited in the future, as there could be benefits to creating the workflowstep early on
+  - Prevents creating workflowsteps for failed workunits
+  - Note: This decision may be revisited in the future, as there could be benefits to creating the workflowstep early on
 - Improved error messaging when running "make stage" in read-only mode
-    - Now displays clear warning messages explaining that staging is skipped
-    - Provides guidance on how to remove the --read-only flag
+  - Now displays clear warning messages explaining that staging is skipped
+  - Provides guidance on how to remove the --read-only flag
 
-## \[0.3.1\] - 2025-09-01
+## [0.3.1] - 2025-09-01
 
 ### Added
 
@@ -117,9 +117,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 # Changed
 
 - Dispatch action detects, when the script modifies `workunit_definition.yml` which should not happen anymore, and notifies
-    the user restoring the original file. The app continues without an error.
+  the user restoring the original file. The app continues without an error.
 
-## \[0.3.0\] - 2025-08-26
+## [0.3.0] - 2025-08-26
 
 ### Added
 
@@ -131,13 +131,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Generic dispatch functionality will not override existing `workunit_definition.yml` files anymore.
 - Update `bfabric` dependency to 1.13.33.
 
-## \[0.2.1\] - 2025-07-22
+## [0.2.1] - 2025-07-22
 
 ### Fixed
 
 - Makefile avoids redundant dispatch on every target.
 
-## \[0.2.0\] - 2025-07-15
+## [0.2.0] - 2025-07-15
 
 This release consolidates various commands in bfabric-app-runner streamlining the user experience.
 It also brings an improved Makefile which should obsolete the manual installation of `bfabric-app-runner` providing
@@ -161,24 +161,24 @@ the user with the configured version by default.
 
 - `copier` based template/demo application for development and end-to-end testing of bfabric-app-runner.
 - Added `ResolvedDirectory` type to represent directories resolved from resource archives.
-- Added `BfabricResourceArchiveSpec` to specify input archives which should be extracted  (and select which files are needed).
+- Added `BfabricResourceArchiveSpec` to specify input archives which should be extracted (and select which files are needed).
 - Validation logic has been added for `ResolvedDirectory` and `BfabricResourceArchiveSpec`. In particular a `ResolvedDirectory` may never overlap with a `ResolvedFile` or `ResolvedStaticFile` path.
 - Using `uv tool` the Makefile will provide the correct version of the app runner when called. To opt-out of this behavior, one can set `USE_EXTERNAL_RUNNER=true` for the makefile.
 
-## \[0.1.2\] - 2025-07-08
+## [0.1.2] - 2025-07-08
 
 ### Changed
 
 - `CommandPythonEnv` with `refresh=True` now will create a separate environment to avoid breaking apps which are already using a particular
-    Python environment without locking it.
+  Python environment without locking it.
 
-## \[0.1.1\] - 2025-07-07
+## [0.1.1] - 2025-07-07
 
 ### Changed
 
 - `CommandPythonEnv` computes the hash more carefully.
 
-## \[0.1.0\] - 2025-06-27
+## [0.1.0] - 2025-06-27
 
 ### Added
 
@@ -190,7 +190,7 @@ the user with the configured version by default.
 - New submitter requires `BFABRICPY_CONFIG_ENV` and `XDG_CACHE_HOME` to be set.
 - Update `bfabric` dependency to 1.13.28.
 
-## \[0.0.23\] - 2025-06-02
+## [0.0.23] - 2025-06-02
 
 ### Added
 
@@ -202,35 +202,35 @@ the user with the configured version by default.
 - AppVersion does not have a `submitter` field anymore.
 - Some old submitter related functionality is deleted.
 
-## \[0.0.22\] - 2025-05-21
+## [0.0.22] - 2025-05-21
 
 ### Added
 
 - Apps can now be referred to by module path rather than just file paths. This is going to be a primary building block
-    to very simple package-based deployment of apps.
+  to very simple package-based deployment of apps.
 - The `static_file` input spec type has been integrated properly.
 - Missing integration for `file` input spec type has been added.
 - The workunit makefile now directly shows how to use the GitHub app runner version instead, which is sometimes required
-    while debugging.
+  while debugging.
 - `CommandExec` allows prepending paths to `PATH` and setting environment variables and is less ambiguous than `shell`.
 - `bfabric-app-runner action` interface which standardizes the various actions of running app steps.
 - `bfabric-app-runner prepare workunit` to prepare a workunit execution and sets up a `app_env.yml` and `Makefile`.
 - `bfabric-app-runner deploy build-app-zip` experimental command to build an app zip file which can be deployed, for a
-    particular Python application.
+  particular Python application.
 
 ### Changed
 
 - Silently interpolate_config_strings log messages.
 - Update `bfabric` dependency to 1.13.27.
 - App versions do not always require a version key as it will default to "latest", but only one version can have a
-    particular version key per app definition.
+  particular version key per app definition.
 
 ### Fixed
 
 - Use most recent cyclopts version again, i.e. [issue 168](https://github.com/fgcz/bfabricPy/issues/168) is fixed.
 - Compatibility with pandera 0.24.0 was restored.
 
-## \[0.0.21\] - 2025-03-27
+## [0.0.21] - 2025-03-27
 
 ### Added
 
@@ -245,12 +245,12 @@ the user with the configured version by default.
 
 - Temporary workaround for https://github.com/fgcz/bfabricPy/issues/168.
 
-## \[0.0.20\] - 2025-03-25
+## [0.0.20] - 2025-03-25
 
 ### Changed
 
 - Input staging is now more efficient for large numbers of similar input types,
-    by batching the transformation into resolved operations.
+  by batching the transformation into resolved operations.
 
 ### Fixed
 
@@ -266,9 +266,9 @@ the user with the configured version by default.
 
 - `file_scp` spec has been removed, one should use `file` instead (`FileSpec`)
 - A lot of the old input handling code has been removed, it should not cause any problems, but mentioning this in case
-    it shows up after the release.
+  it shows up after the release.
 
-## \[0.0.19\] - 2025-02-28
+## [0.0.19] - 2025-02-28
 
 ### Added
 
@@ -279,26 +279,26 @@ the user with the configured version by default.
 
 - The `workunit.mk` Makefile now specifies Python 3.13 in the uv venv, so it is more reliable.
 
-## \[0.0.18\] - 2025-02-25
+## [0.0.18] - 2025-02-25
 
 ### Added
 
 - `static_yaml` input type to write parameters etc.
 - `dispatch.dispatch_resource_flow` implements a generic solution for dispatching resource flow workunits without
-    having to perform entity look up in many cases yourself.
+  having to perform entity look up in many cases yourself.
 - App Definition now supports omitting the collect step.
 
 ### Changed
 
 - `BfabricResourceSpec` defaults to file basename vs resource name, if no name is specified.
 
-## \[0.0.17\] - 2025-02-19
+## [0.0.17] - 2025-02-19
 
 ### Fixed
 
 - Update `bfabric` to 1.13.22 for dataset fix.
 
-## \[0.0.16\] - 2025-02-19
+## [0.0.16] - 2025-02-19
 
 ### Added
 
@@ -310,12 +310,12 @@ the user with the configured version by default.
 - CopyResourceSpec.update_existing now defaults to `if_exists`.
 - Resolve workunit_ref to absolute path if it is a Path instance for CLI.
 
-## \[0.0.15\] - 2025-02-06
+## [0.0.15] - 2025-02-06
 
 ### Added
 
 - New input type `file` which replaces `file_scp` and preserves timestamps whenever possible and allows to create
-    symlinks instead of copying the file, as needed.
+  symlinks instead of copying the file, as needed.
 - `BfabricOrderFastaSpec.required` which allows specifying whether the order fasta is required or not
 
 ### Changed
@@ -326,35 +326,35 @@ the user with the configured version by default.
 
 - Config: Log messages are shown by default again.
 
-## \[0.0.14\] - 2025-01-30
+## [0.0.14] - 2025-01-30
 
 ### Fixed
 
 - Correctly consume bfabricPy from PyPI.
 
-## \[0.0.13\] - 2025-01-28
+## [0.0.13] - 2025-01-28
 
 ### Added
 
 - `WorkunitDefinition.registration.workunit_name` field.
 
-## \[0.0.12\] - 2025-01-22
+## [0.0.12] - 2025-01-22
 
 ## Added
 
 - New input type `bfabric_order_fasta` which will place an order fasta file to the specified path, or create an empty
-    file if there is no order fasta available.
+  file if there is no order fasta available.
 - `--filter` flag has been added to `inputs prepare` and `inputs clean` commands.
 - The `app-runner app` commands now support passing a `AppVersion` yaml file instead of just a `AppSpec` yaml file.
 
-## \[0.0.11\] - 2025-01-16
+## [0.0.11] - 2025-01-16
 
 ### Added
 
 - New input type `BfabricAnnotationSpec`.
-    - For now, it only supports one type of annotation, which is `"resource_sample"`.
+  - For now, it only supports one type of annotation, which is `"resource_sample"`.
 
-## \[0.0.10\] - 2025-01-15
+## [0.0.10] - 2025-01-15
 
 ### Added
 
@@ -363,40 +363,40 @@ the user with the configured version by default.
 - `DispatchSingleDatasetFlow` dispatch a workunit in dataset-flow which consists of only one execution unit.
 - `DispatchSingleResourceFlow` dispatch a workunit in resource-flow which consists of only one execution unit.
 
-## \[0.0.9\] - 2025-01-09
+## [0.0.9] - 2025-01-09
 
 ### Added
 
 - App specs can now define multiple versions in one file. (AppSpec = Collection of app versions and other information.)
-    - To avoid boilerplate, mako templates can be used inside of strings.
-    - Apps will resolve the version to use based on the `application_version` field.
-    - Validation functionality for the new app specification has been added.
+  - To avoid boilerplate, mako templates can be used inside of strings.
+  - Apps will resolve the version to use based on the `application_version` field.
+  - Validation functionality for the new app specification has been added.
 - App versions can define a submitter, however this information is not yet used.
 
-## \[0.0.8\] - 2025-01-08
+## [0.0.8] - 2025-01-08
 
 ### Added
 
 - Register single file command: `bfabric-app-runner outputs register-single-file`
 - Implement copy resource `UpdateExisting.IF_EXISTS` and `UpdateExisting.REQUIRED` support.
 - The following fields have been added to `WorkunitRegistrationDefinition`:
-    - `storage_id`
-    - `storage_output_folder`
-    - `application_id`
-    - `application_name`
+  - `storage_id`
+  - `storage_output_folder`
+  - `application_id`
+  - `application_name`
 
 ### Changed
 
 - App-runner code related to output staging accepts workunit-definition file like the other steps.
 
-## \[0.0.7\] - 2024-11-22
+## [0.0.7] - 2024-11-22
 
 ### Fixed
 
 - When executing `app run` the experimental entity cache created incorrect behavior. The caching is temporarily disabled,
-    until the issue is resolved.
+  until the issue is resolved.
 
-## \[0.0.6\] - 2024-11-14
+## [0.0.6] - 2024-11-14
 
 First version with CD that will trigger the deployment automatically.
 
@@ -407,29 +407,29 @@ First version with CD that will trigger the deployment automatically.
 ### Changed
 
 - The app spec is now strict and will fail parsing if there are any unknown fields in the spec. It is better to find
-    this type of error early.
+  this type of error early.
 - Log messages originating in `app_runner` should be printed now, they were previously muted (unintentionally).
 
-## \[0.0.5\] - 2024-11-11
+## [0.0.5] - 2024-11-11
 
 ### Added
 
 - `CommandDocker.mac_address`: allows to specify the MAC address of the container.
 - `CommandDocker.custom_args`: allows to specify arbitrary additional arguments to the `docker run` command.
 
-## \[0.0.4\] - 2024-11-11
+## [0.0.4] - 2024-11-11
 
 ### Added
 
 - `MountOptions.writeable` list for writeable mount points.
 
-## \[0.0.3\] - 2024-10-24
+## [0.0.3] - 2024-10-24
 
 ### Added
 
 - Specify environment variables for docker container in spec.
 
-## \[0.0.2\] - 2024-10-23
+## [0.0.2] - 2024-10-23
 
 ### Added
 

--- a/bfabric_app_runner/docs/getting_started/installation.md
+++ b/bfabric_app_runner/docs/getting_started/installation.md
@@ -6,7 +6,6 @@
 - **uv**: [Install uv](https://docs.astral.sh/uv/getting-started/installation/) if you don't have it
 - **B-Fabric account**: You need valid B-Fabric credentials configured in `~/.bfabricpy.yml` (see the [bfabric Configuration Guide](https://fgcz.github.io/bfabricPy/getting_started/configuration.html))
 
-
 ## Installing as a CLI Tool (Recommended)
 
 The easiest way to install bfabric-app-runner is as an isolated CLI tool using `uv tool`:
@@ -31,7 +30,6 @@ uv tool run bfabric-app-runner@0.2.1 --help
 
 This is useful when an app's `app.yml` specifies a particular `app_runner` version.
 
-
 ## Development Installation
 
 To install from the Git repository for development:
@@ -41,7 +39,6 @@ git clone https://github.com/fgcz/bfabricPy.git
 cd bfabricPy
 uv sync --package bfabric_app_runner
 ```
-
 
 ## Verifying Installation
 
@@ -59,7 +56,6 @@ This displays the top-level command groups:
 - **inputs** -- Manage input files (prepare, clean, list, check)
 - **outputs** -- Register output files
 - **validate** -- Validate spec files (app-spec, inputs-spec, outputs-spec)
-
 
 ## Next Steps
 

--- a/bfabric_app_runner/docs/getting_started/quick_start.md
+++ b/bfabric_app_runner/docs/getting_started/quick_start.md
@@ -8,7 +8,6 @@ This tutorial walks through running a B-Fabric application workunit using bfabri
 2. **B-Fabric credentials configured**: `~/.bfabricpy.yml` must contain valid credentials
 3. **A workunit to process**: You need a workunit ID from B-Fabric
 
-
 ## Makefile Workflow (Interactive)
 
 The Makefile workflow is the recommended approach for development and debugging. It breaks execution into discrete steps that you can run, inspect, and re-run individually.
@@ -70,7 +69,6 @@ make stage
 
 Uploads results back to B-Fabric.
 
-
 ## Run Workunit (Unattended)
 
 For automated execution (e.g., from a Slurm script), use `run workunit` to execute all stages in sequence:
@@ -80,7 +78,6 @@ bfabric-app-runner run workunit <app_definition> <scratch_root> <workunit_ref>
 ```
 
 This runs dispatch, inputs, process, and outputs in a single invocation.
-
 
 ## Running Individual Actions
 
@@ -104,7 +101,6 @@ bfabric-app-runner action run-all --config app_env.yml
 
 Instead of `--config` you can pass the parameters explicitly, e.g.
 `action dispatch --work-dir ./work --app-ref app.yml --workunit-ref 12345`.
-
 
 ## Troubleshooting
 
@@ -145,7 +141,6 @@ For significant changes, use a development version of the app:
 ```bash
 bfabric-app-runner prepare workunit /path/to/app.yml ./work 12345 --force-app-version devel
 ```
-
 
 ## Next Steps
 

--- a/bfabric_app_runner/docs/specs/output_specification.md
+++ b/bfabric_app_runner/docs/specs/output_specification.md
@@ -52,7 +52,7 @@ Please note:
 - The workunit reference (an integer workunit ID or a path to a workunit definition YAML file) must
   be specified, so the correct information can be retrieved.
 - Several actions might require a particular user to be possible, e.g. the `bfabric_copy_resource` will require a user
-    with permission to create the particular file over SSH.
+  with permission to create the particular file over SSH.
 
 ## Reference
 

--- a/bfabric_app_runner/docs/user_guides/cli_reference.md
+++ b/bfabric_app_runner/docs/user_guides/cli_reference.md
@@ -6,10 +6,10 @@ Complete reference for the `bfabric-app-runner` command-line interface.
 
 Every command that talks to B-Fabric also accepts these options (omitted from the per-command listings below):
 
-| Option | Description |
-| -------------- | ------------------------------------------------------------------------------------- |
-| `--config-env` | Override the config environment; falls back to `BFABRICPY_CONFIG_ENV` or the file default |
-| `--config-file`| Override the config file path (default `~/.bfabricpy.yml`) |
+| Option          | Description                                                                               |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| `--config-env`  | Override the config environment; falls back to `BFABRICPY_CONFIG_ENV` or the file default |
+| `--config-file` | Override the config file path (default `~/.bfabricpy.yml`)                                |
 
 ## run
 
@@ -21,11 +21,11 @@ Run a workunit end-to-end (dispatch, process all chunks, register outputs).
 bfabric-app-runner run workunit <app_definition> <scratch_root> <workunit_ref>
 ```
 
-| Argument | Description |
-| ---------------- | ------------------------------------------- |
+| Argument         | Description                            |
+| ---------------- | -------------------------------------- |
 | `app_definition` | Path to the app.yml specification file |
-| `scratch_root` | Root directory for scratch/work files |
-| `workunit_ref` | Workunit reference (ID or URI) |
+| `scratch_root`   | Root directory for scratch/work files  |
+| `workunit_ref`   | Workunit reference (ID or URI)         |
 
 ## prepare
 
@@ -37,18 +37,18 @@ Prepare a workunit for execution (resolve inputs, set up work directory).
 bfabric-app-runner prepare workunit <app_spec> <work_dir> <workunit_ref> [options]
 ```
 
-| Argument | Description |
-| --------------- | ------------------------------------------- |
-| `app_spec` | Path to the app.yml specification file |
-| `work_dir` | Working directory for the workunit |
-| `workunit_ref` | Workunit reference (ID or URI) |
+| Argument       | Description                            |
+| -------------- | -------------------------------------- |
+| `app_spec`     | Path to the app.yml specification file |
+| `work_dir`     | Working directory for the workunit     |
+| `workunit_ref` | Workunit reference (ID or URI)         |
 
-| Option | Description |
-| ----------------------- | ---------------------------------------------------------- |
-| `--ssh-user` | SSH user for remote file access |
-| `--force-storage` | Override the storage location |
-| `--force-app-version` | Force a specific application version |
-| `--read-only` | Prepare in read-only mode |
+| Option                  | Description                          |
+| ----------------------- | ------------------------------------ |
+| `--ssh-user`            | SSH user for remote file access      |
+| `--force-storage`       | Override the storage location        |
+| `--force-app-version`   | Force a specific application version |
+| `--read-only`           | Prepare in read-only mode            |
 | `--use-external-runner` | Use an external runner for execution |
 
 ## action
@@ -110,15 +110,15 @@ Download and prepare input files into the target folder.
 bfabric-app-runner inputs prepare <inputs_yaml> [target_folder] [options]
 ```
 
-| Argument | Description |
-| --------------- | ------------------------------------------------ |
-| `inputs_yaml` | Path to the inputs YAML specification file |
+| Argument        | Description                                  |
+| --------------- | -------------------------------------------- |
+| `inputs_yaml`   | Path to the inputs YAML specification file   |
 | `target_folder` | Target directory (optional, defaults to cwd) |
 
-| Option | Description |
-| ------------ | ------------------------------------------------- |
-| `--ssh-user` | SSH user for remote file access |
-| `--filter` | Only prepare inputs matching this filename pattern |
+| Option       | Description                                        |
+| ------------ | -------------------------------------------------- |
+| `--ssh-user` | SSH user for remote file access                    |
+| `--filter`   | Only prepare inputs matching this filename pattern |
 
 ### inputs list
 
@@ -128,13 +128,13 @@ List all defined inputs and their status.
 bfabric-app-runner inputs list <inputs_yaml> [target_folder] [options]
 ```
 
-| Argument | Description |
-| --------------- | ------------------------------------------------ |
-| `inputs_yaml` | Path to the inputs YAML specification file |
+| Argument        | Description                                  |
+| --------------- | -------------------------------------------- |
+| `inputs_yaml`   | Path to the inputs YAML specification file   |
 | `target_folder` | Target directory (optional, defaults to cwd) |
 
-| Option | Description |
-| --------- | --------------------------------------------- |
+| Option    | Description                                  |
+| --------- | -------------------------------------------- |
 | `--check` | Also check whether each input exists on disk |
 
 ### inputs check
@@ -145,9 +145,9 @@ Verify that all expected input files are present.
 bfabric-app-runner inputs check <inputs_yaml> [target_folder]
 ```
 
-| Argument | Description |
-| --------------- | ------------------------------------------------ |
-| `inputs_yaml` | Path to the inputs YAML specification file |
+| Argument        | Description                                  |
+| --------------- | -------------------------------------------- |
+| `inputs_yaml`   | Path to the inputs YAML specification file   |
 | `target_folder` | Target directory (optional, defaults to cwd) |
 
 ### inputs clean
@@ -158,13 +158,13 @@ Remove prepared input files from the target folder.
 bfabric-app-runner inputs clean <inputs_yaml> [target_folder] [options]
 ```
 
-| Argument | Description |
-| --------------- | ------------------------------------------------ |
-| `inputs_yaml` | Path to the inputs YAML specification file |
+| Argument        | Description                                  |
+| --------------- | -------------------------------------------- |
+| `inputs_yaml`   | Path to the inputs YAML specification file   |
 | `target_folder` | Target directory (optional, defaults to cwd) |
 
-| Option | Description |
-| ---------- | ------------------------------------------------- |
+| Option     | Description                                      |
+| ---------- | ------------------------------------------------ |
 | `--filter` | Only clean inputs matching this filename pattern |
 
 ## outputs
@@ -179,15 +179,15 @@ Register all outputs defined in a YAML file.
 bfabric-app-runner outputs register <outputs_yaml> <workunit_ref> [options]
 ```
 
-| Argument | Description |
-| --------------- | ------------------------------------------------- |
+| Argument       | Description                                 |
+| -------------- | ------------------------------------------- |
 | `outputs_yaml` | Path to the outputs YAML specification file |
-| `workunit_ref` | Workunit reference (ID or URI) |
+| `workunit_ref` | Workunit reference (ID or URI)              |
 
-| Option | Description |
-| -------------------------- | ----------------------------------------------- |
-| `--ssh-user` | SSH user for remote file transfers |
-| `--force-storage` | Override the storage location |
+| Option            | Description                        |
+| ----------------- | ---------------------------------- |
+| `--ssh-user`      | SSH user for remote file transfers |
+| `--force-storage` | Override the storage location      |
 
 ### outputs register-single-file
 
@@ -197,18 +197,18 @@ Register a single output file without an outputs YAML.
 bfabric-app-runner outputs register-single-file <local_path> [options]
 ```
 
-| Argument | Description |
-| ------------ | ----------------------------------- |
+| Argument     | Description                        |
+| ------------ | ---------------------------------- |
 | `local_path` | Path to the local file to register |
 
-| Option | Description |
-| -------------------------- | ---------------------------------------------------------- |
-| `--workunit-ref` (required)| Workunit reference (ID or URI) |
-| `--store-entry-path` | Filename in B-Fabric storage |
-| `--store-folder-path` | Directory path within storage |
-| `--update-existing` | Update behavior: `no`, `if-exists`, or `required` (default `no`) |
-| `--ssh-user` | SSH user for remote transfers |
-| `--force-storage` | Override the storage location |
+| Option                      | Description                                                      |
+| --------------------------- | ---------------------------------------------------------------- |
+| `--workunit-ref` (required) | Workunit reference (ID or URI)                                   |
+| `--store-entry-path`        | Filename in B-Fabric storage                                     |
+| `--store-folder-path`       | Directory path within storage                                    |
+| `--update-existing`         | Update behavior: `no`, `if-exists`, or `required` (default `no`) |
+| `--ssh-user`                | SSH user for remote transfers                                    |
+| `--force-storage`           | Override the storage location                                    |
 
 ## validate
 
@@ -222,13 +222,13 @@ Validate an app specification file.
 bfabric-app-runner validate app-spec <app_yaml> [options]
 ```
 
-| Argument | Description |
-| ---------- | ----------------------------------- |
+| Argument   | Description              |
+| ---------- | ------------------------ |
 | `app_yaml` | Path to the app.yml file |
 
-| Option | Description |
-| ------------- | ------------------------------------------------ |
-| `--app-id` | Application ID for template variable resolution |
+| Option       | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `--app-id`   | Application ID for template variable resolution   |
 | `--app-name` | Application name for template variable resolution |
 
 ### validate app-spec-template
@@ -239,8 +239,8 @@ Validate an app specification template (before variable resolution).
 bfabric-app-runner validate app-spec-template <yaml_file>
 ```
 
-| Argument | Description |
-| ----------- | -------------------------------------- |
+| Argument    | Description                        |
+| ----------- | ---------------------------------- |
 | `yaml_file` | Path to the app spec template file |
 
 ### validate inputs-spec
@@ -251,8 +251,8 @@ Validate an inputs specification file.
 bfabric-app-runner validate inputs-spec <yaml_file>
 ```
 
-| Argument | Description |
-| ----------- | ---------------------------------------- |
+| Argument    | Description                  |
+| ----------- | ---------------------------- |
 | `yaml_file` | Path to the inputs YAML file |
 
 ### validate outputs-spec
@@ -263,6 +263,6 @@ Validate an outputs specification file.
 bfabric-app-runner validate outputs-spec <yaml_file>
 ```
 
-| Argument | Description |
-| ----------- | ----------------------------------------- |
+| Argument    | Description                   |
+| ----------- | ----------------------------- |
 | `yaml_file` | Path to the outputs YAML file |

--- a/bfabric_app_runner/docs/user_guides/creating_an_app.md
+++ b/bfabric_app_runner/docs/user_guides/creating_an_app.md
@@ -80,7 +80,7 @@ When multiple versions share a definition, the following template variables are 
 
 `${app.dir}`
 : The directory containing the `app.yml`. Use it for paths that are not path fields, i.e. inside a
-  `command` string or an `env` value, where they cannot be resolved automatically.
+`command` string or an `env` value, where they cannot be resolved automatically.
 
 These variables use Mako template interpolation and are resolved when the app spec is loaded.
 

--- a/bfabric_app_runner/docs/user_guides/index.md
+++ b/bfabric_app_runner/docs/user_guides/index.md
@@ -14,14 +14,14 @@ cli_reference
 
 ## Guides Overview
 
-| Guide | Description | Skill Level |
-| --------------------------------------------------------- | ---------------------------------------------------- | ------------ |
-| [Creating an App](creating_an_app.md) | Define app specs, versions, and commands | Beginner |
-| [Deploying Apps](deploying_apps.md) | Build and deploy Python apps with uv | Intermediate |
-| [Working with Inputs](working_with_inputs.md) | Resolve and prepare input files for app execution | Intermediate |
-| [Working with Outputs](working_with_outputs.md) | Register output files and datasets in B-Fabric | Intermediate |
-| [Python Environments](python_environments.md) | Cached and ephemeral environment management | Advanced |
-| [CLI Reference](cli_reference.md) | Complete command-line reference | All Levels |
+| Guide                                           | Description                                       | Skill Level  |
+| ----------------------------------------------- | ------------------------------------------------- | ------------ |
+| [Creating an App](creating_an_app.md)           | Define app specs, versions, and commands          | Beginner     |
+| [Deploying Apps](deploying_apps.md)             | Build and deploy Python apps with uv              | Intermediate |
+| [Working with Inputs](working_with_inputs.md)   | Resolve and prepare input files for app execution | Intermediate |
+| [Working with Outputs](working_with_outputs.md) | Register output files and datasets in B-Fabric    | Intermediate |
+| [Python Environments](python_environments.md)   | Cached and ephemeral environment management       | Advanced     |
+| [CLI Reference](cli_reference.md)               | Complete command-line reference                   | All Levels   |
 
 ## Common Workflows
 

--- a/bfabric_app_runner/docs/user_guides/python_environments.md
+++ b/bfabric_app_runner/docs/user_guides/python_environments.md
@@ -105,9 +105,9 @@ commands:
 
 ## When to Use Refresh Mode
 
-| Scenario | `refresh` | Rationale |
-| ----------------------------- | --------- | ----------------------------------------- |
-| Production deployment | `false` | Stable, cached environment for speed |
-| Active development | `true` | Pick up source code changes immediately |
-| Debugging dependency issues | `true` | Start fresh to isolate problems |
-| CI/CD testing | `true` | Ensure clean environment each run |
+| Scenario                    | `refresh` | Rationale                               |
+| --------------------------- | --------- | --------------------------------------- |
+| Production deployment       | `false`   | Stable, cached environment for speed    |
+| Active development          | `true`    | Pick up source code changes immediately |
+| Debugging dependency issues | `true`    | Start fresh to isolate problems         |
+| CI/CD testing               | `true`    | Ensure clean environment each run       |

--- a/bfabric_app_runner/examples/README.md
+++ b/bfabric_app_runner/examples/README.md
@@ -14,39 +14,39 @@ Copier templates for creating BFabric app runner applications with proper struct
 
 1. **Generate from template:**
 
-    ```bash
-    uvx copier copy ~/code/bfabricPy/bfabric_app_runner/examples/template $PWD/my_app
-    # Enter your project name when prompted
-    ```
+   ```bash
+   uvx copier copy ~/code/bfabricPy/bfabric_app_runner/examples/template $PWD/my_app
+   # Enter your project name when prompted
+   ```
 
-    Give the destination as an absolute path: it is written into `bfabric_app.xml` as the
-    `<program>` path that B-Fabric uses to find `app.yml`. The paths in `app.yml` itself are
-    relative to the app directory, so the app can be moved or checked out elsewhere.
+   Give the destination as an absolute path: it is written into `bfabric_app.xml` as the
+   `<program>` path that B-Fabric uses to find `app.yml`. The paths in `app.yml` itself are
+   relative to the app directory, so the app can be moved or checked out elsewhere.
 
 2. **Test in development mode:**
 
-    ```bash
-    cd my_app
-    uv lock -U
-    uv export --no-emit-project --format pylock.toml > pylock.toml
+   ```bash
+   cd my_app
+   uv lock -U
+   uv export --no-emit-project --format pylock.toml > pylock.toml
 
-    # Test with workunit
-    bfabric-app-runner prepare workunit app.yml \
-      --work-dir workdir \
-      --workunit-ref <WORKUNIT_ID> \
-      --read-only \
-      --force-app-version devel
-    ```
+   # Test with workunit
+   bfabric-app-runner prepare workunit app.yml \
+     --work-dir workdir \
+     --workunit-ref <WORKUNIT_ID> \
+     --read-only \
+     --force-app-version devel
+   ```
 
 3. **Run the workflow:**
 
-    ```bash
-    cd workdir
-    make dispatch    # Initialize workflow
-    make inputs      # Prepare input data
-    make process     # Execute main processing
-    make stage       # (Optional) Stage results
-    ```
+   ```bash
+   cd workdir
+   make dispatch    # Initialize workflow
+   make inputs      # Prepare input data
+   make process     # Execute main processing
+   make stage       # (Optional) Stage results
+   ```
 
 ## Moving to Production
 
@@ -54,22 +54,22 @@ Once you've tested your application in development mode, you can build it for pr
 
 1. **Update version in pyproject.toml:**
 
-    **Important**: Always increase the version number before creating a release. Do not reuse existing versions.
+   **Important**: Always increase the version number before creating a release. Do not reuse existing versions.
 
 2. **Build the application:**
 
-    ```bash
-    bash release.bash
-    ```
+   ```bash
+   bash release.bash
+   ```
 
 3. **Test the production build:**
 
-    ```bash
-    bfabric-app-runner prepare workunit app.yml \
-      --work-dir workdir \
-      --workunit-ref <WORKUNIT_ID> \
-      --read-only
-    ```
+   ```bash
+   bfabric-app-runner prepare workunit app.yml \
+     --work-dir workdir \
+     --workunit-ref <WORKUNIT_ID> \
+     --read-only
+   ```
 
 Production mode uses packaged wheel files from `dist/` with isolated dependencies, while development mode uses source code directly.
 

--- a/bfabric_asgi_auth/docs/changelog.md
+++ b/bfabric_asgi_auth/docs/changelog.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## \[Unreleased\]
+## [Unreleased]
 
 ### Changed
 
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed redirect URL scheme handling: protocol-relative URLs (//example.com) and absolute URLs with wrong scheme are now corrected based on X-Forwarded-Proto headers
 - Honor `scope["root_path"]` when the app is mounted behind a reverse-proxy sub-path: landing/logout matching strips a leading `root_path` from `scope["path"]`, and root-relative redirect targets (e.g. `authenticated_path="/"`) are prefixed with `root_path` so the browser lands at the correct public URL
 
-## \[0.0.1\] - 2026-01-06
+## [0.0.1] - 2026-01-06
 
 ### Added
 

--- a/bfabric_rest_proxy/docs/changelog.md
+++ b/bfabric_rest_proxy/docs/changelog.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## \[Unreleased\]
+## [Unreleased]
 
 ### Changed
 

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -8,7 +8,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - `Y` is increased for feature releases, that should not break the API
 - `Z` is increased for bug-fix releases
 
-## \[Unreleased\]
+## [Unreleased]
 
 ### Added
 
@@ -34,7 +34,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - `auth register-webapp` prints `Error: ...` and exits 1 when the OAuth session cannot be refreshed, instead of a raw traceback.
 - `auth register` no longer prompts for an *Employee Bearer token* when a login exists; it authenticates as the environment in effect.
 
-## \[1.16.0\] - 2026-08-03
+## [1.16.0] - 2026-08-03
 
 - `bfabric-cli auth` — OAuth authentication & client management. Login: `login` (browser), `device-code` (headless), `pat`; client registration: `register` / `register-webapp`; environment management: `default`, `list`, `status`, `logout`. Scope presets (`read-only` / `read-write` / `upload`) or a raw scope, via an interactive picker when `--scope` is omitted in a terminal; no baked-in default scope, so a headless run must pass `--scope` (registration keeps the OIDC-inclusive default webapps need). When `--config-env` is omitted it prompts for the environment (else targets the current default / `PRODUCTION`); unless `--set-default` / `--no-set-default` is given it asks (default yes) whether to make the env the default, and cancelling that prompt aborts the login. `status` reports an OAuth env's cached-token freshness and granted scope (annotated with the matching preset); `logout` removes an env's config entry and cached tokens (confirmation required). PATs are stored under a `pat` key (`auth_method: pat`), keeping the config parseable by ≤1.19.0 clients.
 - `bfabric-cli workunit upload FILES...` — upload files/directories to a workunit over tus (resumable, large-file capable): new or `--workunit-id`, one resource per file, skips duplicates (`--force`), live progress (`--no-progress`), optional `--track-job`. Requires an OAuth client with the `tus` scope.
@@ -43,7 +43,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - `bfabric-cli dataset update` — update an existing dataset with a change preview before confirming (`csv`/`tsv`/`xlsx`/`parquet`).
 - Internal: `dataset upload` / `bfabric_save_csv2dataset.py` use `bfabric.operations.dataset.create_dataset`; API error handling centralized in `@use_client` (dropped `@logger.catch`); `--config-env` naming unified; `lxml` now an explicit dep (was transitive via optional `zeep`); requires `bfabric[transfer]>=1.20`; adds `questionary`-based `cli.interactive` helpers and `config_writer.remove_environment_from_config`.
 
-## \[1.15.0\] - 2026-04-20
+## [1.15.0] - 2026-04-20
 
 ### Added
 
@@ -59,7 +59,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - `PathConventionMS` now handles instruments with a number in the name before the underscore character.
 
-## \[1.14.0\] - 2026-03-12
+## [1.14.0] - 2026-03-12
 
 ### Added
 
@@ -69,19 +69,19 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - `bfabric-cli api read` and `bfabric-cli executable upload` diagnostic/informational output is now routed through loguru, so it can be silenced via `BFABRICPY_LOG_LEVEL=OFF` (or `WARNING`/`ERROR`/`CRITICAL`).
 
-## \[1.13.40\] - 2025-12-16
+## [1.13.40] - 2025-12-16
 
 ### Added
 
 - `bfabric-cli api inspect` to inspect various API endpoints directly from the command line.
 
-## \[1.13.39\] - 2025-12-03
+## [1.13.39] - 2025-12-03
 
 ### Fixed
 
 - Fix bfabric_read_samples_of_workunit.py returns the same column name `groupingvar_name` as in the past.
 
-## \[1.13.38\] - 2025-12-03
+## [1.13.38] - 2025-12-03
 
 ### Changed
 
@@ -93,7 +93,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - Fix bfabric_read_samples_of_workunit.py ordering.
 
-## \[1.13.37\] - 2025-10-27
+## [1.13.37] - 2025-10-27
 
 ### Changed
 
@@ -102,7 +102,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - Update `bfabric` to `1.13.36`.
 - Update `cyclopts` to `4.*`
 
-## \[1.13.36\] - 2025-10-13
+## [1.13.36] - 2025-10-13
 
 ### Removed
 
@@ -117,13 +117,13 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - `bfabric_flask.py` didn't log exceptions properly because it passed the wrong argument `exc_info` instead of `exception`.
 - Legacy: `bfabric_save_workflowstep.py` reads config from `~/slurmworker/config/legacy_template_steps.yml`. Not relevant for bfabric-app-runner apps.
 
-## \[1.13.35\] - 2025-09-25
+## [1.13.35] - 2025-09-25
 
 ### Changed
 
 - `bfabric_list_not_existing_storage_directories.py` is made more robust. Instead of the file based cache, it will check all containers modified within a sliding time window (default 14 days).
 
-## \[1.13.34\] - 2025-09-22
+## [1.13.34] - 2025-09-22
 
 ### Fixed
 
@@ -133,13 +133,13 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - Update `bfabric` to include case-insensitive dataset column type detection support.
 
-## \[1.13.33\] - 2025-08-26
+## [1.13.33] - 2025-08-26
 
 ### Changed
 
 - Update `bfabric` to 1.13.32.
 
-## \[1.13.32\] - 2025-08-20
+## [1.13.32] - 2025-08-20
 
 ### Fixed
 
@@ -149,7 +149,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - Update `bfabric` to 1.13.31.
 
-## \[1.13.31\] - 2025-08-19
+## [1.13.31] - 2025-08-19
 
 ### Fixed
 
@@ -159,7 +159,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - Update `bfabric` to 1.13.30. This includes a fix for legacy wrapper creator.
 
-## \[1.13.30\] - 2025-07-04
+## [1.13.30] - 2025-07-04
 
 ### Added
 
@@ -169,7 +169,7 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - `bfabric_flask.py` is not exported as a script anymore, because misuse can lead to security issues and should be deployed properly.
 
-## \[1.13.29\] - 2025-06-27
+## [1.13.29] - 2025-06-27
 
 ### Removed
 
@@ -188,11 +188,11 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 ### Changed
 
 - Columns of tables named after B-Fabric entities, containing only integers, will be set as the specified type
-    when saving to B-Fabric.
+  when saving to B-Fabric.
 - Update `bfabric` to 1.13.28.
 - Update legacy `bfabric_logthis.py`, the workunit target logic has been removed (unused).
 
-## \[1.13.28\] - 2025-05-21
+## [1.13.28] - 2025-05-21
 
 ### Removed
 
@@ -204,18 +204,18 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - Update `bfabric` to 1.13.27.
 - `bfabric-cli api delete` will use the type of the entity in CLI messages.
 
-## \[1.13.27\] - 2025-04-22
+## [1.13.27] - 2025-04-22
 
 ### Changed
 
 - `bfabric-cli dataset upload` will print warnings when trailing whitespace is detected and not print the whole
-    response anymore, but rather the important information only.
+  response anymore, but rather the important information only.
 
 ### Added
 
 - Optional support for uploading xlsx (currently behind `excel` optional feature).
 
-## \[1.13.26\] - 2025-04-08
+## [1.13.26] - 2025-04-08
 
 ### Changed
 
@@ -229,19 +229,19 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - Use most recent cyclopts version again, i.e. [issue 168](https://github.com/fgcz/bfabricPy/issues/168) is fixed.
 
-## \[1.13.25\] - 2025-03-27
+## [1.13.25] - 2025-03-27
 
 ### Fixed
 
 - Temporary workaround for https://github.com/fgcz/bfabricPy/issues/168.
 
-## \[1.13.24\] - 2025-02-19
+## [1.13.24] - 2025-02-19
 
 ### Fixed
 
 - Update `bfabric` to 1.13.22 for dataset fix.
 
-## \[1.13.23\] - 2025-02-19
+## [1.13.23] - 2025-02-19
 
 ### Added
 
@@ -250,37 +250,37 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 - `bfabric-cli api create` command to create a new entity
 - `bfabric-cli api delete` command to delete an existing entity
 
-## \[1.13.22\] - 2025-02-17
+## [1.13.22] - 2025-02-17
 
 ### Fixed
 
 - Fix printing of YAML for parsing with shyaml, previously line breaks could have been introduced.
 
-## \[1.13.21\] - 2025-02-11
+## [1.13.21] - 2025-02-11
 
 ### Fixed
 
 - Add missing default value for columns in `bfabric-cli api read`
 
-## \[1.13.20\] - 2025-02-10
+## [1.13.20] - 2025-02-10
 
 ### Added
 
 - `bfabric-cli workunit not-available`:
-    - allows sorting by arbitrary fields, e.g. application id
-    - allows filtering inclusive or exclusive by user
+  - allows sorting by arbitrary fields, e.g. application id
+  - allows filtering inclusive or exclusive by user
 
 ### Changed
 
 - Pin bfabricPy version to avoid future headaches.
 - `bfabric-cli api read`
-    - Removes the automatic output type logic
-    - Multiple values can be submitted for the same key (just specify it multiple times)
-    - The actual query will be printed as a line of bfabricPy code
-    - `--file` parameter to write the output to a specific file
-    - Argument parsing is handled with pydantic now
-    - Added tsv support
+  - Removes the automatic output type logic
+  - Multiple values can be submitted for the same key (just specify it multiple times)
+  - The actual query will be printed as a line of bfabricPy code
+  - `--file` parameter to write the output to a specific file
+  - Argument parsing is handled with pydantic now
+  - Added tsv support
 
-## \[1.13.19\] - 2025-01-29
+## [1.13.19] - 2025-01-29
 
 Initial release of standalone bfabric_scripts package.

--- a/noxfile.py
+++ b/noxfile.py
@@ -424,12 +424,12 @@ def changelog(session: nox.Session, package):
     except FileNotFoundError:
         session.error(f"Changelog not found at {changelog_path}")
 
-    # Look for version header with escaped brackets
-    version_pattern = rf"## \\\[{re.escape(current_version)}\\\]"
+    # Tolerate the historical escaped form, `## \[1.2.3\]`, still present in older sections
+    version_pattern = rf"## \\?\[{re.escape(current_version)}\\?\]"
     if not re.search(version_pattern, changelog_content):
         session.error(
             f"{changelog_path} does not contain entry for version {current_version}.\n"
-            f"Expected to find a section starting with: ## \\[{current_version}\\]"
+            f"Expected to find a section starting with: ## [{current_version}]"
         )
 
     session.log(f"✓ {changelog_path} contains entry for version {current_version}")


### PR DESCRIPTION
- Re-enable the `mdformat` pre-commit hook, pinned to mdformat 1.0.0 with `mdformat-gfm` (tables) and `mdformat-simple-breaks` (`---` rather than a row of 70 underscores). Markdown formatting is deterministic again after being off since February.
- Reformat 45 markdown files once: table padding, CommonMark nested-list indent, blank lines around fences. Changelog headings lose their backslash escaping, `## \[1.20.0\]` becomes `## [1.20.0]`, so `nox -s changelog` now accepts both forms and the extract-changelog action gained a test for the unescaped one.
- The February regression came from #424 bumping the hook 0.7.17 -> 1.0.0 while also dropping `mdformat-mkdocs`. The reformat committed in 989f4bc1 is byte-for-byte the output of the *old* pin, so it came from a stale local mdformat, not from the pinned hook.
- Caveat: 45 reformatted files will conflict with any in-flight branch that edits a changelog. Resolve by taking either side and re-running `pre-commit run mdformat --all-files`.

Closes #437

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.