### PR TITLE
Resolve a single-version app spec without application_version

### DIFF
--- a/bfabric_app_runner/docs/changelog.md
+++ b/bfabric_app_runner/docs/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- An app spec that defines exactly one version no longer needs the workunit's `application_version` parameter; a workunit without one resolves to that version. A parameter that is present must still name a defined version.
 - Output registration always creates a new resource instead of recycling the legacy wrapper creator's `pending` placeholder ([#361](https://github.com/fgcz/bfabricPy/issues/361)); the `reuse_default_resource` field and its CLI options are gone, but remain tolerated in an `app.yml`.
 - Relative paths in the app spec (`pylock`, `local_extra_deps`, `prepend_paths`, host side of docker `mounts`) resolve against the `app.yml` directory instead of the run's scratch directory, with a leading `~` expanded ([#212](https://github.com/fgcz/bfabricPy/issues/212)).
 - Captured command output (`uv venv` / `uv pip install`) is logged one record per line, so every line carries its level prefix.

--- a/bfabric_app_runner/src/bfabric_app_runner/app_runner/resolve_app.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/app_runner/resolve_app.py
@@ -17,7 +17,7 @@ def _resolve_app(versions: AppSpec, workunit_definition: WorkunitDefinition) -> 
     if app_version is None:
         requested = workunit_definition.execution.raw_parameters.get("application_version")
         reason = (
-            "the workunit definition does not specify an application_version"
+            "the workunit definition does not specify an application_version and the app spec defines several"
             if requested is None
             else f"application_version '{requested}' is not defined in the app spec"
         )

--- a/bfabric_app_runner/src/bfabric_app_runner/specs/app/app_spec.py
+++ b/bfabric_app_runner/src/bfabric_app_runner/specs/app/app_spec.py
@@ -86,11 +86,15 @@ class AppSpec(BaseModel):
     def for_parameters(self, raw_parameters: Mapping[str, str | None]) -> AppVersion | None:
         """Returns the app version these workunit parameters select, or ``None`` if there is no such version.
 
-        ``None`` covers both an absent ``application_version`` and one naming a version the spec does not
-        define; the callers differ in how loudly they react, so neither case raises here.
+        A spec defining exactly one version needs no ``application_version`` parameter: a workunit without one
+        resolves to that version, so an app that never had the parameter works unchanged. A parameter that *is*
+        present is always taken literally -- naming an undefined version gives ``None`` even for a
+        single-version spec, rather than quietly running something else.
         """
         version = raw_parameters.get("application_version")
-        return self[version] if version is not None else None
+        if version is None:
+            return self.versions[0] if len(self.versions) == 1 else None
+        return self[version]
 
     @property
     def available_versions(self) -> set[str]:

--- a/tests/bfabric_app_runner/bfabric_integration/submitter/config/test_slurm_params.py
+++ b/tests/bfabric_app_runner/bfabric_integration/submitter/config/test_slurm_params.py
@@ -169,7 +169,13 @@ class TestEvaluateAppParams:
         workunit.application_parameters = {"application_version": "9.9.9"}
         assert _evaluate_app_params(workunit) == {}
 
-    def test_absent_version_parameter_returns_empty(self, workunit):
+    def test_absent_version_parameter_uses_the_only_version(self, workunit):
+        """An app that never had an ``application_version`` parameter still gets its params."""
+        workunit.application_parameters = {}
+        assert _evaluate_app_params(workunit) == {"--cpus-per-task": 24}
+
+    def test_absent_version_parameter_returns_empty_when_several_versions_exist(self, workunit, app_yaml):
+        app_yaml.write_text(app_yaml.read_text().replace("  - version: '1.0.0'\n", "  - version: ['1.0.0', '1.0.1']\n"))
         workunit.application_parameters = {}
         assert _evaluate_app_params(workunit) == {}
 

--- a/tests/bfabric_app_runner/specs/app/test_app_spec.py
+++ b/tests/bfabric_app_runner/specs/app/test_app_spec.py
@@ -42,6 +42,10 @@ class TestVersions:
 
 
 class TestForParameters:
+    @pytest.fixture()
+    def single(self, parsed) -> AppSpec:
+        return AppSpec(bfabric=parsed.bfabric, versions=[parsed["0.1.0"]])
+
     def test_selects_the_requested_version(self, parsed):
         assert parsed.for_parameters({"application_version": "0.1.0"}) is parsed["0.1.0"]
 
@@ -49,8 +53,15 @@ class TestForParameters:
         assert parsed.for_parameters({"application_version": "9.9.9"}) is None
 
     @pytest.mark.parametrize("raw_parameters", [{}, {"application_version": None}])
-    def test_returns_none_without_a_version(self, parsed, raw_parameters):
+    def test_returns_none_without_a_version_when_several_are_defined(self, parsed, raw_parameters):
         assert parsed.for_parameters(raw_parameters) is None
+
+    @pytest.mark.parametrize("raw_parameters", [{}, {"application_version": None}])
+    def test_falls_back_to_the_only_version(self, single, raw_parameters):
+        assert single.for_parameters(raw_parameters) is single["0.1.0"]
+
+    def test_does_not_fall_back_when_a_different_version_is_requested(self, single):
+        assert single.for_parameters({"application_version": "9.9.9"}) is None
 
 
 class TestBfabricAppSpec:


### PR DESCRIPTION
- Resolve an app spec that defines exactly one version without the workunit's `application_version` parameter, so an app that never had the parameter works unchanged. An explicitly named version is still taken literally, so a single-version spec asked for an undefined version resolves to nothing rather than running the one it has.
- Stacked on #584 for `AppSpec.for_parameters`; the base retargets to main once that merges.
- Revisits closed issue #236, which rejected a default-version heuristic on reproducibility grounds. That argument holds when several versions exist and one is chosen for you; with a single version there is nothing to choose.