### PR TITLE
Only re-download and re-extract archive inputs when they changed

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Output registration always creates a new resource instead of recycling the legacy wrapper creator's `pending` placeholder ([#361](https://github.com/fgcz/bfabricPy/issues/361)); the `reuse_default_resource` field and its CLI options are gone, but remain tolerated in an `app.yml`.
 - Relative paths in the app spec (`pylock`, `local_extra_deps`, `prepend_paths`, host side of docker `mounts`) resolve against the `app.yml` directory instead of the run's scratch directory, with a leading `~` expanded ([#212](https://github.com/fgcz/bfabricPy/issues/212)).
 - Captured command output (`uv venv` / `uv pip install`) is logged one record per line, so every line carries its level prefix.
+- Preparing an archive input (`bfabric_resource_archive`) reuses an already downloaded archive whose checksum still matches, and only extracts the entries whose local copy is missing or differs (size, then CRC32), so a repeated prepare does no work when nothing changed ([#458](https://github.com/fgcz/bfabricPy/issues/458)).
+- `inputs check` now also verifies the extracted files of an archive input, not just the downloaded archive.
 - Requires `bfabric` 1.20.1 for the logging fix that keeps a nested app-runner from falling back to loguru's verbose DEBUG format.
 - Internal: the input `Resolver` dispatches through a spec-class registry instead of an `issubclass` ladder, and reports a spec type with no resolver when it is constructed rather than part-way through a resolve; clears the 38 grandfathered basedpyright entries on that module.
 
@@ -22,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The demo app copier template can be instantiated again; the destination must now be given as an absolute path.
 - A failing app command reports a single `Error: Command failed with exit code N: <command>` line instead of ~10 frames of app-runner boilerplate ([#231](https://github.com/fgcz/bfabricPy/issues/231)).
 - `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory.
+- `BfabricResourceArchiveSpec.check_checksum` now takes effect: the downloaded archive is verified against the resource checksum instead of being accepted unchecked.
+- `inputs check` locates an archive input's cached archive correctly when the input filename contains a subdirectory (it looked for `input/input/name.zip`).
 
 ## \[0.7.0\] - 2026-08-03
 

--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `run workunit` no longer prints a second traceback when `make run-all` fails; it reports one line naming the workunit, exit code, and work directory.
 - `BfabricResourceArchiveSpec.check_checksum` now takes effect: the downloaded archive is verified against the resource checksum instead of being accepted unchecked.
 - `inputs check` locates an archive input's cached archive correctly when the input filename contains a subdirectory (it looked for `input/input/name.zip`).
+- `inputs clean` removes an archive input's extracted directory and its cached archive, instead of aborting on the directory and removing nothing.
 
 ## \[0.7.0\] - 2026-08-03
 

--- a/bfabric_app_runner/src/bfabric_app_runner/inputs/list_inputs/integrity.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/inputs/list_inputs/integrity.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import zipfile
 from enum import Enum
 from typing import TYPE_CHECKING, assert_never
 
 from bfabric.transfer import md5_checksum
+from bfabric_app_runner.inputs.prepare.prepare_resolved_directory import all_entries_current, archive_cache_path
 from bfabric_app_runner.inputs.resolve.resolved_inputs import (
     ResolvedInput,
     ResolvedFile,
@@ -73,8 +75,9 @@ def check_integrity(file: ResolvedInput, local_path: Path, client: Bfabric) -> I
             return _check_directory_integrity(file, local_path)
         else:
             assert_never(file)
-    except OSError:
-        # File exists but can't be read - treat as incorrect to trigger refresh
+    except (OSError, zipfile.BadZipFile):
+        # Exists but can't be read, or the cached archive isn't a readable zip (BadZipFile is not an
+        # OSError) - treat as incorrect to trigger refresh rather than raising out of a check.
         return IntegrityState.Incorrect
 
 
@@ -99,7 +102,8 @@ def _check_directory_integrity(file: ResolvedDirectory, local_path: Path) -> Int
 
     For directories, we validate:
     1. The extracted directory exists and contains files
-    2. The cache .zip file (if it exists) has correct checksum
+    2. The cache .zip file has the correct checksum
+    3. Every entry the archive would extract is present and unmodified
 
     If no checksum is available, we do basic structural validation.
     """
@@ -114,18 +118,14 @@ def _check_directory_integrity(file: ResolvedDirectory, local_path: Path) -> Int
     except PermissionError:
         return IntegrityState.Incorrect
 
-    # Check the cache .zip file if checksum is available
-    if file.checksum is not None:
-        cache_file = local_path.parent / f"{file.filename}.zip"
-        if cache_file.exists():
-            if not cache_file.is_file():
-                return IntegrityState.Incorrect
-            # Validate cache file checksum
-            actual_checksum = md5_checksum(cache_file)
-            return IntegrityState.Correct if file.checksum == actual_checksum else IntegrityState.Incorrect
-        else:
-            # Cache file missing but we have checksum - trigger refresh
-            return IntegrityState.Incorrect
-
     # No checksum available - can only do basic validation
-    return IntegrityState.NotChecked
+    if file.checksum is None:
+        return IntegrityState.NotChecked
+
+    # Validate the cached archive (see issue #323 for the nested-filename case its path handles).
+    cache_file = archive_cache_path(local_path)
+    if not cache_file.is_file() or md5_checksum(cache_file) != file.checksum:
+        return IntegrityState.Incorrect
+
+    # The archive is the current one, so the extracted files are what remains to be verified.
+    return IntegrityState.Correct if all_entries_current(cache_file, local_path, file) else IntegrityState.Incorrect

--- a/bfabric_app_runner/src/bfabric_app_runner/inputs/prepare/prepare_folder.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/inputs/prepare/prepare_folder.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import os
+import shutil
 from typing import TYPE_CHECKING, Literal, assert_never
 
 from bfabric.transfer import ScopeError, check_download_scope, token_provider
 from loguru import logger
 
 from bfabric_app_runner.inputs.prepare.prepare_context import PrepareContext
-from bfabric_app_runner.inputs.prepare.prepare_resolved_directory import prepare_resolved_directory
+from bfabric_app_runner.inputs.prepare.prepare_resolved_directory import (
+    archive_cache_path,
+    prepare_resolved_directory,
+)
 from bfabric_app_runner.inputs.prepare.prepare_resolved_file import prepare_resolved_file
 from bfabric_app_runner.inputs.prepare.prepare_resolved_static_file import prepare_resolved_static_file
 from bfabric_app_runner.inputs.resolve.resolved_inputs import (
@@ -124,6 +129,38 @@ def _clean_input_files(input_files: ResolvedInputs, working_dir: Path) -> None:
     """Removes the specified files from working_dir, if they exist."""
     for input_file in input_files.files:
         path = working_dir / input_file.filename
-        if path.exists():
-            path.unlink()
-            logger.info(f"Removed {path}")
+        if not _is_inside(path, working_dir):
+            # A filename of "." resolves to working_dir itself, and one containing ".." can point
+            # outside it; removing a directory input there would take the whole chunk folder (or a
+            # sibling) with it.
+            logger.warning(f"Refusing to remove {path}, which is not inside {working_dir}")
+            continue
+        _remove_input_path(path)
+        if isinstance(input_file, ResolvedDirectory):
+            # The cached archive sits beside the extracted directory and the next prepare would reuse
+            # it, so leaving it behind would not be a clean.
+            _remove_input_path(archive_cache_path(path))
+
+
+def _is_inside(path: Path, working_dir: Path) -> bool:
+    """Whether ``path`` is strictly inside ``working_dir``, collapsing ``.`` and ``..`` lexically.
+
+    Lexically rather than via ``resolve()``, so a symlinked input (``link: true``, whose target lives
+    outside the working directory) still counts as inside and gets cleaned.
+    """
+    normalized = os.path.normpath(path)
+    base = os.path.normpath(working_dir)
+    # normpath strips any trailing separator, so appending one makes this a true path-component prefix
+    # check: "/work/sub" is inside "/work", "/workspace" is not.
+    return normalized.startswith(f"{base}{os.sep}")
+
+
+def _remove_input_path(path: Path) -> None:
+    """Removes a file, symlink or directory tree, logging only what was actually there."""
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    elif path.exists() or path.is_symlink():
+        path.unlink()
+    else:
+        return
+    logger.info(f"Removed {path}")

--- a/bfabric_app_runner/src/bfabric_app_runner/inputs/prepare/prepare_resolved_directory.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/inputs/prepare/prepare_resolved_directory.py
@@ -1,7 +1,9 @@
 import shutil
 import zipfile
+import zlib
 from pathlib import Path
 
+from bfabric.transfer import md5_checksum
 from loguru import logger
 
 from bfabric_app_runner.inputs._filter_files import filter_files
@@ -23,9 +25,12 @@ def prepare_resolved_directory(file: ResolvedDirectory, working_dir: Path, conte
 
 def _prepare_zip_archive(file: ResolvedDirectory, output_path: Path, context: PrepareContext) -> None:
     """Prepare a zip archive by downloading, extracting, and filtering."""
-    # Download zip to permanent location in working directory for caching
-    zip_path = output_path.parent / f"{output_path.name}.zip"
-    _download_file(file, zip_path, context)
+    # Without a checksum to prove the local copy is the current one, re-download.
+    zip_path = archive_cache_path(output_path)
+    if file.checksum is not None and zip_path.is_file() and md5_checksum(zip_path) == file.checksum:
+        logger.info(f"Reusing already downloaded {zip_path}")
+    else:
+        _download_file(file, zip_path, context)
     _extract_zip_with_filtering(zip_path, output_path, file)
 
 
@@ -35,7 +40,7 @@ def _download_file(file: ResolvedDirectory, zip_path: Path, context: PrepareCont
         source=file.source,
         filename=zip_path.name,
         link=False,
-        checksum=None,
+        checksum=file.checksum,
     )
     prepare_resolved_file(file=zip_resolved_file, working_dir=zip_path.parent, context=context)
 
@@ -45,24 +50,84 @@ def _extract_zip_with_filtering(zip_path: Path, output_path: Path, file: Resolve
     output_path.mkdir(parents=True, exist_ok=True)
 
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
-        # Filter files based on include/exclude patterns, excluding directories
-        filtered_files = [
-            f
-            for f in filter_files(zip_ref.namelist(), file.include_patterns, file.exclude_patterns)
-            if not f.endswith("/")
-        ]
+        entries = _planned_entries(zip_ref, output_path, file)
 
-        # Determine if we should strip root based on archive structure
-        should_strip_root = file.strip_root and _should_strip_root_directory(zip_ref.namelist())
-
-        # Extract filtered files
-        for file_path in filtered_files:
-            output_file_path = _get_output_file_path(file_path, output_path, should_strip_root)
+        num_extracted = 0
+        for zip_info, output_file_path in entries:
+            if _is_entry_current(zip_info, output_file_path):
+                continue
             output_file_path.parent.mkdir(parents=True, exist_ok=True)
 
-            logger.info(f"Extracting {file_path} to {output_file_path}")
-            with zip_ref.open(file_path) as source, output_file_path.open("wb") as target:
+            logger.info(f"Extracting {zip_info.filename} to {output_file_path}")
+            with zip_ref.open(zip_info) as source, output_file_path.open("wb") as target:
                 shutil.copyfileobj(source, target)
+            num_extracted += 1
+
+        logger.info(
+            f"Extracted {num_extracted} of {len(entries)} entries into {output_path}"
+            f" ({len(entries) - num_extracted} already up-to-date)"
+        )
+
+
+def archive_cache_path(output_path: Path) -> Path:
+    """The archive kept beside an extracted directory so a repeated prepare can reuse it.
+
+    Derived from the last path component, not the spec's ``filename``: a filename may contain a
+    subdirectory, in which case the archive belongs inside it rather than one level below.
+    """
+    return output_path.parent / f"{output_path.name}.zip"
+
+
+def all_entries_current(zip_path: Path, output_path: Path, file: ResolvedDirectory) -> bool:
+    """Whether extracting ``zip_path`` into ``output_path`` would be a no-op.
+
+    Shares :func:`_planned_entries` with the extraction itself, so an integrity check cannot drift from
+    what a prepare would actually do.
+    """
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        return all(_is_entry_current(zip_info, path) for zip_info, path in _planned_entries(zip_ref, output_path, file))
+
+
+def _planned_entries(
+    zip_ref: zipfile.ZipFile, output_path: Path, file: ResolvedDirectory
+) -> list[tuple[zipfile.ZipInfo, Path]]:
+    """The archive entries the spec selects, paired with the path each one extracts to."""
+    # Filter files based on include/exclude patterns, excluding directories
+    filtered_files = [
+        f for f in filter_files(zip_ref.namelist(), file.include_patterns, file.exclude_patterns) if not f.endswith("/")
+    ]
+
+    # Determine if we should strip root based on archive structure
+    should_strip_root = file.strip_root and _should_strip_root_directory(zip_ref.namelist())
+
+    return [
+        (zip_ref.getinfo(file_path), _get_output_file_path(file_path, output_path, should_strip_root))
+        for file_path in filtered_files
+    ]
+
+
+def _is_entry_current(zip_info: zipfile.ZipInfo, path: Path) -> bool:
+    """Whether ``path`` already holds this zip entry's bytes, comparing the size first and then the CRC32.
+
+    Zip stores a CRC-32/ISO-HDLC per entry, which is exactly what :func:`zlib.crc32` computes, so a
+    modified extracted file is detected even when the archive itself is unchanged. A missing or
+    unreadable path counts as not current, i.e. it will be (re-)extracted.
+    """
+    try:
+        if path.stat().st_size != zip_info.file_size:
+            return False
+        return _crc32(path) == zip_info.CRC
+    except OSError:
+        return False
+
+
+def _crc32(path: Path, chunk_size: int = 1024 * 1024) -> int:
+    """Computes the CRC32 of ``path``, reading it in chunks."""
+    value = 0
+    with path.open("rb") as fh:
+        while chunk := fh.read(chunk_size):
+            value = zlib.crc32(chunk, value)
+    return value
 
 
 def _should_strip_root_directory(all_files: list[str]) -> bool:

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_resource_archive_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/inputs/bfabric_resource_archive_spec.py
@@ -31,4 +31,7 @@ class BfabricResourceArchiveSpec(BaseModel):
     """If True, the root directory (if present) of the archive will be stripped during extraction."""
 
     check_checksum: bool = True
-    """Whether to check the checksum of the archive file, after downloading."""
+    """Whether to verify the downloaded archive against the resource checksum.
+
+    The checksum is also what lets a repeated preparation reuse an already downloaded archive, so
+    ``False`` means the archive is transferred again every time."""

--- a/tests/bfabric_app_runner/inputs/list_inputs/test_integrity.py
+++ b/tests/bfabric_app_runner/inputs/list_inputs/test_integrity.py
@@ -1,0 +1,168 @@
+import zipfile
+from pathlib import Path
+
+import pytest
+from bfabric.transfer import md5_checksum
+
+from bfabric_app_runner.inputs.list_inputs.integrity import IntegrityState, check_integrity
+from bfabric_app_runner.inputs.prepare.prepare_context import PrepareContext
+from bfabric_app_runner.inputs.prepare.prepare_resolved_directory import prepare_resolved_directory
+from bfabric_app_runner.inputs.resolve.resolved_inputs import ResolvedDirectory
+from bfabric_app_runner.specs.inputs.file_spec import FileSourceLocal
+
+
+@pytest.fixture
+def mock_client(mocker):
+    """The client is only needed by the signature; the directory checks never use it."""
+    return mocker.Mock(name="client")
+
+
+@pytest.fixture
+def source_zip(tmp_path):
+    path = tmp_path / "source" / "archive.zip"
+    path.parent.mkdir()
+    with zipfile.ZipFile(path, "w") as zip_file:
+        zip_file.writestr("root/file1.txt", "content1")
+        zip_file.writestr("root/subdir/file2.txt", "content2")
+    return path
+
+
+class TestDirectoryIntegrity:
+    """``inputs check`` must report Incorrect exactly when a prepare would have work to do."""
+
+    @pytest.fixture
+    def target(self, tmp_path):
+        return tmp_path / "target"
+
+    def _prepared(self, source_zip, target, filename="extracted", **kwargs):
+        """Prepares the archive under ``target`` and returns the matching resolved input."""
+        directory = ResolvedDirectory(
+            source=FileSourceLocal(local=str(source_zip)),
+            filename=filename,
+            extract="zip",
+            checksum=md5_checksum(source_zip),
+            **kwargs,
+        )
+        prepare_resolved_directory(directory, target, PrepareContext())
+        return directory
+
+    def test_correct_after_prepare(self, source_zip, target, mock_client):
+        directory = self._prepared(source_zip, target)
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Correct
+
+    def test_correct_for_nested_filename(self, source_zip, target, mock_client):
+        """Regression test for the issue #323 cache path: the archive sits inside the subdirectory."""
+        directory = self._prepared(source_zip, target, filename="input/extracted")
+
+        state = check_integrity(file=directory, local_path=target / "input" / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Correct
+
+    def test_incorrect_when_extracted_file_modified(self, source_zip, target, mock_client):
+        directory = self._prepared(source_zip, target)
+        # Same size as the original, so only the CRC32 can tell them apart.
+        _ = (target / "extracted" / "root" / "file1.txt").write_text("CONTENT1")
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Incorrect
+
+    def test_incorrect_when_extracted_file_deleted(self, source_zip, target, mock_client):
+        directory = self._prepared(source_zip, target)
+        (target / "extracted" / "root" / "subdir" / "file2.txt").unlink()
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Incorrect
+
+    def test_ignores_files_the_spec_excludes(self, source_zip, target, mock_client):
+        """A file outside the include patterns is not extracted, so its absence is not a defect."""
+        directory = self._prepared(source_zip, target, include_patterns=["root/file1.txt"])
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Correct
+        assert not (target / "extracted" / "root" / "subdir" / "file2.txt").exists()
+
+    def test_incorrect_when_cache_archive_missing(self, source_zip, target, mock_client):
+        directory = self._prepared(source_zip, target)
+        (target / "extracted.zip").unlink()
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Incorrect
+
+    def test_incorrect_when_cache_archive_stale(self, source_zip, target, mock_client):
+        directory = self._prepared(source_zip, target)
+        with zipfile.ZipFile(target / "extracted.zip", "w") as zip_file:
+            zip_file.writestr("root/file1.txt", "content1")
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Incorrect
+
+    def test_incorrect_when_cache_archive_is_not_a_zip(self, source_zip, target, mock_client):
+        """A checksum-matching resource that isn't an archive must report a state, not raise."""
+        directory = self._prepared(source_zip, target)
+        not_a_zip = target / "extracted.zip"
+        _ = not_a_zip.write_text("this is not a zip file")
+        directory = directory.model_copy(update={"checksum": md5_checksum(not_a_zip)})
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Incorrect
+
+    def test_missing_when_directory_absent(self, source_zip, target, mock_client):
+        directory = ResolvedDirectory(
+            source=FileSourceLocal(local=str(source_zip)),
+            filename="extracted",
+            extract="zip",
+            checksum=md5_checksum(source_zip),
+        )
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Missing
+
+    def test_incorrect_when_directory_empty(self, source_zip, target, mock_client):
+        directory = ResolvedDirectory(
+            source=FileSourceLocal(local=str(source_zip)),
+            filename="extracted",
+            extract="zip",
+            checksum=md5_checksum(source_zip),
+        )
+        (target / "extracted").mkdir(parents=True)
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Incorrect
+
+    def test_not_checked_without_checksum(self, source_zip, target, mock_client):
+        directory = ResolvedDirectory(
+            source=FileSourceLocal(local=str(source_zip)),
+            filename="extracted",
+            extract="zip",
+            checksum=None,
+        )
+        prepare_resolved_directory(directory, target, PrepareContext())
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.NotChecked
+
+    def test_incorrect_when_path_is_a_file(self, source_zip, target, mock_client):
+        directory = ResolvedDirectory(
+            source=FileSourceLocal(local=str(source_zip)),
+            filename="extracted",
+            extract="zip",
+            checksum=md5_checksum(source_zip),
+        )
+        target.mkdir()
+        _ = Path(target / "extracted").write_text("not a directory")
+
+        state = check_integrity(file=directory, local_path=target / "extracted", client=mock_client)
+
+        assert state == IntegrityState.Incorrect

--- a/tests/bfabric_app_runner/inputs/prepare/test_prepare_folder.py
+++ b/tests/bfabric_app_runner/inputs/prepare/test_prepare_folder.py
@@ -11,7 +11,12 @@ from bfabric_app_runner.inputs.prepare.prepare_folder import (
     _needs_bearer_token,
     _resolve_token_provider,
 )
-from bfabric_app_runner.inputs.resolve.resolved_inputs import ResolvedInputs, ResolvedFile, ResolvedStaticFile
+from bfabric_app_runner.inputs.resolve.resolved_inputs import (
+    ResolvedDirectory,
+    ResolvedInputs,
+    ResolvedFile,
+    ResolvedStaticFile,
+)
 from bfabric_app_runner.specs.inputs.file_spec import FileSourceHttp, FileSourceHttpValue, FileSourceLocal
 from bfabric_app_runner.specs.inputs_spec import InputsSpec
 
@@ -412,3 +417,99 @@ def test_clean_input_files(fs, mocker, mock_logger):
     assert not file1_path.exists()  # Should be removed
     assert not file2_path.exists()  # Should still not exist
     mock_logger.info.assert_called_once_with(f"Removed {file1_path}")
+
+
+class TestCleanDirectoryInputs:
+    """An archive input is an extracted directory plus the cached archive beside it; both must go."""
+
+    @staticmethod
+    def _directory(filename: str) -> ResolvedDirectory:
+        return ResolvedDirectory(
+            source=FileSourceLocal(local="/source.zip"),
+            filename=filename,
+            extract="zip",
+        )
+
+    @staticmethod
+    def _create_extracted(working_dir: Path, filename: str) -> tuple[Path, Path]:
+        """Creates an extracted directory with nested content plus its cached archive."""
+        extracted = working_dir / filename
+        (extracted / "run").mkdir(parents=True)
+        _ = (extracted / "run" / "file.txt").write_text("content")
+        cached_archive = extracted.parent / f"{extracted.name}.zip"
+        _ = cached_archive.write_bytes(b"PK\x05\x06" + bytes(18))
+        return extracted, cached_archive
+
+    def test_removes_extracted_directory_and_cached_archive(self, tmp_path):
+        directory = self._directory("extracted")
+        extracted, cached_archive = self._create_extracted(tmp_path, "extracted")
+
+        _clean_input_files(input_files=ResolvedInputs(files=[directory]), working_dir=tmp_path)
+
+        assert not extracted.exists()
+        assert not cached_archive.exists()
+
+    def test_removes_cached_archive_of_nested_filename(self, tmp_path):
+        """The archive of a nested input sits inside the subdirectory, not below it."""
+        directory = self._directory("input/extracted")
+        extracted, cached_archive = self._create_extracted(tmp_path, "input/extracted")
+        assert cached_archive == tmp_path / "input" / "extracted.zip"
+
+        _clean_input_files(input_files=ResolvedInputs(files=[directory]), working_dir=tmp_path)
+
+        assert not extracted.exists()
+        assert not cached_archive.exists()
+
+    def test_removes_directory_without_cached_archive(self, tmp_path):
+        directory = self._directory("extracted")
+        extracted, cached_archive = self._create_extracted(tmp_path, "extracted")
+        cached_archive.unlink()
+
+        _clean_input_files(input_files=ResolvedInputs(files=[directory]), working_dir=tmp_path)
+
+        assert not extracted.exists()
+
+    def test_tolerates_nothing_to_remove(self, tmp_path, mock_logger):
+        directory = self._directory("extracted")
+
+        _clean_input_files(input_files=ResolvedInputs(files=[directory]), working_dir=tmp_path)
+
+        mock_logger.info.assert_not_called()
+
+    def test_refuses_to_remove_the_working_directory_itself(self, tmp_path, mock_logger):
+        """A "." filename resolves to the working directory, which holds inputs.yml and any outputs."""
+        directory = self._directory(".")
+        bystander = tmp_path / "inputs.yml"
+        _ = bystander.write_text("inputs: []")
+
+        _clean_input_files(input_files=ResolvedInputs(files=[directory]), working_dir=tmp_path)
+
+        assert tmp_path.is_dir()
+        assert bystander.exists()
+        mock_logger.warning.assert_called_once()
+
+    def test_refuses_to_remove_a_path_outside_the_working_directory(self, tmp_path, mock_logger):
+        working_dir = tmp_path / "chunk"
+        working_dir.mkdir()
+        sibling = tmp_path / "sibling"
+        sibling.mkdir()
+        _ = (sibling / "keep.txt").write_text("keep me")
+        directory = self._directory("../sibling")
+
+        _clean_input_files(input_files=ResolvedInputs(files=[directory]), working_dir=working_dir)
+
+        assert (sibling / "keep.txt").exists()
+        mock_logger.warning.assert_called_once()
+
+    def test_removes_only_the_matching_inputs(self, tmp_path):
+        """A sibling file that is not part of this spec is left alone."""
+        directory = self._directory("extracted")
+        extracted, cached_archive = self._create_extracted(tmp_path, "extracted")
+        bystander = tmp_path / "other.txt"
+        _ = bystander.write_text("keep me")
+
+        _clean_input_files(input_files=ResolvedInputs(files=[directory]), working_dir=tmp_path)
+
+        assert not extracted.exists()
+        assert not cached_archive.exists()
+        assert bystander.exists()

--- a/tests/bfabric_app_runner/inputs/prepare/test_prepare_resolved_directory.py
+++ b/tests/bfabric_app_runner/inputs/prepare/test_prepare_resolved_directory.py
@@ -1,14 +1,18 @@
+import os
 import tempfile
 import zipfile
 from pathlib import Path
 
 import pytest
+from bfabric.transfer import md5_checksum
 
 from bfabric_app_runner.inputs.prepare.prepare_context import PrepareContext
 from bfabric_app_runner.inputs.prepare.prepare_resolved_directory import (
     prepare_resolved_directory,
+    _crc32,
     _download_file,
     _get_output_file_path,
+    _is_entry_current,
     _should_strip_root_directory,
 )
 from bfabric_app_runner.inputs.resolve.resolved_inputs import ResolvedDirectory
@@ -218,6 +222,7 @@ def test_download_file_success(mock_prepare_resolved_file, tmp_path):
         include_patterns=[],
         exclude_patterns=[],
         strip_root=False,
+        checksum="d41d8cd98f00b204e9800998ecf8427e",
     )
 
     # Should not raise an exception
@@ -230,7 +235,8 @@ def test_download_file_success(mock_prepare_resolved_file, tmp_path):
     assert resolved_file.source == directory.source
     assert resolved_file.filename == "test.zip"
     assert resolved_file.link is False
-    assert resolved_file.checksum is None
+    # The archive is verified against the resource checksum after the transfer.
+    assert resolved_file.checksum == "d41d8cd98f00b204e9800998ecf8427e"
 
 
 def test_download_file_failure(mock_prepare_resolved_file, tmp_path):
@@ -352,39 +358,161 @@ def test_prepare_resolved_directory_subdirectory_filename(temp_zip_file, tmp_pat
     assert (extracted_path / "root" / "file1.txt").exists()
 
 
-def test_caching_behavior_zip_file_reuse(temp_zip_file, tmp_path):
-    """Test that zip file is left in working directory for caching."""
-    directory = ResolvedDirectory(
-        source=FileSourceLocal(local=str(temp_zip_file)),
-        filename="cached_extract",
-        extract="zip",
-        include_patterns=[],
-        exclude_patterns=[],
-        strip_root=False,
-    )
+class TestSkipUnchangedEntries:
+    """A repeated prepare must not redo work, but must repair any extracted file that no longer matches."""
 
-    # First extraction
-    prepare_resolved_directory(directory, tmp_path, PrepareContext())
+    # An mtime far enough in the past that a re-extraction is unmistakable.
+    OLD_MTIME = 1000000000
 
-    # Verify zip file exists and extraction worked
-    zip_file_path = tmp_path / "cached_extract.zip"
-    extracted_path = tmp_path / "cached_extract"
-    assert zip_file_path.exists()
-    assert extracted_path.exists()
-    assert (extracted_path / "root" / "file1.txt").exists()
+    @pytest.fixture
+    def directory(self, temp_zip_file):
+        return ResolvedDirectory(
+            source=FileSourceLocal(local=str(temp_zip_file)),
+            filename="extracted",
+            extract="zip",
+            include_patterns=[],
+            exclude_patterns=[],
+            strip_root=False,
+        )
 
-    # Get the modification time of the zip file
-    first_mtime = zip_file_path.stat().st_mtime
+    @staticmethod
+    def _backdate(path: Path) -> None:
+        os.utime(path, (TestSkipUnchangedEntries.OLD_MTIME, TestSkipUnchangedEntries.OLD_MTIME))
 
-    # Second extraction (should reuse zip file via rsync caching)
-    # For local files, rsync would detect the file is unchanged and skip download
-    prepare_resolved_directory(directory, tmp_path, PrepareContext())
+    def _prepare_twice(self, directory, tmp_path, modify=None):
+        """Prepares, backdates every extracted file, optionally mutates the tree, then prepares again."""
+        prepare_resolved_directory(directory, tmp_path, PrepareContext())
+        extracted_path = tmp_path / "extracted"
+        for path in sorted(p for p in extracted_path.rglob("*") if p.is_file()):
+            self._backdate(path)
+        if modify is not None:
+            modify(extracted_path)
+        prepare_resolved_directory(directory, tmp_path, PrepareContext())
+        return extracted_path
 
-    # Verify zip file still exists and extraction still works
-    assert zip_file_path.exists()
-    assert extracted_path.exists()
-    assert (extracted_path / "root" / "file1.txt").exists()
+    def test_unchanged_files_are_not_re_extracted(self, directory, tmp_path):
+        extracted_path = self._prepare_twice(directory, tmp_path)
 
-    # The zip file should still be there for caching
-    # (In real usage, rsync would handle the caching optimization)
-    assert zip_file_path.stat().st_mtime >= first_mtime
+        for path in (p for p in extracted_path.rglob("*") if p.is_file()):
+            assert path.stat().st_mtime == self.OLD_MTIME, f"{path} was re-extracted"
+
+    def test_modified_file_of_same_size_is_restored(self, directory, tmp_path):
+        # Same byte count as "content1", so only the CRC32 can tell the two apart.
+        def modify(extracted_path: Path) -> None:
+            (extracted_path / "root" / "file1.txt").write_text("CONTENT1")
+
+        extracted_path = self._prepare_twice(directory, tmp_path, modify)
+
+        modified = extracted_path / "root" / "file1.txt"
+        assert modified.read_text() == "content1"
+        assert modified.stat().st_mtime != self.OLD_MTIME
+        # The untouched siblings are still left alone.
+        assert (extracted_path / "root" / "subdir" / "file2.txt").stat().st_mtime == self.OLD_MTIME
+
+    def test_truncated_file_is_restored(self, directory, tmp_path):
+        def modify(extracted_path: Path) -> None:
+            (extracted_path / "root" / "file1.txt").write_text("c")
+
+        extracted_path = self._prepare_twice(directory, tmp_path, modify)
+
+        assert (extracted_path / "root" / "file1.txt").read_text() == "content1"
+
+    def test_deleted_file_is_restored(self, directory, tmp_path):
+        def modify(extracted_path: Path) -> None:
+            (extracted_path / "root" / "file1.txt").unlink()
+
+        extracted_path = self._prepare_twice(directory, tmp_path, modify)
+
+        assert (extracted_path / "root" / "file1.txt").read_text() == "content1"
+
+
+class TestSkipDownload:
+    """The archive is re-downloaded unless the cached copy provably matches the resource checksum."""
+
+    @pytest.fixture
+    def cached_zip(self, temp_zip_file, tmp_path):
+        """Puts the archive where prepare caches it, and returns its checksum."""
+        cache_path = tmp_path / "extracted.zip"
+        _ = cache_path.write_bytes(temp_zip_file.read_bytes())
+        return md5_checksum(cache_path)
+
+    @staticmethod
+    def _directory(temp_zip_file, checksum):
+        return ResolvedDirectory(
+            source=FileSourceLocal(local=str(temp_zip_file)),
+            filename="extracted",
+            extract="zip",
+            include_patterns=[],
+            exclude_patterns=[],
+            strip_root=False,
+            checksum=checksum,
+        )
+
+    def test_skips_download_when_cached_zip_matches(
+        self, mock_prepare_resolved_file, temp_zip_file, cached_zip, tmp_path
+    ):
+        directory = self._directory(temp_zip_file, cached_zip)
+
+        prepare_resolved_directory(directory, tmp_path, PrepareContext())
+
+        mock_prepare_resolved_file.assert_not_called()
+        # The cached archive is still extracted, i.e. skipping the transfer does not skip the work.
+        assert (tmp_path / "extracted" / "root" / "file1.txt").read_text() == "content1"
+
+    def test_downloads_when_cached_zip_does_not_match(
+        self, mock_prepare_resolved_file, temp_zip_file, cached_zip, tmp_path
+    ):
+        directory = self._directory(temp_zip_file, "0" * 32)
+
+        prepare_resolved_directory(directory, tmp_path, PrepareContext())
+
+        mock_prepare_resolved_file.assert_called_once()
+
+    def test_downloads_when_no_checksum_available(
+        self, mock_prepare_resolved_file, temp_zip_file, cached_zip, tmp_path
+    ):
+        directory = self._directory(temp_zip_file, None)
+
+        prepare_resolved_directory(directory, tmp_path, PrepareContext())
+
+        mock_prepare_resolved_file.assert_called_once()
+
+
+class TestIsEntryCurrent:
+    @pytest.fixture
+    def zip_info(self, temp_zip_file):
+        with zipfile.ZipFile(temp_zip_file) as zip_ref:
+            return zip_ref.getinfo("root/file1.txt")
+
+    def test_matching_file(self, zip_info, tmp_path):
+        path = tmp_path / "file1.txt"
+        _ = path.write_text("content1")
+        assert _is_entry_current(zip_info, path) is True
+
+    def test_missing_file(self, zip_info, tmp_path):
+        assert _is_entry_current(zip_info, tmp_path / "absent.txt") is False
+
+    def test_same_size_different_content(self, zip_info, tmp_path):
+        path = tmp_path / "file1.txt"
+        _ = path.write_text("CONTENT1")
+        assert _is_entry_current(zip_info, path) is False
+
+    def test_different_size(self, zip_info, tmp_path):
+        path = tmp_path / "file1.txt"
+        _ = path.write_text("content1-and-more")
+        assert _is_entry_current(zip_info, path) is False
+
+    def test_directory_in_place_of_file(self, zip_info, tmp_path):
+        path = tmp_path / "file1.txt"
+        path.mkdir()
+        assert _is_entry_current(zip_info, path) is False
+
+    def test_crc32_matches_zip_entry_crc(self, zip_info, tmp_path):
+        path = tmp_path / "file1.txt"
+        _ = path.write_text("content1")
+        assert _crc32(path) == zip_info.CRC
+
+    def test_crc32_is_chunk_size_independent(self, tmp_path):
+        path = tmp_path / "large.bin"
+        _ = path.write_bytes(b"0123456789" * 1000)
+        assert _crc32(path, chunk_size=7) == _crc32(path)


### PR DESCRIPTION
- Change preparing a `bfabric_resource_archive` input to reuse the already downloaded archive when its checksum still matches, and to extract only the entries whose local copy is missing or differs (size, then CRC32) — a repeated prepare now does no transfer and no extraction when nothing changed, while a modified or deleted extracted file is still repaired.
- Change `inputs check` to verify an archive input's extracted files too, not just the downloaded archive.
- Fix `BfabricResourceArchiveSpec.check_checksum` to take effect: the downloaded archive is verified against the resource checksum instead of being accepted unchecked.
- Fix `inputs clean` to remove an archive input's extracted directory and its cached archive, instead of aborting on the directory and removing nothing.
- Fix `inputs check` to locate the cached archive correctly when an input filename contains a subdirectory (it looked for `input/input/name.zip`).

Closes #458

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.