### PR TITLE
Run legacy apps under app-runner without the wrapper creator

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - New `${app.dir}` template variable holding the app spec's directory, for paths no spec field resolves — e.g. `command: uv run --script ${app.dir}/dispatch.py`.
 - New `legacy_wrapper_yaml` input type writes the legacy wrapper-creator `config.yaml` for a workunit, so pre-app-runner apps can run without the old wrapper creator ([#262](https://github.com/fgcz/bfabricPy/issues/262)). It reads only, so the YAML carries no external job and no `slurm_stdout`/`slurm_stderr` resources; see the "Running Legacy Apps" guide.
-- New `legacy dispatch`, `legacy run` and `legacy collect` commands wrap a legacy app end-to-end from an `app.yml` with no per-app Python: `run` shadows the status-writing `bfabric_*` commands it calls with no-ops, and `collect` declares its output in `outputs.yml`.
+- New `legacy dispatch` and `legacy run` commands wrap a legacy app end-to-end from an `app.yml` with no per-app Python: `run` shadows the status-writing `bfabric_*` commands it calls with no-ops, then declares its output in `outputs.yml` so no `collect` command is needed.
 - `legacy run` also redirects `bfabric_upload_resource.py` to record its file instead of uploading it, so a legacy app's extra resources are registered on the application's storage instead of being base64-uploaded to B-Fabric's internal storage.
 
 ### Changed

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - New `${app.dir}` template variable holding the app spec's directory, for paths no spec field resolves — e.g. `command: uv run --script ${app.dir}/dispatch.py`.
+- New `legacy_wrapper_yaml` input type writes the legacy wrapper-creator `config.yaml` for a workunit, so pre-app-runner apps can run without the old wrapper creator ([#262](https://github.com/fgcz/bfabricPy/issues/262)). It reads only, so the YAML carries no external job and no `slurm_stdout`/`slurm_stderr` resources; see the "Running Legacy Apps" guide.
+- New `legacy dispatch`, `legacy run` and `legacy collect` commands wrap a legacy app end-to-end from an `app.yml` with no per-app Python: `run` shadows the status-writing `bfabric_*` commands it calls with no-ops, and `collect` declares its output in `outputs.yml`.
+- `legacy run` also redirects `bfabric_upload_resource.py` to record its file instead of uploading it, so a legacy app's extra resources are registered on the application's storage instead of being base64-uploaded to B-Fabric's internal storage.
 
 ### Changed
 

--- a/bfabric_app_runner/docs/user_guides/index.md
+++ b/bfabric_app_runner/docs/user_guides/index.md
@@ -10,6 +10,7 @@ working_with_inputs
 working_with_outputs
 python_environments
 cli_reference
+running_legacy_apps
 ```
 
 ## Guides Overview
@@ -22,6 +23,7 @@ cli_reference
 | [Working with Outputs](working_with_outputs.md) | Register output files and datasets in B-Fabric | Intermediate |
 | [Python Environments](python_environments.md) | Cached and ephemeral environment management | Advanced |
 | [CLI Reference](cli_reference.md) | Complete command-line reference | All Levels |
+| [Running Legacy Apps](running_legacy_apps.md) | Compatibility shim for pre-app-runner apps | Advanced |
 
 ## Common Workflows
 

--- a/bfabric_app_runner/docs/user_guides/running_legacy_apps.md
+++ b/bfabric_app_runner/docs/user_guides/running_legacy_apps.md
@@ -7,7 +7,7 @@ app-runner without the wrapper creator, submitter and external-job machinery
 
 ## The app spec
 
-Wrapping a legacy app needs no Python: three `legacy` commands cover the whole lifecycle, and each
+Wrapping a legacy app needs no Python: two `legacy` commands cover the whole lifecycle, and each
 receives its trailing argument from the usual calling convention.
 
 ```yaml
@@ -27,9 +27,6 @@ versions:
         command: >-
           bfabric-app-runner legacy run
           /home/bfabric/slurmworker/bin/fgcz_slurm_maxquant_linux.bash
-      collect:
-        type: exec
-        command: bfabric-app-runner legacy collect
 ```
 
 `legacy dispatch` writes a single chunk whose `inputs.yml` holds exactly one entry, the legacy YAML.
@@ -38,12 +35,13 @@ staged. The app's output is placed at `<chunk_dir>/output-WU<id>.zip`; use `--ou
 app whose output is not a zip.
 
 `legacy run` invokes the app with the YAML path as its last argument, which is the convention the
-legacy submitter used, with the shims described below on `PATH`.
+legacy submitter used, with the shims described below on `PATH`. Once the app succeeds it writes the
+chunk's `outputs.yml`, since a legacy app deposits its files where the YAML told it to but cannot
+declare them for registration. There is deliberately no `collect` command: doing this at the end of
+the process step keeps a legacy app spec to the same two commands a modern app uses, and leaves a
+hand-corrected `outputs.yml` alone when you re-run `make stage`.
 
-`legacy collect` writes the chunk's `outputs.yml`, since a legacy app deposits its files where the
-YAML told it to but cannot declare them for registration.
-
-All three take `--config-filename` if the YAML should not be called `config.yaml`.
+Both take `--config-filename` if the YAML should not be called `config.yaml`.
 
 ## The generated YAML
 
@@ -96,7 +94,7 @@ the wrong entity.
 `bfabric_upload_resource.py` is redirected rather than neutralised. The real command base64s the file
 over SOAP, which makes B-Fabric file the resource on its own internal storage instead of the
 application's. The shim instead appends the file's absolute path to `<chunk_dir>/legacy_uploads.txt`,
-and `legacy collect` declares it like any other output --- so a legacy app's extra resources land on
+which `legacy run` then declares like any other output --- so a legacy app's extra resources land on
 the same storage as its main output, and the internal repo stays out of it. The file is referenced
 where the app left it rather than copied, since no legacy app removes its scratch directory before
 exiting. A missing file is ignored rather than fatal, matching the `|| { echo failed; }` these calls
@@ -106,14 +104,14 @@ Because those uploads are now registered at the outputs step rather than mid-run
 *after* uploading extra resources no longer leaves them behind in B-Fabric. In practice those calls
 sit on the success path, after the main output has been written.
 
-## What `collect` accepts
+## What gets registered
 
 Uploads keep the order the app made them in, and the same path uploaded twice is recorded once.
 
 A few legacy apps only ever upload extra resources and never write the declared output at all. If
-the declared output is missing but uploads were recorded, `collect` warns and registers just the
+the declared output is missing but uploads were recorded, the run warns and registers just the
 uploads; if nothing at all was produced, it fails. An app that *should* have written its output fails
-its own `scp` first, which fails the process step, so `collect` never runs in that case.
+its own `scp` first, and a non-zero exit means no `outputs.yml` is written at all.
 
 It also fails if the declared output is a remote `host:path` destination app-runner cannot register
 locally, if a recorded upload has since disappeared, or if two different files would claim the same

--- a/bfabric_app_runner/docs/user_guides/running_legacy_apps.md
+++ b/bfabric_app_runner/docs/user_guides/running_legacy_apps.md
@@ -1,0 +1,130 @@
+# Running Legacy Apps
+
+Compatibility shim for applications written against the old wrapper creator, which expect a
+`config.yaml` in the legacy format as their sole argument. It exists so those apps can run under
+app-runner without the wrapper creator, submitter and external-job machinery
+([#262](https://github.com/fgcz/bfabricPy/issues/262)). Do not use it for new apps.
+
+## The app spec
+
+Wrapping a legacy app needs no Python: three `legacy` commands cover the whole lifecycle, and each
+receives its trailing argument from the usual calling convention.
+
+```yaml
+bfabric:
+  app_runner: 0.8.0
+versions:
+  - version:
+      - 1.0.0
+    commands:
+      dispatch:
+        type: exec
+        command: >-
+          bfabric-app-runner legacy dispatch
+          --executable /home/bfabric/slurmworker/bin/fgcz_slurm_maxquant_linux.bash
+      process:
+        type: exec
+        command: >-
+          bfabric-app-runner legacy run
+          /home/bfabric/slurmworker/bin/fgcz_slurm_maxquant_linux.bash
+      collect:
+        type: exec
+        command: bfabric-app-runner legacy collect
+```
+
+`legacy dispatch` writes a single chunk whose `inputs.yml` holds exactly one entry, the legacy YAML.
+A legacy app fetches its own input resources from the scp URLs inside that YAML, so nothing else is
+staged. The app's output is placed at `<chunk_dir>/output-WU<id>.zip`; use `--output-filename` for an
+app whose output is not a zip.
+
+`legacy run` invokes the app with the YAML path as its last argument, which is the convention the
+legacy submitter used, with the shims described below on `PATH`.
+
+`legacy collect` writes the chunk's `outputs.yml`, since a legacy app deposits its files where the
+YAML told it to but cannot declare them for registration.
+
+All three take `--config-filename` if the YAML should not be called `config.yaml`.
+
+## The generated YAML
+
+The resolved file has the same two sections the wrapper creator produced --- `application`
+(`parameters`, `protocol`, `input`, `output`) and `job_configuration`. Resolution only reads from
+B-Fabric, so it is safe to re-run `inputs prepare`, `inputs list` and `inputs check`.
+
+Two things are deliberately absent, because app-runner already owns the state they represented.
+
+**No external job.** `job_configuration.external_job_id` is `0`. Nothing creates an external job,
+and `bfabric_setExternalJobStatus_done.py` has nothing to mark done.
+
+**No log resources.** The wrapper creator registered a `slurm_stdout` and a `slurm_stderr` resource
+on the SlurmLog storage and pointed Slurm's `-o`/`-e` at them. app-runner captures stdout and
+stderr itself into a single timestamped log, so `job_configuration.stdout` and `stderr` carry
+`resource_id: 0` and `url: /dev/null`, and no resource is created. The log is not reachable from
+the B-Fabric UI.
+
+Every resource id in the YAML is `0` for the same reason --- app-runner creates the output resource
+during output registration, not up front. `0` rather than `null` keeps a consumer that flattens the
+YAML into shell variables working under `set -u`.
+
+To drive the input spec directly rather than through `legacy dispatch`, the entry is:
+
+```yaml
+inputs:
+  - type: legacy_wrapper_yaml
+    filename: config.yaml
+    workunit_id: 349972
+    output_path: /scratch/A224_MaxQuant/WU349972/work/output-WU349972.zip
+    executable: /home/bfabric/slurmworker/bin/fgcz_slurm_maxquant_linux.bash
+```
+
+`output_path` is where the app should deposit its output. Pointing it inside the chunk directory
+makes the app's `scp` degrade to a local copy, so app-runner can register the file afterwards. It is
+a spec field rather than something the resolver derives, because only the dispatcher knows the chunk
+directory. `executable` overrides `job_configuration.executable`; without it the application's own
+`program` field is used, which under app-runner points at the `app.yml` rather than at the legacy app.
+
+## The shims
+
+For the duration of `legacy run`, a directory of shims is prepended to `PATH`.
+
+Six are no-ops: `bfabric_setResourceStatus_available.py`,
+`bfabric_setWorkunitStatus_{processing,available,failed}.py`, `bfabric_setExternalJobStatus_done.py`
+and `bfabric_save_workflowstep.py`. All of them duplicate work app-runner already does, and the ids
+they would be handed are sentinels, so left alone they would at best be redundant and at worst mark
+the wrong entity.
+
+`bfabric_upload_resource.py` is redirected rather than neutralised. The real command base64s the file
+over SOAP, which makes B-Fabric file the resource on its own internal storage instead of the
+application's. The shim instead appends the file's absolute path to `<chunk_dir>/legacy_uploads.txt`,
+and `legacy collect` declares it like any other output --- so a legacy app's extra resources land on
+the same storage as its main output, and the internal repo stays out of it. The file is referenced
+where the app left it rather than copied, since no legacy app removes its scratch directory before
+exiting. A missing file is ignored rather than fatal, matching the `|| { echo failed; }` these calls
+are usually wrapped in.
+
+Because those uploads are now registered at the outputs step rather than mid-run, an app that fails
+*after* uploading extra resources no longer leaves them behind in B-Fabric. In practice those calls
+sit on the success path, after the main output has been written.
+
+## What `collect` accepts
+
+Uploads keep the order the app made them in, and the same path uploaded twice is recorded once.
+
+A few legacy apps only ever upload extra resources and never write the declared output at all. If
+the declared output is missing but uploads were recorded, `collect` warns and registers just the
+uploads; if nothing at all was produced, it fails. An app that *should* have written its output fails
+its own `scp` first, which fails the process step, so `collect` never runs in that case.
+
+It also fails if the declared output is a remote `host:path` destination app-runner cannot register
+locally, if a recorded upload has since disappeared, or if two different files would claim the same
+resource name --- B-Fabric allows a resource name only once per workunit.
+
+## Known limitation
+
+Most apps read the output path via `fgcz_yaml2.bash`, which uses `shyaml get-value
+application.output.-1` and so passes a colon-free local path through unchanged. A few parse it
+themselves and assume a `host:path` shape --- `fgcz_slurm_maxquant_textfiles.bash` does
+`cut -d":" -f2`, and `fgcz_slurm_SummarizedExperiment_A315.bash` runs a `sed` expecting a
+`p<number>/` segment. Those need adapting before they can run this way; `output_path` accepts a real
+scp URL as an escape hatch, but then the app uploads to storage itself and the file is no longer
+local when app-runner would register it.

--- a/bfabric_app_runner/docs/user_guides/running_legacy_apps.md
+++ b/bfabric_app_runner/docs/user_guides/running_legacy_apps.md
@@ -75,11 +75,12 @@ inputs:
     executable: /home/bfabric/slurmworker/bin/fgcz_slurm_maxquant_linux.bash
 ```
 
-`output_path` is where the app should deposit its output. Pointing it inside the chunk directory
-makes the app's `scp` degrade to a local copy, so app-runner can register the file afterwards. It is
-a spec field rather than something the resolver derives, because only the dispatcher knows the chunk
-directory. `executable` overrides `job_configuration.executable`; without it the application's own
-`program` field is used, which under app-runner points at the `app.yml` rather than at the legacy app.
+`output_path` is where the app should deposit its output, and must be an absolute path inside the
+chunk directory: that makes the app's `scp` degrade to a local copy, so app-runner can register the
+file afterwards. It is a spec field rather than something the resolver derives, because only the
+dispatcher knows the chunk directory. `executable` overrides `job_configuration.executable`; without
+it the application's own `program` field is used, which under app-runner points at the `app.yml`
+rather than at the legacy app.
 
 ## The shims
 
@@ -89,7 +90,15 @@ Six are no-ops: `bfabric_setResourceStatus_available.py`,
 `bfabric_setWorkunitStatus_{processing,available,failed}.py`, `bfabric_setExternalJobStatus_done.py`
 and `bfabric_save_workflowstep.py`. All of them duplicate work app-runner already does, and the ids
 they would be handed are sentinels, so left alone they would at best be redundant and at worst mark
-the wrong entity.
+the wrong entity. Neutralising `..._failed.py` loses nothing, because app-runner derives failure from
+the process command's exit status: every app that calls it either exits non-zero straight afterwards
+or fires it from an EXIT trap. Each shim echoes what it swallowed to stderr, which app-runner logs.
+
+Write commands that take the *real* workunit id are deliberately left alone --- notably
+`bfabric_save_workunit_attribute.py` and `bfabric_save_link_to_workunit.py`, which apps use to rename
+a workunit and to attach a results link. The YAML carries the true `workunit_id`, so those calls
+still do exactly what the app intends; shimming them would silently drop a user-visible feature. It
+does mean the process step is not entirely free of B-Fabric writes.
 
 `bfabric_upload_resource.py` is redirected rather than neutralised. The real command base64s the file
 over SOAP, which makes B-Fabric file the resource on its own internal storage instead of the
@@ -106,16 +115,19 @@ sit on the success path, after the main output has been written.
 
 ## What gets registered
 
-Uploads keep the order the app made them in, and the same path uploaded twice is recorded once.
+Uploads keep the order the app made them in, and the same file is registered once however many times
+it was uploaded --- including when the app uploads its declared output as well, which is one resource
+rather than a name clash. `legacy_uploads.txt` is truncated at the start of each run, so a retry of
+the process step never inherits the previous run's uploads.
 
 A few legacy apps only ever upload extra resources and never write the declared output at all. If
 the declared output is missing but uploads were recorded, the run warns and registers just the
 uploads; if nothing at all was produced, it fails. An app that *should* have written its output fails
 its own `scp` first, and a non-zero exit means no `outputs.yml` is written at all.
 
-It also fails if the declared output is a remote `host:path` destination app-runner cannot register
-locally, if a recorded upload has since disappeared, or if two different files would claim the same
-resource name --- B-Fabric allows a resource name only once per workunit.
+It also fails if a recorded upload has since disappeared, or if two *different* files would claim the
+same resource name --- B-Fabric allows a resource name only once per workunit. A remote `host:path`
+destination is rejected before the app starts, rather than after it has run.
 
 ## Known limitation
 
@@ -123,6 +135,6 @@ Most apps read the output path via `fgcz_yaml2.bash`, which uses `shyaml get-val
 application.output.-1` and so passes a colon-free local path through unchanged. A few parse it
 themselves and assume a `host:path` shape --- `fgcz_slurm_maxquant_textfiles.bash` does
 `cut -d":" -f2`, and `fgcz_slurm_SummarizedExperiment_A315.bash` runs a `sed` expecting a
-`p<number>/` segment. Those need adapting before they can run this way; `output_path` accepts a real
-scp URL as an escape hatch, but then the app uploads to storage itself and the file is no longer
-local when app-runner would register it.
+`p<number>/` segment. Those need adapting before they can run this way --- `output_path` cannot simply
+be pointed at a real scp URL instead, since app-runner registers a local file and rejects a
+`host:path` destination up front.

--- a/bfabric_app_runner/src/bfabric_app_runner/cli/__main__.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/cli/__main__.py
@@ -33,7 +33,7 @@ from bfabric_app_runner.cli.cmd_action import (
 from bfabric_app_runner.cli.cmd_prepare import cmd_prepare_workunit
 from bfabric_app_runner.cli.cmd_run import cmd_run_workunit
 from bfabric_app_runner.cli.inputs import cmd_inputs_check, cmd_inputs_clean, cmd_inputs_list, cmd_inputs_prepare
-from bfabric_app_runner.cli.legacy import cmd_legacy_collect, cmd_legacy_dispatch, cmd_legacy_run
+from bfabric_app_runner.cli.legacy import cmd_legacy_dispatch, cmd_legacy_run
 from bfabric_app_runner.cli.outputs import cmd_outputs_register, cmd_outputs_register_single_file
 from bfabric_app_runner.cli.validate import (
     cmd_validate_app_spec,
@@ -100,7 +100,6 @@ _ = app.command(cmd_run)
 cmd_legacy = cyclopts.App(name="legacy", help="Run applications written against the old wrapper creator.")
 _ = cmd_legacy.command(cmd_legacy_dispatch, name="dispatch")
 _ = cmd_legacy.command(cmd_legacy_run, name="run")
-_ = cmd_legacy.command(cmd_legacy_collect, name="collect")
 _ = app.command(cmd_legacy)
 
 if __name__ == "__main__":

--- a/bfabric_app_runner/src/bfabric_app_runner/cli/__main__.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/cli/__main__.py
@@ -33,6 +33,7 @@ from bfabric_app_runner.cli.cmd_action import (
 from bfabric_app_runner.cli.cmd_prepare import cmd_prepare_workunit
 from bfabric_app_runner.cli.cmd_run import cmd_run_workunit
 from bfabric_app_runner.cli.inputs import cmd_inputs_check, cmd_inputs_clean, cmd_inputs_list, cmd_inputs_prepare
+from bfabric_app_runner.cli.legacy import cmd_legacy_collect, cmd_legacy_dispatch, cmd_legacy_run
 from bfabric_app_runner.cli.outputs import cmd_outputs_register, cmd_outputs_register_single_file
 from bfabric_app_runner.cli.validate import (
     cmd_validate_app_spec,
@@ -93,6 +94,14 @@ cmd_run = cyclopts.App(name="run", help="Run an app end-to-end.")
 _ = cmd_run.command(cmd_run_workunit, name="workunit")
 cmd_run.group = groups["Running Apps"]
 _ = app.command(cmd_run)
+
+# Compatibility shim for pre-app-runner apps; see the "Running Legacy Apps" guide. Deliberately not
+# in a listed group, so it stays out of the way of anyone writing a new app.
+cmd_legacy = cyclopts.App(name="legacy", help="Run applications written against the old wrapper creator.")
+_ = cmd_legacy.command(cmd_legacy_dispatch, name="dispatch")
+_ = cmd_legacy.command(cmd_legacy_run, name="run")
+_ = cmd_legacy.command(cmd_legacy_collect, name="collect")
+_ = app.command(cmd_legacy)
 
 if __name__ == "__main__":
     app()

--- a/bfabric_app_runner/src/bfabric_app_runner/cli/legacy.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/cli/legacy.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import ClassVar
+
+import yaml
+from loguru import logger
+from pydantic import BaseModel, ConfigDict
+
+from bfabric.experimental.workunit_definition import WorkunitDefinition
+from bfabric_app_runner.dispatch.generic import write_chunks_file
+from bfabric_app_runner.legacy.shim import UPLOAD_MANIFEST_ENV, materialize_shim_dir
+from bfabric_app_runner.specs.inputs.legacy_wrapper_yaml_spec import LegacyWrapperYamlSpec
+from bfabric_app_runner.specs.inputs_spec import InputsSpec
+from bfabric_app_runner.specs.outputs_spec import CopyResourceSpec, OutputsSpec, SpecType
+
+DEFAULT_CONFIG_FILENAME = "config.yaml"
+
+UPLOAD_MANIFEST_FILENAME = "legacy_uploads.txt"
+"""File in the chunk directory where the upload shim records the paths a legacy app uploaded."""
+
+
+class _LegacyApplicationSection(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
+    output: list[str]
+
+
+class _LegacyConfig(BaseModel):
+    """The one part of the legacy YAML that ``collect`` needs; the rest is for the app itself."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
+    application: _LegacyApplicationSection
+
+
+def cmd_legacy_dispatch(
+    workunit_definition_path: Path,
+    work_dir: Path,
+    *,
+    executable: str,
+    output_filename: str | None = None,
+    config_filename: str = DEFAULT_CONFIG_FILENAME,
+) -> None:
+    """Dispatch a legacy app into a single chunk holding just its wrapper-creator YAML.
+
+    Intended as an app's ``dispatch`` command, which appends the workunit definition and work
+    directory. A legacy app fetches its own input resources from the scp URLs inside the YAML, so
+    nothing else is staged; the chunk's ``inputs.yml`` has exactly one entry.
+
+    :param executable: The legacy app, recorded as the YAML's ``job_configuration.executable``.
+    :param output_filename: Name for the app's output inside the chunk directory; ``None`` uses
+        ``output-WU<workunit id>.zip``. Set it for an app whose output is not a zip.
+    :param config_filename: Name to write the legacy YAML under.
+    """
+    definition = WorkunitDefinition.from_yaml(workunit_definition_path)
+    if definition.registration is None:
+        raise ValueError(f"{workunit_definition_path} has no registration section")
+    workunit_id = definition.registration.workunit_id
+
+    chunk_dir = work_dir / "work"
+    chunk_dir.mkdir(parents=True, exist_ok=True)
+    spec = LegacyWrapperYamlSpec(
+        filename=config_filename,
+        workunit_id=workunit_id,
+        output_path=str(chunk_dir / (output_filename or f"output-WU{workunit_id}.zip")),
+        executable=executable,
+    )
+    InputsSpec.write_yaml([spec], chunk_dir / "inputs.yml")
+    write_chunks_file(work_dir, [chunk_dir])
+    logger.info("Dispatched workunit {} to a single chunk at {}", workunit_id, chunk_dir)
+
+
+def cmd_legacy_run(executable: str, chunk_dir: Path, *, config_filename: str = DEFAULT_CONFIG_FILENAME) -> None:
+    """Run a legacy app against the wrapper-creator YAML in a chunk directory.
+
+    Intended as an app's ``process`` command, which appends the chunk directory. The legacy
+    state-writing commands are shadowed by no-ops on ``PATH`` for the duration of the run, and
+    ``bfabric_upload_resource.py`` records its file for ``legacy collect`` instead of uploading it.
+
+    :param executable: The legacy app, shell-split; it receives the YAML path as its last argument.
+    :param chunk_dir: The chunk directory holding the legacy YAML.
+    :param config_filename: Name of the legacy YAML inside ``chunk_dir``.
+    """
+    config_path = _config_path(chunk_dir, config_filename)
+    with tempfile.TemporaryDirectory(prefix="app-runner-legacy-shims-") as shim_dir:
+        env = os.environ.copy()
+        env["PATH"] = f"{materialize_shim_dir(Path(shim_dir))}:{env.get('PATH', '')}"
+        env[UPLOAD_MANIFEST_ENV] = str(chunk_dir / UPLOAD_MANIFEST_FILENAME)
+        command = [*shlex.split(executable), str(config_path)]
+        logger.info("Running legacy app: {}", shlex.join(command))
+        _ = subprocess.run(command, check=True, env=env)
+
+
+def cmd_legacy_collect(chunk_dir: Path, *, config_filename: str = DEFAULT_CONFIG_FILENAME) -> None:
+    """Write a chunk's ``outputs.yml`` from a legacy app's declared output and recorded uploads.
+
+    Intended as an app's ``collect`` command, since a legacy app deposits its files where the YAML
+    told it to but cannot declare them for registration.
+
+    :param chunk_dir: The chunk directory holding the legacy YAML; ``outputs.yml`` is written here.
+    :param config_filename: Name of the legacy YAML inside ``chunk_dir``.
+    """
+    config = _LegacyConfig.model_validate(yaml.safe_load(_config_path(chunk_dir, config_filename).read_text()))
+    uploaded = _uploaded_paths(chunk_dir)
+    produced, missing = _partition_declared_outputs(config.application.output)
+    if missing and not uploaded:
+        raise FileNotFoundError(f"The app did not produce its declared output {missing[0]}")
+    for path in missing:
+        # A few legacy apps only ever upload extra resources, and their scp of the main output is
+        # what would have failed the process step, so a missing one here is not on its own an error.
+        logger.warning("The app did not write its declared output {}, registering only its uploads", path)
+
+    specs: list[SpecType] = [_copy_spec(path) for path in produced]
+    specs += [_copy_spec(_require_file(path)) for path in uploaded]
+    _check_no_duplicate_names(specs)
+    outputs_yaml = chunk_dir / "outputs.yml"
+    OutputsSpec.write_yaml(specs, outputs_yaml)
+    logger.info("Declared {} output(s) in {}", len(specs), outputs_yaml)
+
+
+def _config_path(chunk_dir: Path, config_filename: str) -> Path:
+    config_path = chunk_dir / config_filename
+    if not config_path.is_file():
+        raise FileNotFoundError(f"No legacy configuration at {config_path}")
+    return config_path
+
+
+def _partition_declared_outputs(outputs: list[str]) -> tuple[list[Path], list[Path]]:
+    """Splits ``application.output`` into the paths the app wrote and the ones it did not."""
+    produced: list[Path] = []
+    missing: list[Path] = []
+    for output in outputs:
+        if ":" in output:
+            msg = (
+                f"Cannot register the remote output {output!r}: app-runner registers a local file, so the "
+                f"input spec's output_path has to point inside the chunk directory."
+            )
+            raise ValueError(msg)
+        path = Path(output)
+        (produced if path.is_file() else missing).append(path)
+    return produced, missing
+
+
+def _uploaded_paths(chunk_dir: Path) -> list[Path]:
+    """Paths the upload shim recorded, in upload order, dropping repeats of the same path.
+
+    A repeated path is an app uploading the same file twice, which the real command tolerated; two
+    *different* paths sharing a basename is a genuine conflict and is left to the duplicate check.
+    """
+    manifest = chunk_dir / UPLOAD_MANIFEST_FILENAME
+    if not manifest.is_file():
+        return []
+    lines = [line.strip() for line in manifest.read_text().splitlines() if line.strip()]
+    return [Path(line) for line in dict.fromkeys(lines)]
+
+
+def _require_file(path: Path) -> Path:
+    if not path.is_file():
+        raise FileNotFoundError(f"An uploaded file recorded by the app is gone: {path}")
+    return path
+
+
+def _copy_spec(local_path: Path) -> CopyResourceSpec:
+    return CopyResourceSpec(local_path=local_path, store_entry_path=Path(local_path.name))
+
+
+def _check_no_duplicate_names(specs: list[SpecType]) -> None:
+    """B-Fabric allows a resource name only once per workunit, so catch a clash before uploading."""
+    names = [spec.store_entry_path.name for spec in specs if isinstance(spec, CopyResourceSpec)]
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    if duplicates:
+        raise ValueError(f"Multiple legacy outputs share a resource name: {', '.join(duplicates)}")

--- a/bfabric_app_runner/src/bfabric_app_runner/cli/legacy.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/cli/legacy.py
@@ -30,7 +30,7 @@ class _LegacyApplicationSection(BaseModel):
 
 
 class _LegacyConfig(BaseModel):
-    """The one part of the legacy YAML that ``collect`` needs; the rest is for the app itself."""
+    """The one part of the legacy YAML that app-runner reads back; the rest is for the app itself."""
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="ignore")
     application: _LegacyApplicationSection
@@ -78,10 +78,15 @@ def cmd_legacy_run(executable: str, chunk_dir: Path, *, config_filename: str = D
 
     Intended as an app's ``process`` command, which appends the chunk directory. The legacy
     state-writing commands are shadowed by no-ops on ``PATH`` for the duration of the run, and
-    ``bfabric_upload_resource.py`` records its file for ``legacy collect`` instead of uploading it.
+    ``bfabric_upload_resource.py`` records its file instead of uploading it.
+
+    Once the app succeeds, writes the chunk's ``outputs.yml`` from its declared output and those
+    recorded uploads, since a legacy app deposits its files where the YAML told it to but cannot
+    declare them for registration. Doing that here rather than in a ``collect`` command keeps a
+    legacy app spec to the same two commands a modern app uses.
 
     :param executable: The legacy app, shell-split; it receives the YAML path as its last argument.
-    :param chunk_dir: The chunk directory holding the legacy YAML.
+    :param chunk_dir: The chunk directory holding the legacy YAML; ``outputs.yml`` is written here.
     :param config_filename: Name of the legacy YAML inside ``chunk_dir``.
     """
     config_path = _config_path(chunk_dir, config_filename)
@@ -92,18 +97,12 @@ def cmd_legacy_run(executable: str, chunk_dir: Path, *, config_filename: str = D
         command = [*shlex.split(executable), str(config_path)]
         logger.info("Running legacy app: {}", shlex.join(command))
         _ = subprocess.run(command, check=True, env=env)
+    _write_outputs_spec(chunk_dir, config_path)
 
 
-def cmd_legacy_collect(chunk_dir: Path, *, config_filename: str = DEFAULT_CONFIG_FILENAME) -> None:
-    """Write a chunk's ``outputs.yml`` from a legacy app's declared output and recorded uploads.
-
-    Intended as an app's ``collect`` command, since a legacy app deposits its files where the YAML
-    told it to but cannot declare them for registration.
-
-    :param chunk_dir: The chunk directory holding the legacy YAML; ``outputs.yml`` is written here.
-    :param config_filename: Name of the legacy YAML inside ``chunk_dir``.
-    """
-    config = _LegacyConfig.model_validate(yaml.safe_load(_config_path(chunk_dir, config_filename).read_text()))
+def _write_outputs_spec(chunk_dir: Path, config_path: Path) -> None:
+    """Declare a legacy app's output and recorded uploads in the chunk's ``outputs.yml``."""
+    config = _LegacyConfig.model_validate(yaml.safe_load(config_path.read_text()))
     uploaded = _uploaded_paths(chunk_dir)
     produced, missing = _partition_declared_outputs(config.application.output)
     if missing and not uploaded:

--- a/bfabric_app_runner/src/bfabric_app_runner/cli/legacy.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/cli/legacy.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import subprocess
 import tempfile
+from collections import Counter
 from pathlib import Path
 from typing import ClassVar
 
@@ -19,6 +20,9 @@ from bfabric_app_runner.specs.inputs_spec import InputsSpec
 from bfabric_app_runner.specs.outputs_spec import CopyResourceSpec, OutputsSpec, SpecType
 
 DEFAULT_CONFIG_FILENAME = "config.yaml"
+
+CHUNK_NAME = "work"
+"""Name of the single chunk directory a legacy dispatch creates, relative to the work directory."""
 
 UPLOAD_MANIFEST_FILENAME = "legacy_uploads.txt"
 """File in the chunk directory where the upload shim records the paths a legacy app uploaded."""
@@ -50,6 +54,8 @@ def cmd_legacy_dispatch(
     directory. A legacy app fetches its own input resources from the scp URLs inside the YAML, so
     nothing else is staged; the chunk's ``inputs.yml`` has exactly one entry.
 
+    :param workunit_definition_path: The workunit definition to read the workunit id from.
+    :param work_dir: Directory to dispatch into; the chunk is its ``work`` subdirectory.
     :param executable: The legacy app, recorded as the YAML's ``job_configuration.executable``.
     :param output_filename: Name for the app's output inside the chunk directory; ``None`` uses
         ``output-WU<workunit id>.zip``. Set it for an app whose output is not a zip.
@@ -60,7 +66,9 @@ def cmd_legacy_dispatch(
         raise ValueError(f"{workunit_definition_path} has no registration section")
     workunit_id = definition.registration.workunit_id
 
-    chunk_dir = work_dir / "work"
+    # Resolved because the app reads output_path out of the YAML after its own `cd`, so a relative
+    # path would send the output somewhere neither the app nor output registration expects.
+    chunk_dir = (work_dir / CHUNK_NAME).resolve()
     chunk_dir.mkdir(parents=True, exist_ok=True)
     spec = LegacyWrapperYamlSpec(
         filename=config_filename,
@@ -69,7 +77,8 @@ def cmd_legacy_dispatch(
         executable=executable,
     )
     InputsSpec.write_yaml([spec], chunk_dir / "inputs.yml")
-    write_chunks_file(work_dir, [chunk_dir])
+    # Relative, as ChunksFile documents and Runner.infer_from_directory produces.
+    write_chunks_file(work_dir, [Path(CHUNK_NAME)])
     logger.info("Dispatched workunit {} to a single chunk at {}", workunit_id, chunk_dir)
 
 
@@ -90,10 +99,19 @@ def cmd_legacy_run(executable: str, chunk_dir: Path, *, config_filename: str = D
     :param config_filename: Name of the legacy YAML inside ``chunk_dir``.
     """
     config_path = _config_path(chunk_dir, config_filename)
+    # Checked up front: a remote destination is only detectable from the YAML, and finding out after
+    # the app has run would throw away hours of work for something knowable in advance.
+    _reject_remote_outputs(_read_config(config_path).application.output)
+
+    manifest = chunk_dir / UPLOAD_MANIFEST_FILENAME
+    # A retry of the process step must not inherit the previous run's uploads.
+    manifest.unlink(missing_ok=True)
+
     with tempfile.TemporaryDirectory(prefix="app-runner-legacy-shims-") as shim_dir:
         env = os.environ.copy()
-        env["PATH"] = f"{materialize_shim_dir(Path(shim_dir))}:{env.get('PATH', '')}"
-        env[UPLOAD_MANIFEST_ENV] = str(chunk_dir / UPLOAD_MANIFEST_FILENAME)
+        # An empty PATH element means the current directory, so fall back to a real default.
+        env["PATH"] = os.pathsep.join([str(materialize_shim_dir(Path(shim_dir))), env.get("PATH") or os.defpath])
+        env[UPLOAD_MANIFEST_ENV] = str(manifest)
         command = [*shlex.split(executable), str(config_path)]
         logger.info("Running legacy app: {}", shlex.join(command))
         _ = subprocess.run(command, check=True, env=env)
@@ -102,9 +120,10 @@ def cmd_legacy_run(executable: str, chunk_dir: Path, *, config_filename: str = D
 
 def _write_outputs_spec(chunk_dir: Path, config_path: Path) -> None:
     """Declare a legacy app's output and recorded uploads in the chunk's ``outputs.yml``."""
-    config = _LegacyConfig.model_validate(yaml.safe_load(config_path.read_text()))
+    declared = _read_config(config_path).application.output
+    _reject_remote_outputs(declared)
+    produced, missing = _partition_declared_outputs(declared)
     uploaded = _uploaded_paths(chunk_dir)
-    produced, missing = _partition_declared_outputs(config.application.output)
     if missing and not uploaded:
         raise FileNotFoundError(f"The app did not produce its declared output {missing[0]}")
     for path in missing:
@@ -112,9 +131,15 @@ def _write_outputs_spec(chunk_dir: Path, config_path: Path) -> None:
         # what would have failed the process step, so a missing one here is not on its own an error.
         logger.warning("The app did not write its declared output {}, registering only its uploads", path)
 
-    specs: list[SpecType] = [_copy_spec(path) for path in produced]
-    specs += [_copy_spec(_require_file(path)) for path in uploaded]
-    _check_no_duplicate_names(specs)
+    # An app is free to upload its declared output as well; that is one resource, not a name clash.
+    # Keyed on the resolved path, since a declared output and an upload can spell the same file
+    # differently, but declared with the path as given so the spec stays readable.
+    by_target: dict[Path, Path] = {}
+    for path in [*produced, *(_require_file(path) for path in uploaded)]:
+        _ = by_target.setdefault(path.resolve(), path)
+    copy_specs = [_copy_spec(path) for path in by_target.values()]
+    _check_no_duplicate_names(copy_specs)
+    specs: list[SpecType] = list(copy_specs)
     outputs_yaml = chunk_dir / "outputs.yml"
     OutputsSpec.write_yaml(specs, outputs_yaml)
     logger.info("Declared {} output(s) in {}", len(specs), outputs_yaml)
@@ -127,10 +152,12 @@ def _config_path(chunk_dir: Path, config_filename: str) -> Path:
     return config_path
 
 
-def _partition_declared_outputs(outputs: list[str]) -> tuple[list[Path], list[Path]]:
-    """Splits ``application.output`` into the paths the app wrote and the ones it did not."""
-    produced: list[Path] = []
-    missing: list[Path] = []
+def _read_config(config_path: Path) -> _LegacyConfig:
+    return _LegacyConfig.model_validate(yaml.safe_load(config_path.read_text()))
+
+
+def _reject_remote_outputs(outputs: list[str]) -> None:
+    """Rejects a ``host:path`` destination, which app-runner cannot register as a local file."""
     for output in outputs:
         if ":" in output:
             msg = (
@@ -138,6 +165,13 @@ def _partition_declared_outputs(outputs: list[str]) -> tuple[list[Path], list[Pa
                 f"input spec's output_path has to point inside the chunk directory."
             )
             raise ValueError(msg)
+
+
+def _partition_declared_outputs(outputs: list[str]) -> tuple[list[Path], list[Path]]:
+    """Splits ``application.output`` into the paths the app wrote and the ones it did not."""
+    produced: list[Path] = []
+    missing: list[Path] = []
+    for output in outputs:
         path = Path(output)
         (produced if path.is_file() else missing).append(path)
     return produced, missing
@@ -166,9 +200,9 @@ def _copy_spec(local_path: Path) -> CopyResourceSpec:
     return CopyResourceSpec(local_path=local_path, store_entry_path=Path(local_path.name))
 
 
-def _check_no_duplicate_names(specs: list[SpecType]) -> None:
+def _check_no_duplicate_names(specs: list[CopyResourceSpec]) -> None:
     """B-Fabric allows a resource name only once per workunit, so catch a clash before uploading."""
-    names = [spec.store_entry_path.name for spec in specs if isinstance(spec, CopyResourceSpec)]
-    duplicates = sorted({name for name in names if names.count(name) > 1})
+    counts = Counter(spec.store_entry_path.name for spec in specs)
+    duplicates = sorted(name for name, count in counts.items() if count > 1)
     if duplicates:
         raise ValueError(f"Multiple legacy outputs share a resource name: {', '.join(duplicates)}")

--- a/bfabric_app_runner/src/bfabric_app_runner/inputs/resolve/_resolve_legacy_wrapper_yaml_specs.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/inputs/resolve/_resolve_legacy_wrapper_yaml_specs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from bfabric_app_runner.inputs.resolve.resolved_inputs import ResolvedStaticFile
+from bfabric_app_runner.legacy.wrapper_yaml import build_legacy_wrapper_yaml
+
+if TYPE_CHECKING:
+    from bfabric import Bfabric
+
+    from bfabric_app_runner.specs.inputs.legacy_wrapper_yaml_spec import LegacyWrapperYamlSpec
+
+
+class ResolveLegacyWrapperYamlSpecs:
+    def __init__(self, client: Bfabric) -> None:
+        self._client: Bfabric = client
+
+    def __call__(self, specs: list[LegacyWrapperYamlSpec]) -> list[ResolvedStaticFile]:
+        """Convert legacy wrapper YAML specifications to file specifications."""
+        return [ResolvedStaticFile(filename=spec.filename, content=self._render(spec=spec)) for spec in specs]
+
+    def _render(self, spec: LegacyWrapperYamlSpec) -> str:
+        config = build_legacy_wrapper_yaml(
+            client=self._client,
+            workunit_id=spec.workunit_id,
+            output_path=spec.output_path,
+            executable=spec.executable,
+        )
+        return yaml.safe_dump(config)

--- a/bfabric_app_runner/src/bfabric_app_runner/inputs/resolve/resolver.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/inputs/resolve/resolver.py
@@ -11,6 +11,7 @@ from bfabric_app_runner.inputs.resolve._resolve_bfabric_resource_archive_specs i
 from bfabric_app_runner.inputs.resolve._resolve_bfabric_resource_dataset_specs import ResolveBfabricResourceDatasetSpecs
 from bfabric_app_runner.inputs.resolve._resolve_bfabric_resource_specs import ResolveBfabricResourceSpecs
 from bfabric_app_runner.inputs.resolve._resolve_file_specs import ResolveFileSpecs
+from bfabric_app_runner.inputs.resolve._resolve_legacy_wrapper_yaml_specs import ResolveLegacyWrapperYamlSpecs
 from bfabric_app_runner.inputs.resolve._resolve_static_file_specs import ResolveStaticFileSpecs
 from bfabric_app_runner.inputs.resolve._resolve_static_yaml_specs import ResolveStaticYamlSpecs
 from bfabric_app_runner.inputs.resolve.resolved_inputs import ResolvedInput, ResolvedInputs
@@ -21,6 +22,7 @@ from bfabric_app_runner.specs.inputs.bfabric_resource_archive_spec import Bfabri
 from bfabric_app_runner.specs.inputs.bfabric_resource_dataset_spec import BfabricResourceDatasetSpec
 from bfabric_app_runner.specs.inputs.bfabric_resource_spec import BfabricResourceSpec
 from bfabric_app_runner.specs.inputs.file_spec import FileSpec
+from bfabric_app_runner.specs.inputs.legacy_wrapper_yaml_spec import LegacyWrapperYamlSpec
 from bfabric_app_runner.specs.inputs.static_file_spec import StaticFileSpec
 from bfabric_app_runner.specs.inputs.static_yaml_spec import StaticYamlSpec
 from bfabric_app_runner.specs.inputs_spec import InputSpecType
@@ -49,12 +51,13 @@ class Resolver:
             BfabricDatasetSpec: ResolveBfabricDatasetSpecs(reader=client.reader),
             BfabricOrderFastaSpec: ResolveBfabricOrderFastaSpecs(client=client),
             BfabricAnnotationSpec: ResolveBfabricAnnotationSpecs(client=client),
+            LegacyWrapperYamlSpec: ResolveLegacyWrapperYamlSpecs(client=client),
         }
         self._check_registry_exhaustive()
 
     def resolve(self, specs: list[InputSpecType]) -> ResolvedInputs:
         """Convert input specifications to resolved file specifications."""
-        with cache_entities(entities=["application", "dataset", "resource", "storage"], max_size=500):
+        with cache_entities(entities=["application", "dataset", "resource", "storage", "workunit"], max_size=500):
             files: list[ResolvedInput] = []
             for spec_type, specs_list in self._group_specs_by_type(specs=specs).items():
                 files.extend(self._registry[spec_type](specs_list))

--- a/bfabric_app_runner/src/bfabric_app_runner/legacy/shim.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/legacy/shim.py
@@ -27,8 +27,9 @@ UPLOAD_COMMAND = "bfabric_upload_resource.py"
 """Legacy extra-resource upload, recorded for later registration rather than neutralised.
 
 The real command base64s the file over SOAP, which makes B-Fabric file it on its internal storage
-instead of the application's. Noting the path for ``legacy collect`` instead puts those resources on
-the same storage as every other app-runner output and keeps the internal repo out of the picture.
+instead of the application's. Noting the path for the ``outputs.yml`` that ``legacy run`` writes
+afterwards instead puts those resources on the same storage as every other app-runner output and
+keeps the internal repo out of the picture.
 """
 
 SHIMMED_COMMANDS = (*NOOP_COMMANDS, UPLOAD_COMMAND)

--- a/bfabric_app_runner/src/bfabric_app_runner/legacy/shim.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/legacy/shim.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import stat
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+NOOP_COMMANDS = (
+    "bfabric_setResourceStatus_available.py",
+    "bfabric_setExternalJobStatus_done.py",
+    "bfabric_setWorkunitStatus_processing.py",
+    "bfabric_setWorkunitStatus_available.py",
+    "bfabric_setWorkunitStatus_failed.py",
+    "bfabric_save_workflowstep.py",
+)
+"""Legacy state-writing commands a legacy app must not run under app-runner.
+
+app-runner sets the workunit status, the resource status and the workflow step itself, and the ids in
+the legacy YAML are sentinels, so these calls would at best duplicate work and at worst mark the
+wrong entity.
+"""
+
+UPLOAD_COMMAND = "bfabric_upload_resource.py"
+"""Legacy extra-resource upload, recorded for later registration rather than neutralised.
+
+The real command base64s the file over SOAP, which makes B-Fabric file it on its internal storage
+instead of the application's. Noting the path for ``legacy collect`` instead puts those resources on
+the same storage as every other app-runner output and keeps the internal repo out of the picture.
+"""
+
+SHIMMED_COMMANDS = (*NOOP_COMMANDS, UPLOAD_COMMAND)
+
+UPLOAD_MANIFEST_ENV = "APP_RUNNER_LEGACY_UPLOAD_MANIFEST"
+"""Env var by which ``legacy run`` tells the upload shim where to record uploaded paths."""
+
+_NOOP_SCRIPT = """#!/bin/sh
+echo "[app-runner legacy shim] ignoring: $(basename "$0") $*" >&2
+exit 0
+"""
+
+# Records the path instead of copying the file: no legacy app removes its scratch directory before
+# exiting, so a copy would only duplicate output that can be arbitrarily large. Mirrors the real
+# command's tolerance of a missing file, since callers habitually append `|| { echo failed; }`.
+_UPLOAD_SCRIPT = f"""#!/bin/sh
+file="$1"
+if [ -z "${{{UPLOAD_MANIFEST_ENV}:-}}" ]; then
+    echo "[app-runner legacy shim] no upload manifest set, ignoring upload of '$file'" >&2
+    exit 0
+fi
+if [ ! -f "$file" ]; then
+    echo "[app-runner legacy shim] no such file, ignoring upload of '$file'" >&2
+    exit 0
+fi
+case "$file" in
+    /*) path="$file" ;;
+    *) path="$PWD/$file" ;;
+esac
+printf '%s\\n' "$path" >> "${{{UPLOAD_MANIFEST_ENV}}}" || exit 1
+echo "[app-runner legacy shim] recorded '$path' for registration" >&2
+exit 0
+"""
+
+_EXECUTABLE_BITS = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+
+
+def materialize_shim_dir(path: Path) -> Path:
+    """Writes an executable shim for every command in :data:`SHIMMED_COMMANDS` into ``path``.
+
+    Generated rather than shipped as package data, since nothing preserves an executable bit through
+    a wheel and app-runner itself often runs from an ephemeral ``uv run --with`` environment.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    for command in SHIMMED_COMMANDS:
+        script = path / command
+        _ = script.write_text(_UPLOAD_SCRIPT if command == UPLOAD_COMMAND else _NOOP_SCRIPT)
+        script.chmod(script.stat().st_mode | _EXECUTABLE_BITS)
+    logger.debug("Materialized {} legacy shims in {}", len(SHIMMED_COMMANDS), path)
+    return path

--- a/bfabric_app_runner/src/bfabric_app_runner/legacy/wrapper_yaml.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/legacy/wrapper_yaml.py
@@ -30,10 +30,11 @@ def build_legacy_wrapper_yaml(
 ) -> dict[str, object]:
     """Builds the legacy wrapper-creator YAML for a workunit, writing nothing to B-Fabric.
 
-    The result matches what ``bfabric.wrapper_creator.BfabricWrapperCreator`` produces, except that
-    ``application.output`` is whatever ``output_path`` says (app-runner registers the output itself,
-    so there is no pre-created resource to address) and every resource and external-job id is
-    :data:`SENTINEL_ID`.
+    The result matches what ``bfabric.wrapper_creator.BfabricWrapperCreator`` produces, except where
+    app-runner owns the output itself: ``application.output`` is whatever ``output_path`` says, every
+    resource and external-job id is :data:`SENTINEL_ID`, and ``job_configuration.output`` describes a
+    local file (``protocol: file``, empty ``ssh_args``) rather than the wrapper creator's scp
+    destination. ``application.protocol`` stays ``scp``, since it describes the *inputs*.
 
     :param output_path: Where the app should deposit its output; ends up in ``application.output``.
     :param executable: ``job_configuration.executable``; ``None`` reads the application's own
@@ -57,7 +58,7 @@ def build_legacy_wrapper_yaml(
             "output": [output_path],
         },
         "job_configuration": {
-            "executable": executable if executable is not None else str(workunit.application.executable["program"]),
+            "executable": executable if executable is not None else _application_program(workunit),
             "external_job_id": SENTINEL_ID,
             "fastasequence": _fasta_sequence(order),
             "input": input_references,
@@ -73,6 +74,21 @@ def build_legacy_wrapper_yaml(
             "workunit_url": str(workunit.uri),
         },
     }
+
+
+def _application_program(workunit: Workunit) -> str:
+    """The application's own ``program``, used when the spec names no executable.
+
+    An application with no executable at all already raises from ``HasOne``, which is not optional
+    here; this only covers an executable that carries no ``program``, which would be a bare KeyError.
+    """
+    executable = workunit.application.executable
+    if "program" not in executable.data_dict:
+        raise ValueError(
+            f"Executable {executable.id} of application {workunit.application.id} has no `program`, "
+            f"so the spec must set `executable`"
+        )
+    return str(executable["program"])
 
 
 def _collect_inputs(resources: list[Resource]) -> tuple[dict[str, list[str]], dict[str, list[dict[str, object]]]]:

--- a/bfabric_app_runner/src/bfabric_app_runner/legacy/wrapper_yaml.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/legacy/wrapper_yaml.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from bfabric.entities import Order, Project, Workunit
+
+if TYPE_CHECKING:
+    from bfabric import Bfabric
+    from bfabric.entities import Resource
+
+SENTINEL_ID = 0
+"""Stands in for the resource and external-job ids the legacy wrapper creator used to register.
+
+app-runner owns workunit and resource state itself, so no resource or external job is created here.
+``0`` rather than ``null`` keeps a consumer that flattens the YAML into shell variables working
+under ``set -u``.
+"""
+
+NO_LOG_URL = "/dev/null"
+"""Log path written into the ``stdout``/``stderr`` sections; app-runner captures the real log itself."""
+
+
+def build_legacy_wrapper_yaml(
+    *,
+    client: Bfabric,
+    workunit_id: int,
+    output_path: str,
+    executable: str | None = None,
+) -> dict[str, object]:
+    """Builds the legacy wrapper-creator YAML for a workunit, writing nothing to B-Fabric.
+
+    The result matches what ``bfabric.wrapper_creator.BfabricWrapperCreator`` produces, except that
+    ``application.output`` is whatever ``output_path`` says (app-runner registers the output itself,
+    so there is no pre-created resource to address) and every resource and external-job id is
+    :data:`SENTINEL_ID`.
+
+    :param output_path: Where the app should deposit its output; ends up in ``application.output``.
+    :param executable: ``job_configuration.executable``; ``None`` reads the application's own
+        ``program``, which under app-runner points at the ``app.yml`` rather than the legacy app.
+    """
+    workunit = client.reader.read_id(Workunit, workunit_id)
+    if workunit is None:
+        raise ValueError(f"Workunit {workunit_id} does not exist")
+
+    input_urls, input_references = _collect_inputs(workunit.input_resources.list)
+    container = workunit.container
+    order = container if isinstance(container, Order) else None
+    project = container if isinstance(container, Project) else (order.project if order is not None else None)
+    dataset = workunit.input_dataset
+
+    return {
+        "application": {
+            "parameters": {key: value or "" for key, value in workunit.application_parameters.items()},
+            "protocol": "scp",
+            "input": input_urls,
+            "output": [output_path],
+        },
+        "job_configuration": {
+            "executable": executable if executable is not None else str(workunit.application.executable["program"]),
+            "external_job_id": SENTINEL_ID,
+            "fastasequence": _fasta_sequence(order),
+            "input": input_references,
+            "inputdataset": None if dataset is None else {"_id": dataset.id, "name": dataset["name"]},
+            "order_id": order.id if order is not None else None,
+            "project_id": project.id if project is not None else None,
+            "output": {"protocol": "file", "resource_id": SENTINEL_ID, "ssh_args": ""},
+            # Distinct dicts on purpose: yaml.safe_dump would emit an anchor/alias for a shared one.
+            "stderr": _log_section(),
+            "stdout": _log_section(),
+            "workunit_createdby": workunit["createdby"],
+            "workunit_id": workunit.id,
+            "workunit_url": str(workunit.uri),
+        },
+    }
+
+
+def _collect_inputs(resources: list[Resource]) -> tuple[dict[str, list[str]], dict[str, list[dict[str, object]]]]:
+    """Groups input resources by the name of the application that produced them.
+
+    Returns the ``application.input`` (scp URLs) and ``job_configuration.input`` (id plus URI) views.
+    """
+    urls: dict[str, list[str]] = defaultdict(list)
+    references: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for resource in resources:
+        scp_prefix = resource.storage.scp_prefix
+        if scp_prefix is None:
+            # Interpolating None would yield a "bfabric@None/..." URL that only fails inside the app.
+            raise ValueError(f"Storage {resource.storage.id} of input resource {resource.id} is not scp-accessible")
+        application_name = str(resource.workunit.application["name"])
+        urls[application_name].append(f"bfabric@{scp_prefix}{resource['relativepath']}")
+        references[application_name].append({"resource_id": resource.id, "resource_url": str(resource.uri)})
+    return dict(urls), dict(references)
+
+
+def _fasta_sequence(order: Order | None) -> str:
+    if order is None or "fastasequence" not in order.data_dict:
+        return ""
+    return "\n".join(part.strip() for part in str(order["fastasequence"]).split("\r"))
+
+
+def _log_section() -> dict[str, object]:
+    return {"protocol": "file", "resource_id": SENTINEL_ID, "url": NO_LOG_URL}

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/legacy_wrapper_yaml_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/legacy_wrapper_yaml_spec.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from bfabric_app_runner.specs.common_types import RelativeFilePath
+
+
+class LegacyWrapperYamlSpec(BaseModel):
+    """Writes the legacy wrapper-creator YAML for a workunit to a file.
+
+    Compatibility shim for pre-app-runner applications that expect that YAML as their sole argument;
+    do not use it for new apps. Nothing is written to B-Fabric, so the YAML carries no external job
+    and no ``slurm_stdout``/``slurm_stderr`` log resources -- see the "Running legacy apps" guide.
+    """
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+    type: Literal["legacy_wrapper_yaml"] = "legacy_wrapper_yaml"
+    """Discriminator marking this input as a legacy wrapper-creator YAML."""
+
+    filename: RelativeFilePath
+    """Target filename (relative to the chunk directory) to write the YAML to."""
+
+    workunit_id: int
+    """ID of the workunit to describe."""
+
+    output_path: str
+    """Where the app should deposit its output, written to ``application.output``.
+
+    Normally an absolute path inside the chunk directory, so that the app's ``scp`` degrades to a
+    local copy and app-runner can register the file afterwards. An app that insists on a remote
+    destination can be given a ``bfabric@host:path`` URL instead, but then it has to register the
+    result itself.
+    """
+
+    executable: str | None = None
+    """``job_configuration.executable``; ``None`` uses the application's own ``program`` field."""

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/legacy_wrapper_yaml_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/legacy_wrapper_yaml_spec.py
@@ -28,10 +28,9 @@ class LegacyWrapperYamlSpec(BaseModel):
     output_path: str
     """Where the app should deposit its output, written to ``application.output``.
 
-    Normally an absolute path inside the chunk directory, so that the app's ``scp`` degrades to a
-    local copy and app-runner can register the file afterwards. An app that insists on a remote
-    destination can be given a ``bfabric@host:path`` URL instead, but then it has to register the
-    result itself.
+    An absolute path inside the chunk directory, so that the app's ``scp`` degrades to a local copy
+    and app-runner can register the file afterwards. A ``host:path`` destination is rejected before
+    the app runs, since app-runner registers a local file.
     """
 
     executable: str | None = None

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs_spec.py
@@ -12,6 +12,7 @@ from bfabric_app_runner.specs.inputs.bfabric_resource_archive_spec import Bfabri
 from bfabric_app_runner.specs.inputs.bfabric_resource_dataset_spec import BfabricResourceDatasetSpec
 from bfabric_app_runner.specs.inputs.bfabric_resource_spec import BfabricResourceSpec
 from bfabric_app_runner.specs.inputs.file_spec import FileSpec
+from bfabric_app_runner.specs.inputs.legacy_wrapper_yaml_spec import LegacyWrapperYamlSpec
 from bfabric_app_runner.specs.inputs.static_file_spec import StaticFileSpec
 from bfabric_app_runner.specs.inputs.static_yaml_spec import StaticYamlSpec
 
@@ -27,7 +28,8 @@ InputSpecType = Annotated[
     | BfabricResourceArchiveSpec
     | BfabricResourceDatasetSpec
     | StaticYamlSpec
-    | StaticFileSpec,
+    | StaticFileSpec
+    | LegacyWrapperYamlSpec,
     Field(discriminator="type"),
 ]
 

--- a/tests/bfabric_app_runner/cli/test_legacy.py
+++ b/tests/bfabric_app_runner/cli/test_legacy.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 from bfabric_app_runner.cli.legacy import (
     UPLOAD_MANIFEST_FILENAME,
-    cmd_legacy_collect,
+    _write_outputs_spec,
     cmd_legacy_dispatch,
     cmd_legacy_run,
 )
@@ -106,20 +106,26 @@ class TestDispatch:
             cmd_legacy_dispatch(path, work_dir, executable="/opt/legacy.bash")
 
 
-class TestCollect:
-    def test_declares_the_produced_output(self, chunk_dir):
+class TestWriteOutputsSpec:
+    """``legacy run`` writes outputs.yml itself, so a legacy app needs no collect command."""
+
+    @pytest.fixture
+    def declare(self, chunk_dir):
+        return lambda: _write_outputs_spec(chunk_dir, chunk_dir / "config.yaml")
+
+    def test_declares_the_produced_output(self, chunk_dir, declare):
         output = chunk_dir / "result.zip"
         output.write_text("payload")
         _write_config(chunk_dir, output)
 
-        cmd_legacy_collect(chunk_dir)
+        declare()
 
         specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
         assert len(specs) == 1
         assert specs[0].local_path == output
         assert str(specs[0].store_entry_path) == "result.zip"
 
-    def test_declares_uploads_in_place_alongside_the_output(self, chunk_dir, tmp_path):
+    def test_declares_uploads_in_place_alongside_the_output(self, chunk_dir, tmp_path, declare):
         """Recorded uploads reach the same storage as the main output, without being copied first."""
         output = chunk_dir / "result.zip"
         output.write_text("payload")
@@ -128,21 +134,21 @@ class TestCollect:
         _record_upload(chunk_dir, scratch / "proteinGroups.txt")
         _record_upload(chunk_dir, scratch / "specs.pdf")
 
-        cmd_legacy_collect(chunk_dir)
+        declare()
 
         specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
         assert [str(spec.store_entry_path) for spec in specs] == ["result.zip", "proteinGroups.txt", "specs.pdf"]
         # referenced where the app left them, not relocated into the chunk directory
         assert specs[1].local_path == scratch / "proteinGroups.txt"
 
-    def test_preserves_upload_order(self, chunk_dir, tmp_path):
+    def test_preserves_upload_order(self, chunk_dir, tmp_path, declare):
         output = chunk_dir / "result.zip"
         output.write_text("payload")
         _write_config(chunk_dir, output)
         for name in ["specs.pdf", "parameters.txt", "proteinGroups.txt"]:
             _record_upload(chunk_dir, tmp_path / "scratch" / name)
 
-        cmd_legacy_collect(chunk_dir)
+        declare()
 
         specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
         assert [str(spec.store_entry_path) for spec in specs[1:]] == [
@@ -151,7 +157,7 @@ class TestCollect:
             "proteinGroups.txt",
         ]
 
-    def test_ignores_a_repeated_upload_of_the_same_path(self, chunk_dir, tmp_path):
+    def test_ignores_a_repeated_upload_of_the_same_path(self, chunk_dir, tmp_path, declare):
         output = chunk_dir / "result.zip"
         output.write_text("payload")
         _write_config(chunk_dir, output)
@@ -159,20 +165,20 @@ class TestCollect:
         _record_upload(chunk_dir, upload)
         _record_upload(chunk_dir, upload)
 
-        cmd_legacy_collect(chunk_dir)
+        declare()
 
         assert len(OutputsSpec.read_yaml(chunk_dir / "outputs.yml")) == 2
 
-    def test_works_without_any_uploads(self, chunk_dir):
+    def test_works_without_any_uploads(self, chunk_dir, declare):
         output = chunk_dir / "result.zip"
         output.write_text("payload")
         _write_config(chunk_dir, output)
 
-        cmd_legacy_collect(chunk_dir)
+        declare()
 
         assert len(OutputsSpec.read_yaml(chunk_dir / "outputs.yml")) == 1
 
-    def test_rejects_two_uploads_sharing_a_resource_name(self, chunk_dir, tmp_path):
+    def test_rejects_two_uploads_sharing_a_resource_name(self, chunk_dir, tmp_path, declare):
         output = chunk_dir / "result.zip"
         output.write_text("payload")
         _write_config(chunk_dir, output)
@@ -180,24 +186,24 @@ class TestCollect:
         _record_upload(chunk_dir, tmp_path / "b" / "proteinGroups.txt")
 
         with pytest.raises(ValueError, match="share a resource name: proteinGroups.txt"):
-            cmd_legacy_collect(chunk_dir)
+            declare()
 
-    def test_missing_output_and_no_uploads_fails(self, chunk_dir):
+    def test_missing_output_and_no_uploads_fails(self, chunk_dir, declare):
         _write_config(chunk_dir, chunk_dir / "result.zip")
         with pytest.raises(FileNotFoundError, match="did not produce its declared output"):
-            cmd_legacy_collect(chunk_dir)
+            declare()
 
-    def test_missing_output_with_uploads_registers_the_uploads(self, chunk_dir, tmp_path):
+    def test_missing_output_with_uploads_registers_the_uploads(self, chunk_dir, tmp_path, declare):
         """A few legacy apps only ever upload extra resources and never write the declared output."""
         _write_config(chunk_dir, chunk_dir / "result.zip")
         _record_upload(chunk_dir, tmp_path / "scratch" / "fgcz_MQ_QC_report.pdf")
 
-        cmd_legacy_collect(chunk_dir)
+        declare()
 
         specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
         assert [str(spec.store_entry_path) for spec in specs] == ["fgcz_MQ_QC_report.pdf"]
 
-    def test_recorded_upload_that_vanished(self, chunk_dir, tmp_path):
+    def test_recorded_upload_that_vanished(self, chunk_dir, tmp_path, declare):
         output = chunk_dir / "result.zip"
         output.write_text("payload")
         _write_config(chunk_dir, output)
@@ -205,23 +211,12 @@ class TestCollect:
         upload.unlink()
 
         with pytest.raises(FileNotFoundError, match="recorded by the app is gone"):
-            cmd_legacy_collect(chunk_dir)
+            declare()
 
-    def test_remote_output_is_rejected(self, chunk_dir):
+    def test_remote_output_is_rejected(self, chunk_dir, declare):
         _write_config(chunk_dir, "bfabric@fgcz-ms.uzh.ch:/srv/www/htdocs/result.zip")
         with pytest.raises(ValueError, match="Cannot register the remote output"):
-            cmd_legacy_collect(chunk_dir)
-
-    def test_missing_config(self, chunk_dir):
-        with pytest.raises(FileNotFoundError, match="No legacy configuration at"):
-            cmd_legacy_collect(chunk_dir)
-
-    def test_custom_config_filename(self, chunk_dir):
-        output = chunk_dir / "result.zip"
-        output.write_text("payload")
-        _write_config(chunk_dir, output, filename="legacy.yml")
-        cmd_legacy_collect(chunk_dir, config_filename="legacy.yml")
-        assert (chunk_dir / "outputs.yml").is_file()
+            declare()
 
 
 class TestRun:
@@ -233,6 +228,8 @@ class TestRun:
             "#!/bin/sh\n"
             'echo "$1" > "$(dirname "$0")/received_argument"\n'
             'command -v bfabric_setWorkunitStatus_available.py > "$(dirname "$0")/resolved_command"\n'
+            # the declared output, which the config places next to the config file
+            'echo payload > "$(dirname "$1")/result.zip"\n'
             'echo extra > "$(dirname "$0")/proteinGroups.txt"\n'
             'bfabric_upload_resource.py "$(dirname "$0")/proteinGroups.txt" 349972\n'
         )
@@ -262,11 +259,28 @@ class TestRun:
         manifest = (chunk_dir / UPLOAD_MANIFEST_FILENAME).read_text().splitlines()
         assert manifest == [str(legacy_app.parent / "proteinGroups.txt")]
 
+    def test_declares_the_outputs_itself(self, chunk_dir, legacy_app):
+        """No collect command: a successful run leaves the chunk ready for output registration."""
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+
+        cmd_legacy_run(str(legacy_app), chunk_dir)
+
+        specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
+        assert [str(spec.store_entry_path) for spec in specs] == ["result.zip", "proteinGroups.txt"]
+
+    def test_custom_config_filename(self, chunk_dir, legacy_app):
+        _write_config(chunk_dir, chunk_dir / "result.zip", filename="legacy.yml")
+
+        cmd_legacy_run(str(legacy_app), chunk_dir, config_filename="legacy.yml")
+
+        assert (legacy_app.parent / "received_argument").read_text().strip() == str(chunk_dir / "legacy.yml")
+        assert (chunk_dir / "outputs.yml").is_file()
+
     def test_missing_config(self, chunk_dir, legacy_app):
         with pytest.raises(FileNotFoundError, match="No legacy configuration at"):
             cmd_legacy_run(str(legacy_app), chunk_dir)
 
-    def test_failing_app_raises(self, chunk_dir, tmp_path):
+    def test_failing_app_raises_and_declares_nothing(self, chunk_dir, tmp_path):
         failing = tmp_path / "failing.sh"
         failing.write_text("#!/bin/sh\nexit 3\n")
         failing.chmod(failing.stat().st_mode | stat.S_IXUSR)
@@ -274,3 +288,5 @@ class TestRun:
 
         with pytest.raises(Exception, match="returned non-zero exit status 3"):
             cmd_legacy_run(str(failing), chunk_dir)
+
+        assert not (chunk_dir / "outputs.yml").exists()

--- a/tests/bfabric_app_runner/cli/test_legacy.py
+++ b/tests/bfabric_app_runner/cli/test_legacy.py
@@ -1,0 +1,276 @@
+import stat
+
+import pytest
+import yaml
+from bfabric_app_runner.cli.legacy import (
+    UPLOAD_MANIFEST_FILENAME,
+    cmd_legacy_collect,
+    cmd_legacy_dispatch,
+    cmd_legacy_run,
+)
+from bfabric_app_runner.specs.inputs.legacy_wrapper_yaml_spec import LegacyWrapperYamlSpec
+from bfabric_app_runner.specs.inputs_spec import InputsSpec
+from bfabric_app_runner.specs.outputs_spec import OutputsSpec
+
+
+@pytest.fixture
+def chunk_dir(tmp_path):
+    chunk_dir = tmp_path / "work"
+    chunk_dir.mkdir()
+    return chunk_dir
+
+
+def _write_config(chunk_dir, output_path, filename="config.yaml"):
+    config = {"application": {"output": [str(output_path)], "protocol": "scp"}, "job_configuration": {}}
+    (chunk_dir / filename).write_text(yaml.safe_dump(config))
+
+
+def _record_upload(chunk_dir, path, content="payload"):
+    """Stand in for the upload shim: create the file elsewhere and note it in the manifest."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    manifest = chunk_dir / UPLOAD_MANIFEST_FILENAME
+    with manifest.open("a") as handle:
+        _ = handle.write(f"{path}\n")
+    return path
+
+
+class TestDispatch:
+    @pytest.fixture
+    def work_dir(self, tmp_path):
+        work_dir = tmp_path / "WU349972"
+        work_dir.mkdir()
+        definition = {
+            "execution": {"raw_parameters": {}, "resources": [3220134, 3220135]},
+            "registration": {
+                "application_id": 224,
+                "application_name": "MaxQuant",
+                "workunit_id": 349972,
+                "workunit_name": "MaxQuant_Hi5_POI",
+                "container_id": 42904,
+                "container_type": "order",
+                "storage_id": 2,
+                "storage_output_folder": "p42904/bfabric/Proteomics/MaxQuant/2026/2026-08/2026-08-12",
+            },
+        }
+        (work_dir / "workunit_definition.yml").write_text(yaml.safe_dump(definition))
+        return work_dir
+
+    def test_writes_a_single_chunk(self, work_dir):
+        cmd_legacy_dispatch(work_dir / "workunit_definition.yml", work_dir, executable="/opt/legacy.bash")
+
+        chunks = yaml.safe_load((work_dir / "chunks.yml").read_text())["chunks"]
+        assert chunks == [str(work_dir / "work")]
+
+    def test_inputs_hold_only_the_legacy_yaml(self, work_dir):
+        """The legacy app fetches its own resources from the YAML, so nothing else is staged."""
+        cmd_legacy_dispatch(work_dir / "workunit_definition.yml", work_dir, executable="/opt/legacy.bash")
+
+        inputs = InputsSpec.read_yaml(work_dir / "work" / "inputs.yml").inputs
+        assert len(inputs) == 1
+        spec = inputs[0]
+        assert isinstance(spec, LegacyWrapperYamlSpec)
+        assert spec.workunit_id == 349972
+        assert spec.executable == "/opt/legacy.bash"
+        assert spec.filename == "config.yaml"
+
+    def test_output_path_defaults_into_the_chunk_dir(self, work_dir):
+        cmd_legacy_dispatch(work_dir / "workunit_definition.yml", work_dir, executable="/opt/legacy.bash")
+
+        spec = InputsSpec.read_yaml(work_dir / "work" / "inputs.yml").inputs[0]
+        assert spec.output_path == str(work_dir / "work" / "output-WU349972.zip")
+
+    def test_output_filename_override(self, work_dir):
+        cmd_legacy_dispatch(
+            work_dir / "workunit_definition.yml",
+            work_dir,
+            executable="/opt/legacy.bash",
+            output_filename="result.sf3",
+        )
+
+        spec = InputsSpec.read_yaml(work_dir / "work" / "inputs.yml").inputs[0]
+        assert spec.output_path == str(work_dir / "work" / "result.sf3")
+
+    def test_config_filename_override(self, work_dir):
+        cmd_legacy_dispatch(
+            work_dir / "workunit_definition.yml", work_dir, executable="/opt/legacy.bash", config_filename="legacy.yml"
+        )
+
+        assert InputsSpec.read_yaml(work_dir / "work" / "inputs.yml").inputs[0].filename == "legacy.yml"
+
+    def test_definition_without_registration(self, work_dir):
+        path = work_dir / "no_registration.yml"
+        path.write_text(yaml.safe_dump({"execution": {"raw_parameters": {}}, "registration": None}))
+
+        with pytest.raises(ValueError, match="has no registration section"):
+            cmd_legacy_dispatch(path, work_dir, executable="/opt/legacy.bash")
+
+
+class TestCollect:
+    def test_declares_the_produced_output(self, chunk_dir):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+
+        cmd_legacy_collect(chunk_dir)
+
+        specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
+        assert len(specs) == 1
+        assert specs[0].local_path == output
+        assert str(specs[0].store_entry_path) == "result.zip"
+
+    def test_declares_uploads_in_place_alongside_the_output(self, chunk_dir, tmp_path):
+        """Recorded uploads reach the same storage as the main output, without being copied first."""
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+        scratch = tmp_path / "scratch"
+        _record_upload(chunk_dir, scratch / "proteinGroups.txt")
+        _record_upload(chunk_dir, scratch / "specs.pdf")
+
+        cmd_legacy_collect(chunk_dir)
+
+        specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
+        assert [str(spec.store_entry_path) for spec in specs] == ["result.zip", "proteinGroups.txt", "specs.pdf"]
+        # referenced where the app left them, not relocated into the chunk directory
+        assert specs[1].local_path == scratch / "proteinGroups.txt"
+
+    def test_preserves_upload_order(self, chunk_dir, tmp_path):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+        for name in ["specs.pdf", "parameters.txt", "proteinGroups.txt"]:
+            _record_upload(chunk_dir, tmp_path / "scratch" / name)
+
+        cmd_legacy_collect(chunk_dir)
+
+        specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
+        assert [str(spec.store_entry_path) for spec in specs[1:]] == [
+            "specs.pdf",
+            "parameters.txt",
+            "proteinGroups.txt",
+        ]
+
+    def test_ignores_a_repeated_upload_of_the_same_path(self, chunk_dir, tmp_path):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+        upload = tmp_path / "scratch" / "proteinGroups.txt"
+        _record_upload(chunk_dir, upload)
+        _record_upload(chunk_dir, upload)
+
+        cmd_legacy_collect(chunk_dir)
+
+        assert len(OutputsSpec.read_yaml(chunk_dir / "outputs.yml")) == 2
+
+    def test_works_without_any_uploads(self, chunk_dir):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+
+        cmd_legacy_collect(chunk_dir)
+
+        assert len(OutputsSpec.read_yaml(chunk_dir / "outputs.yml")) == 1
+
+    def test_rejects_two_uploads_sharing_a_resource_name(self, chunk_dir, tmp_path):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+        _record_upload(chunk_dir, tmp_path / "a" / "proteinGroups.txt")
+        _record_upload(chunk_dir, tmp_path / "b" / "proteinGroups.txt")
+
+        with pytest.raises(ValueError, match="share a resource name: proteinGroups.txt"):
+            cmd_legacy_collect(chunk_dir)
+
+    def test_missing_output_and_no_uploads_fails(self, chunk_dir):
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+        with pytest.raises(FileNotFoundError, match="did not produce its declared output"):
+            cmd_legacy_collect(chunk_dir)
+
+    def test_missing_output_with_uploads_registers_the_uploads(self, chunk_dir, tmp_path):
+        """A few legacy apps only ever upload extra resources and never write the declared output."""
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+        _record_upload(chunk_dir, tmp_path / "scratch" / "fgcz_MQ_QC_report.pdf")
+
+        cmd_legacy_collect(chunk_dir)
+
+        specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
+        assert [str(spec.store_entry_path) for spec in specs] == ["fgcz_MQ_QC_report.pdf"]
+
+    def test_recorded_upload_that_vanished(self, chunk_dir, tmp_path):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+        upload = _record_upload(chunk_dir, tmp_path / "scratch" / "proteinGroups.txt")
+        upload.unlink()
+
+        with pytest.raises(FileNotFoundError, match="recorded by the app is gone"):
+            cmd_legacy_collect(chunk_dir)
+
+    def test_remote_output_is_rejected(self, chunk_dir):
+        _write_config(chunk_dir, "bfabric@fgcz-ms.uzh.ch:/srv/www/htdocs/result.zip")
+        with pytest.raises(ValueError, match="Cannot register the remote output"):
+            cmd_legacy_collect(chunk_dir)
+
+    def test_missing_config(self, chunk_dir):
+        with pytest.raises(FileNotFoundError, match="No legacy configuration at"):
+            cmd_legacy_collect(chunk_dir)
+
+    def test_custom_config_filename(self, chunk_dir):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output, filename="legacy.yml")
+        cmd_legacy_collect(chunk_dir, config_filename="legacy.yml")
+        assert (chunk_dir / "outputs.yml").is_file()
+
+
+class TestRun:
+    @pytest.fixture
+    def legacy_app(self, tmp_path):
+        """A stand-in legacy app exercising the argument, a no-op shim and the upload shim."""
+        app = tmp_path / "legacy_app.sh"
+        app.write_text(
+            "#!/bin/sh\n"
+            'echo "$1" > "$(dirname "$0")/received_argument"\n'
+            'command -v bfabric_setWorkunitStatus_available.py > "$(dirname "$0")/resolved_command"\n'
+            'echo extra > "$(dirname "$0")/proteinGroups.txt"\n'
+            'bfabric_upload_resource.py "$(dirname "$0")/proteinGroups.txt" 349972\n'
+        )
+        app.chmod(app.stat().st_mode | stat.S_IXUSR)
+        return app
+
+    def test_passes_the_config_path(self, chunk_dir, legacy_app):
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+
+        cmd_legacy_run(str(legacy_app), chunk_dir)
+
+        assert (legacy_app.parent / "received_argument").read_text().strip() == str(chunk_dir / "config.yaml")
+
+    def test_shim_shadows_the_real_status_command(self, chunk_dir, legacy_app):
+        """bfabric_scripts installs the real command, so the shim only helps if it wins on PATH."""
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+
+        cmd_legacy_run(str(legacy_app), chunk_dir)
+
+        assert "app-runner-legacy-shims" in (legacy_app.parent / "resolved_command").read_text()
+
+    def test_uploads_are_recorded_in_the_manifest(self, chunk_dir, legacy_app):
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+
+        cmd_legacy_run(str(legacy_app), chunk_dir)
+
+        manifest = (chunk_dir / UPLOAD_MANIFEST_FILENAME).read_text().splitlines()
+        assert manifest == [str(legacy_app.parent / "proteinGroups.txt")]
+
+    def test_missing_config(self, chunk_dir, legacy_app):
+        with pytest.raises(FileNotFoundError, match="No legacy configuration at"):
+            cmd_legacy_run(str(legacy_app), chunk_dir)
+
+    def test_failing_app_raises(self, chunk_dir, tmp_path):
+        failing = tmp_path / "failing.sh"
+        failing.write_text("#!/bin/sh\nexit 3\n")
+        failing.chmod(failing.stat().st_mode | stat.S_IXUSR)
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+
+        with pytest.raises(Exception, match="returned non-zero exit status 3"):
+            cmd_legacy_run(str(failing), chunk_dir)

--- a/tests/bfabric_app_runner/cli/test_legacy.py
+++ b/tests/bfabric_app_runner/cli/test_legacy.py
@@ -1,4 +1,5 @@
 import stat
+from pathlib import Path
 
 import pytest
 import yaml
@@ -57,10 +58,11 @@ class TestDispatch:
         return work_dir
 
     def test_writes_a_single_chunk(self, work_dir):
+        """Relative to the work directory, as ChunksFile documents and infer_from_directory produces."""
         cmd_legacy_dispatch(work_dir / "workunit_definition.yml", work_dir, executable="/opt/legacy.bash")
 
         chunks = yaml.safe_load((work_dir / "chunks.yml").read_text())["chunks"]
-        assert chunks == [str(work_dir / "work")]
+        assert chunks == ["work"]
 
     def test_inputs_hold_only_the_legacy_yaml(self, work_dir):
         """The legacy app fetches its own resources from the YAML, so nothing else is staged."""
@@ -97,6 +99,16 @@ class TestDispatch:
         )
 
         assert InputsSpec.read_yaml(work_dir / "work" / "inputs.yml").inputs[0].filename == "legacy.yml"
+
+    def test_output_path_is_absolute_for_a_relative_work_dir(self, work_dir, monkeypatch):
+        """The app reads output_path after its own `cd`, so a relative path would misdirect it."""
+        monkeypatch.chdir(work_dir.parent)
+        relative = Path(work_dir.name)
+
+        cmd_legacy_dispatch(relative / "workunit_definition.yml", relative, executable="/opt/legacy.bash")
+
+        spec = InputsSpec.read_yaml(work_dir / "work" / "inputs.yml").inputs[0]
+        assert spec.output_path == str(work_dir / "work" / "output-WU349972.zip")
 
     def test_definition_without_registration(self, work_dir):
         path = work_dir / "no_registration.yml"
@@ -218,6 +230,30 @@ class TestWriteOutputsSpec:
         with pytest.raises(ValueError, match="Cannot register the remote output"):
             declare()
 
+    def test_an_uploaded_declared_output_is_one_resource(self, chunk_dir, declare):
+        """An app may scp its output and upload it too; that is not a name clash."""
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        _write_config(chunk_dir, output)
+        _record_upload(chunk_dir, output)
+
+        declare()
+
+        specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
+        assert [str(spec.store_entry_path) for spec in specs] == ["result.zip"]
+
+    def test_the_same_file_declared_and_uploaded_by_different_paths(self, chunk_dir, declare):
+        output = chunk_dir / "result.zip"
+        output.write_text("payload")
+        (chunk_dir / "sub").mkdir()
+        _write_config(chunk_dir, output)
+        # the app's own path for the same file, which only `resolve()` reveals as a duplicate
+        _record_upload(chunk_dir, chunk_dir / "sub" / ".." / "result.zip")
+
+        declare()
+
+        assert len(OutputsSpec.read_yaml(chunk_dir / "outputs.yml")) == 1
+
 
 class TestRun:
     @pytest.fixture
@@ -267,6 +303,26 @@ class TestRun:
 
         specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
         assert [str(spec.store_entry_path) for spec in specs] == ["result.zip", "proteinGroups.txt"]
+
+    def test_retry_does_not_inherit_the_previous_run_uploads(self, chunk_dir, legacy_app, tmp_path):
+        """A stale manifest entry would either fail the retry or register a file it never produced."""
+        _write_config(chunk_dir, chunk_dir / "result.zip")
+        stale = _record_upload(chunk_dir, tmp_path / "gone" / "from_run_one.txt")
+        stale.unlink()
+
+        cmd_legacy_run(str(legacy_app), chunk_dir)
+
+        specs = OutputsSpec.read_yaml(chunk_dir / "outputs.yml")
+        assert [str(spec.store_entry_path) for spec in specs] == ["result.zip", "proteinGroups.txt"]
+
+    def test_remote_output_is_rejected_before_the_app_runs(self, chunk_dir, legacy_app):
+        """Failing afterwards would throw away the whole run for something knowable up front."""
+        _write_config(chunk_dir, "bfabric@fgcz-ms.uzh.ch:/srv/www/htdocs/result.zip")
+
+        with pytest.raises(ValueError, match="Cannot register the remote output"):
+            cmd_legacy_run(str(legacy_app), chunk_dir)
+
+        assert not (legacy_app.parent / "received_argument").exists()
 
     def test_custom_config_filename(self, chunk_dir, legacy_app):
         _write_config(chunk_dir, chunk_dir / "result.zip", filename="legacy.yml")

--- a/tests/bfabric_app_runner/inputs/resolve/test_resolve_legacy_wrapper_yaml_specs.py
+++ b/tests/bfabric_app_runner/inputs/resolve/test_resolve_legacy_wrapper_yaml_specs.py
@@ -1,0 +1,50 @@
+import pytest
+import yaml
+from bfabric_app_runner.inputs.resolve._resolve_legacy_wrapper_yaml_specs import ResolveLegacyWrapperYamlSpecs
+from bfabric_app_runner.inputs.resolve.resolved_inputs import ResolvedStaticFile
+from bfabric_app_runner.specs.inputs.legacy_wrapper_yaml_spec import LegacyWrapperYamlSpec
+
+
+@pytest.fixture
+def mock_client(mocker):
+    return mocker.MagicMock(name="mock_client")
+
+
+@pytest.fixture
+def mock_build(mocker):
+    return mocker.patch(
+        "bfabric_app_runner.inputs.resolve._resolve_legacy_wrapper_yaml_specs.build_legacy_wrapper_yaml",
+        return_value={"application": {"protocol": "scp"}},
+    )
+
+
+@pytest.fixture
+def resolver(mock_client):
+    return ResolveLegacyWrapperYamlSpecs(client=mock_client)
+
+
+@pytest.fixture
+def spec():
+    return LegacyWrapperYamlSpec(filename="config.yaml", workunit_id=1234, output_path="/work/chunk/result.zip")
+
+
+def test_call(resolver, spec, mock_build):
+    result = resolver([spec])
+    assert result == [ResolvedStaticFile(filename="config.yaml", content=yaml.safe_dump(mock_build.return_value))]
+
+
+def test_call_passes_spec_fields_through(resolver, mock_client, mock_build):
+    spec = LegacyWrapperYamlSpec(
+        filename="config.yaml", workunit_id=1234, output_path="/work/chunk/result.zip", executable="/opt/legacy.bash"
+    )
+    resolver([spec])
+    mock_build.assert_called_once_with(
+        client=mock_client,
+        workunit_id=1234,
+        output_path="/work/chunk/result.zip",
+        executable="/opt/legacy.bash",
+    )
+
+
+def test_call_when_empty(resolver):
+    assert resolver([]) == []

--- a/tests/bfabric_app_runner/legacy/test_shim.py
+++ b/tests/bfabric_app_runner/legacy/test_shim.py
@@ -1,0 +1,116 @@
+import os
+import subprocess
+
+import pytest
+from bfabric_app_runner.legacy.shim import (
+    NOOP_COMMANDS,
+    SHIMMED_COMMANDS,
+    UPLOAD_COMMAND,
+    UPLOAD_MANIFEST_ENV,
+    materialize_shim_dir,
+)
+
+
+@pytest.fixture
+def shim_dir(tmp_path):
+    return materialize_shim_dir(tmp_path / "shims")
+
+
+def _run(script, *args, env=None, cwd=None):
+    return subprocess.run([str(script), *args], capture_output=True, text=True, env=env, cwd=cwd)
+
+
+def test_writes_every_shimmed_command(shim_dir):
+    assert sorted(p.name for p in shim_dir.iterdir()) == sorted(SHIMMED_COMMANDS)
+
+
+@pytest.mark.parametrize("command", SHIMMED_COMMANDS)
+def test_shim_is_executable(shim_dir, command):
+    assert os.access(shim_dir / command, os.X_OK)
+
+
+def test_materialize_is_idempotent(tmp_path):
+    target = tmp_path / "shims"
+    assert sorted(p.name for p in materialize_shim_dir(target).iterdir()) == sorted(
+        p.name for p in materialize_shim_dir(target).iterdir()
+    )
+
+
+class TestNoopShims:
+    @pytest.mark.parametrize(
+        "args",
+        [
+            pytest.param([], id="no_args"),
+            pytest.param(["12345"], id="single_id"),
+            pytest.param(["0", "0", "0"], id="three_sentinels_as_RESSOURCEID_expands"),
+            pytest.param(["not-an-integer"], id="non_integer"),
+        ],
+    )
+    def test_succeeds_on_any_argv(self, shim_dir, args):
+        result = _run(shim_dir / "bfabric_setResourceStatus_available.py", *args)
+        assert result.returncode == 0
+        assert "bfabric_setResourceStatus_available.py" in result.stderr
+
+    def test_upload_is_not_a_noop(self):
+        """It records files for registration rather than discarding them."""
+        assert UPLOAD_COMMAND not in NOOP_COMMANDS
+
+
+class TestUploadShim:
+    @pytest.fixture
+    def payload(self, tmp_path):
+        payload = tmp_path / "scratch" / "proteinGroups.txt"
+        payload.parent.mkdir()
+        payload.write_text("gene\tintensity\n")
+        return payload
+
+    @pytest.fixture
+    def manifest(self, tmp_path):
+        return tmp_path / "chunk" / "legacy_uploads.txt"
+
+    @pytest.fixture
+    def env(self, manifest):
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        return {UPLOAD_MANIFEST_ENV: str(manifest)}
+
+    def test_records_the_path(self, shim_dir, payload, manifest, env):
+        # the workunit id is the real command's second argument and is irrelevant here
+        result = _run(shim_dir / UPLOAD_COMMAND, str(payload), "349972", env=env)
+
+        assert result.returncode == 0
+        assert manifest.read_text().splitlines() == [str(payload)]
+
+    def test_leaves_the_file_in_place(self, shim_dir, payload, env):
+        """No legacy app removes its scratch, so there is no reason to copy possibly-huge output."""
+        _ = _run(shim_dir / UPLOAD_COMMAND, str(payload), "349972", env=env)
+
+        assert payload.is_file()
+
+    def test_appends_across_calls(self, shim_dir, payload, manifest, env):
+        other = payload.with_name("parameters.txt")
+        other.write_text("params\n")
+
+        _ = _run(shim_dir / UPLOAD_COMMAND, str(payload), "349972", env=env)
+        _ = _run(shim_dir / UPLOAD_COMMAND, str(other), "349972", env=env)
+
+        assert manifest.read_text().splitlines() == [str(payload), str(other)]
+
+    def test_resolves_a_relative_path(self, shim_dir, payload, manifest, env):
+        result = _run(shim_dir / UPLOAD_COMMAND, payload.name, "349972", env=env, cwd=payload.parent)
+
+        assert result.returncode == 0
+        assert manifest.read_text().splitlines() == [str(payload)]
+
+    def test_tolerates_missing_file(self, shim_dir, tmp_path, manifest, env):
+        """Callers append `|| { echo failed; }`, so a missing file must not abort the app."""
+        result = _run(shim_dir / UPLOAD_COMMAND, str(tmp_path / "absent.txt"), "349972", env=env)
+
+        assert result.returncode == 0
+        assert "no such file" in result.stderr
+        assert not manifest.exists()
+
+    def test_without_manifest_it_is_a_noop(self, shim_dir, payload):
+        result = _run(shim_dir / UPLOAD_COMMAND, str(payload), "349972", env={})
+
+        assert result.returncode == 0
+        assert "no upload manifest set" in result.stderr

--- a/tests/bfabric_app_runner/legacy/test_wrapper_yaml.py
+++ b/tests/bfabric_app_runner/legacy/test_wrapper_yaml.py
@@ -1,0 +1,202 @@
+import pytest
+import yaml
+from bfabric_app_runner.legacy.wrapper_yaml import build_legacy_wrapper_yaml
+
+from bfabric.entities import Application, Dataset, Executable, Order, Project, Resource, Storage, Workunit
+
+
+def _entity(mocker, cls, entity_id, data):
+    """A MagicMock that passes ``isinstance`` for ``cls`` and supports ``entity[key]`` / ``.data_dict``."""
+    entity = mocker.MagicMock(spec=cls, name=f"{cls.__name__}{entity_id}")
+    entity.id = entity_id
+    entity.data_dict = dict(data)
+    entity.__getitem__.side_effect = data.__getitem__
+    entity.uri = f"https://bfabric.example.com/bfabric/{cls.__name__.lower()}/show.html?id={entity_id}"
+    return entity
+
+
+@pytest.fixture
+def mock_input_resources(mocker):
+    """Two resources produced by the same upstream application, as a resource-flow workunit would have."""
+    producer = _entity(mocker, Workunit, 100, {"name": "upstream"})
+    producer.application = _entity(mocker, Application, 20, {"name": "QEXACTIVEHFX_1"})
+    storage = _entity(mocker, Storage, 2, {"host": "fgcz-ms.uzh.ch", "basepath": "/srv/www/htdocs/"})
+    storage.scp_prefix = "fgcz-ms.uzh.ch:/srv/www/htdocs/"
+
+    resources = []
+    for resource_id, relative_path in [(720983, "p2621/first.raw"), (720984, "p2621/second.raw")]:
+        resource = _entity(mocker, Resource, resource_id, {"relativepath": relative_path})
+        resource.workunit = producer
+        resource.storage = storage
+        resources.append(resource)
+    return resources
+
+
+@pytest.fixture
+def mock_order(mocker):
+    order = _entity(mocker, Order, 4854, {"fastasequence": ">seq\rACGT\r"})
+    order.project = _entity(mocker, Project, 2621, {})
+    return order
+
+
+@pytest.fixture
+def mock_workunit(mocker, mock_input_resources, mock_order):
+    workunit = _entity(mocker, Workunit, 181492, {"createdby": "lkunz", "name": "the workunit"})
+    workunit.application = _entity(mocker, Application, 224, {"name": "MaxQuant"})
+    workunit.application.executable = _entity(
+        mocker, Executable, 11851, {"program": "/home/bfabric/sgeworker/bin/fgcz_sge_maxquant_linux.bash"}
+    )
+    workunit.application_parameters = {"/numThreads": "48", "Rmd": None}
+    workunit.input_resources.list = mock_input_resources
+    workunit.input_dataset = None
+    workunit.container = mock_order
+    return workunit
+
+
+@pytest.fixture
+def mock_client(mocker, mock_workunit):
+    client = mocker.MagicMock(name="mock_client")
+    client.reader.read_id.return_value = mock_workunit
+    return client
+
+
+@pytest.fixture
+def config(mock_client):
+    return build_legacy_wrapper_yaml(
+        client=mock_client, workunit_id=181492, output_path="/work/WU181492/work/result.zip"
+    )
+
+
+class TestApplicationSection:
+    def test_parameters_replace_none_with_empty_string(self, config):
+        assert config["application"]["parameters"] == {"/numThreads": "48", "Rmd": ""}
+
+    def test_protocol(self, config):
+        assert config["application"]["protocol"] == "scp"
+
+    def test_input_groups_scp_urls_by_producing_application(self, config):
+        assert config["application"]["input"] == {
+            "QEXACTIVEHFX_1": [
+                "bfabric@fgcz-ms.uzh.ch:/srv/www/htdocs/p2621/first.raw",
+                "bfabric@fgcz-ms.uzh.ch:/srv/www/htdocs/p2621/second.raw",
+            ]
+        }
+
+    def test_output_is_the_requested_path(self, config):
+        assert config["application"]["output"] == ["/work/WU181492/work/result.zip"]
+
+
+class TestJobConfigurationSection:
+    def test_executable_defaults_to_the_application_program(self, config):
+        assert config["job_configuration"]["executable"] == "/home/bfabric/sgeworker/bin/fgcz_sge_maxquant_linux.bash"
+
+    def test_executable_override(self, mock_client):
+        config = build_legacy_wrapper_yaml(
+            client=mock_client, workunit_id=181492, output_path="/out.zip", executable="/opt/legacy.bash"
+        )
+        assert config["job_configuration"]["executable"] == "/opt/legacy.bash"
+
+    def test_input_groups_ids_and_uris_by_producing_application(self, config):
+        assert config["job_configuration"]["input"] == {
+            "QEXACTIVEHFX_1": [
+                {
+                    "resource_id": 720983,
+                    "resource_url": "https://bfabric.example.com/bfabric/resource/show.html?id=720983",
+                },
+                {
+                    "resource_id": 720984,
+                    "resource_url": "https://bfabric.example.com/bfabric/resource/show.html?id=720984",
+                },
+            ]
+        }
+
+    def test_fastasequence_normalises_carriage_returns(self, config):
+        assert config["job_configuration"]["fastasequence"] == ">seq\nACGT\n"
+
+    def test_workunit_fields(self, config):
+        assert config["job_configuration"]["workunit_id"] == 181492
+        assert config["job_configuration"]["workunit_createdby"] == "lkunz"
+        assert (
+            config["job_configuration"]["workunit_url"]
+            == "https://bfabric.example.com/bfabric/workunit/show.html?id=181492"
+        )
+
+    def test_output_carries_no_resource(self, config):
+        assert config["job_configuration"]["output"] == {"protocol": "file", "resource_id": 0, "ssh_args": ""}
+
+    def test_log_sections_carry_no_resource(self, config):
+        expected = {"protocol": "file", "resource_id": 0, "url": "/dev/null"}
+        assert config["job_configuration"]["stdout"] == expected
+        assert config["job_configuration"]["stderr"] == expected
+
+    def test_external_job_id_is_a_sentinel(self, config):
+        """There is no external job under app-runner, but ``0`` keeps a ``set -u`` consumer working."""
+        assert config["job_configuration"]["external_job_id"] == 0
+
+
+class TestContainer:
+    def test_order_container_reports_order_and_its_project(self, config):
+        assert config["job_configuration"]["order_id"] == 4854
+        assert config["job_configuration"]["project_id"] == 2621
+
+    def test_order_without_project(self, mock_client, mock_order, config_of):
+        mock_order.project = None
+        config = config_of(mock_client)
+        assert config["job_configuration"]["order_id"] == 4854
+        assert config["job_configuration"]["project_id"] is None
+
+    def test_project_container(self, mocker, mock_client, mock_workunit, config_of):
+        mock_workunit.container = _entity(mocker, Project, 2621, {})
+        config = config_of(mock_client)
+        assert config["job_configuration"]["order_id"] is None
+        assert config["job_configuration"]["project_id"] == 2621
+        assert config["job_configuration"]["fastasequence"] == ""
+
+    def test_container_that_is_neither(self, mocker, mock_client, mock_workunit, config_of):
+        """The legacy implementation raised AttributeError here."""
+        mock_workunit.container = _entity(mocker, Dataset, 5, {})
+        config = config_of(mock_client)
+        assert config["job_configuration"]["order_id"] is None
+        assert config["job_configuration"]["project_id"] is None
+
+
+class TestInputDataset:
+    def test_absent(self, config):
+        assert config["job_configuration"]["inputdataset"] is None
+
+    def test_present(self, mocker, mock_client, mock_workunit, config_of):
+        mock_workunit.input_dataset = _entity(mocker, Dataset, 77, {"name": "the dataset"})
+        config = config_of(mock_client)
+        assert config["job_configuration"]["inputdataset"] == {"_id": 77, "name": "the dataset"}
+
+
+@pytest.fixture
+def config_of():
+    def build(client):
+        return build_legacy_wrapper_yaml(client=client, workunit_id=181492, output_path="/out.zip")
+
+    return build
+
+
+def test_missing_workunit(mock_client):
+    mock_client.reader.read_id.return_value = None
+    with pytest.raises(ValueError, match="Workunit 181492 does not exist"):
+        build_legacy_wrapper_yaml(client=mock_client, workunit_id=181492, output_path="/out.zip")
+
+
+def test_input_resource_on_non_scp_storage(mock_client, mock_input_resources, config_of):
+    """Interpolating a None scp prefix would produce a URL that only fails once the app runs."""
+    mock_input_resources[0].storage.scp_prefix = None
+    with pytest.raises(ValueError, match="is not scp-accessible"):
+        config_of(mock_client)
+
+
+def test_serialization_has_no_yaml_aliases(config):
+    """stdout and stderr must be distinct dicts, or safe_dump emits an anchor the legacy parsers choke on."""
+    serialized = yaml.safe_dump(config)
+    assert "&id" not in serialized
+    assert "*id" not in serialized
+
+
+def test_top_level_keys(config):
+    assert set(config) == {"application", "job_configuration"}

--- a/tests/bfabric_app_runner/legacy/test_wrapper_yaml.py
+++ b/tests/bfabric_app_runner/legacy/test_wrapper_yaml.py
@@ -96,6 +96,13 @@ class TestJobConfigurationSection:
         )
         assert config["job_configuration"]["executable"] == "/opt/legacy.bash"
 
+    def test_executable_without_a_program(self, mock_client, mock_workunit, mocker):
+        """Explicit, since indexing the missing key would only raise a bare KeyError."""
+        mock_workunit.application.executable = _entity(mocker, Executable, 11851, {"context": "SUBMITTER"})
+
+        with pytest.raises(ValueError, match="has no `program`"):
+            _ = build_legacy_wrapper_yaml(client=mock_client, workunit_id=181492, output_path="/out.zip")
+
     def test_input_groups_ids_and_uris_by_producing_application(self, config):
         assert config["job_configuration"]["input"] == {
             "QEXACTIVEHFX_1": [

--- a/tests/bfabric_app_runner/specs/test_inputs_spec.py
+++ b/tests/bfabric_app_runner/specs/test_inputs_spec.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 from bfabric_app_runner.specs.inputs.bfabric_dataset_spec import BfabricDatasetSpec
 from bfabric_app_runner.specs.inputs.bfabric_resource_spec import BfabricResourceSpec
+from bfabric_app_runner.specs.inputs.legacy_wrapper_yaml_spec import LegacyWrapperYamlSpec
 from bfabric_app_runner.specs.inputs_spec import InputsSpec
 
 
@@ -22,6 +23,11 @@ def parsed() -> InputsSpec:
                 filename="filename",
                 separator=",",
             ),
+            LegacyWrapperYamlSpec(
+                filename="config.yaml",
+                workunit_id=3,
+                output_path="/work/chunk/result.zip",
+            ),
         ]
     )
 
@@ -36,7 +42,12 @@ def serialized() -> str:
 - filename: filename
   id: 2
   separator: ','
-  type: bfabric_dataset"""
+  type: bfabric_dataset
+- executable: null
+  filename: config.yaml
+  output_path: /work/chunk/result.zip
+  type: legacy_wrapper_yaml
+  workunit_id: 3"""
 
 
 def test_write_yaml(parsed):


### PR DESCRIPTION
- Add a `legacy_wrapper_yaml` input type that writes the legacy wrapper-creator `config.yaml` for a workunit, reading only from B-Fabric.
- Add `legacy dispatch` and `legacy run` so an `app.yml` can wrap a legacy app with no per-app Python; `run` declares the outputs itself, so no `collect` command is needed.
- Change a wrapped app's `bfabric_upload_resource.py` calls to register on the application's storage instead of B-Fabric's internal storage.
- The generated YAML carries no external job and no `slurm_stdout`/`slurm_stderr` resources, since app-runner owns that state itself.
- `fgcz_slurm_maxquant_textfiles.bash` and `fgcz_slurm_SummarizedExperiment_A315.bash` parse the output path assuming a `host:path` shape and need adapting before they can run this way.

Closes #262

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.