### PR TITLE
refactor(bfabric_scripts): trim the api command internals

### DIFF
--- a/.basedpyright/baseline.bfabric_scripts.json
+++ b/.basedpyright/baseline.bfabric_scripts.json
@@ -2346,62 +2346,6 @@
         ],
         "./bfabric_scripts/src/bfabric_scripts/cli/api/read.py": [
             {
-                "code": "reportUnusedParameter",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAny",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnusedCallResult",
                 "range": {
                     "startColumn": 8,

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
@@ -2,11 +2,10 @@ import cyclopts
 from cyclopts import Parameter
 from loguru import logger
 from pydantic import BaseModel, field_validator
-from rich.console import Console
 
 from bfabric import Bfabric
 from bfabric.utils.cli_integration import use_client
-from bfabric_scripts.cli.api.output_format import OutputFormat, render_output
+from bfabric_scripts.cli.api.output_format import OutputFormat, render_saved
 from bfabric_scripts.cli.api.query_repr import Query
 
 app = cyclopts.App()
@@ -37,10 +36,4 @@ def cmd_api_create(params: Params, *, client: Bfabric) -> None:
     attributes_dict = params.attributes.to_dict(duplicates="error")
     result = client.save(params.endpoint, attributes_dict)
     logger.info(f"{params.endpoint} entity with ID {result[0]['id']} created successfully.")
-    _ = render_output(
-        result.to_list_dict(),
-        output_format=params.format,
-        endpoint=params.endpoint,
-        client=client,
-        console=Console(),
-    )
+    render_saved(result, output_format=params.format, endpoint=params.endpoint, client=client)

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/inspect.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/inspect.py
@@ -26,10 +26,8 @@ def _collect_namespaces(signature: dict[str, ParameterModel]) -> dict[str, str]:
     for param in signature.values():
         _collect_namespaces_from_fields(param.children, namespaces_set)
 
-    # Start with known namespaces
     namespaces = {prefix: uri for prefix, uri in NAMESPACES.items() if uri in namespaces_set}
 
-    # Add unknown namespaces with generic prefixes
     counter = 0
     for ns in sorted(namespaces_set - set(NAMESPACE_URIS.keys())):
         namespaces[f"ns{counter}"] = ns
@@ -39,12 +37,7 @@ def _collect_namespaces(signature: dict[str, ParameterModel]) -> dict[str, str]:
 
 
 def _collect_namespaces_from_fields(fields: list[FieldModel], namespaces_set: set[str]) -> None:
-    """Recursively collect namespaces from fields.
-
-    Args:
-        fields: List of FieldModel instances
-        namespaces_set: Set to collect namespace URIs
-    """
+    """Recursively collects namespace URIs from *fields* into *namespaces_set*."""
     for field in fields:
         if isinstance(field.type, tuple) and len(field.type) == 2:
             _, namespace = field.type
@@ -64,15 +57,9 @@ def _format_type(field_type: str | tuple[str, str]) -> str:
 
 
 def display_signature(signature: dict[str, ParameterModel]) -> None:
-    """Pretty-print a parsed method signature with Rich formatting.
-
-    Args:
-        signature: Dictionary mapping parameter names to ParameterModel instances
-    """
-    # Collect all namespaces used in the signature
+    """Pretty-prints a parsed method signature with Rich formatting."""
     namespaces = _collect_namespaces(signature)
 
-    # Display namespace mappings
     if namespaces:
         console.print("\n[bold]Namespaces:[/bold]")
         for prefix, uri in sorted(namespaces.items()):
@@ -93,14 +80,11 @@ def _display_fields(fields: list[FieldModel], indent: int) -> None:
     prefix = "  " * indent
 
     for field in fields:
-        # Format the type with namespace prefix
         formatted_type = _format_type(field.type)
 
-        # Add [] suffix for multi-occurrence fields (lists)
         if field.multi_occurrence:
             formatted_type = f"{formatted_type}[]"
 
-        # Add red asterisk for required fields
         required_marker = " [red]*[/red]" if field.required else ""
 
         console.print(f"{prefix}- {field.name}: [italic]{formatted_type}[/italic]{required_marker}")

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/output_format.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/output_format.py
@@ -7,6 +7,7 @@ from rich.console import Console
 from rich.table import Table
 
 from bfabric import Bfabric, BfabricClientConfig
+from bfabric.results.result_container import ResultContainer
 from bfabric.typing import ApiResponseObjectType
 from bfabric.utils.polars_utils import flatten_relations
 
@@ -58,6 +59,13 @@ def render_output(
 
     print(result)
     return result
+
+
+def render_saved(result: ResultContainer, *, output_format: OutputFormat, endpoint: str, client: Bfabric) -> None:
+    """Renders the entity returned by ``client.save``."""
+    _ = render_output(
+        result.to_list_dict(), output_format=output_format, endpoint=endpoint, client=client, console=Console()
+    )
 
 
 def _determine_output_columns(

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/parser.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/parser.py
@@ -1,18 +1,14 @@
-"""Parser for SOAP API method signatures using SUDS.
+"""Parses SOAP method signatures into Pydantic models for ``api inspect``.
 
-Extracts parameter and type information from SOAP endpoints into reusable
-Pydantic models for introspection and programmatic access.
-
-Note: This module deals with SUDS, which has limited type stubs. Many type
-checks are suppressed here as they relate to the SUDS library's dynamic nature.
-This module deeply interacts with SUDS internals and type checking is disabled.
+Written against SUDS internals, whose limited type stubs are why this module runs at
+``# pyright: basic`` with per-line ignores.
 """
 
 # pyright: basic
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 from suds.xsd.query import TypeQuery  # pyright: ignore[reportMissingTypeStubs]
 
 from bfabric import Bfabric
@@ -30,8 +26,6 @@ class FieldModel(BaseModel):
     multi_occurrence: bool
     children: list["FieldModel"] = Field(default_factory=list)
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)  # pyright: ignore[reportUnannotatedClassAttribute]
-
 
 class ParameterModel(BaseModel):
     """Represents a complete parameter with its type structure."""
@@ -41,8 +35,6 @@ class ParameterModel(BaseModel):
     required: bool
     children: list[FieldModel] = Field(default_factory=list)
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)  # pyright: ignore[reportUnannotatedClassAttribute]
-
 
 def parse_method_signature(
     client: Bfabric,
@@ -50,20 +42,10 @@ def parse_method_signature(
     method_name: str,
     max_depth: int = 5,
 ) -> dict[str, ParameterModel]:
-    """Parse a SOAP method signature into reusable Pydantic models.
+    """Parses a SOAP method signature into reusable Pydantic models.
 
-    Args:
-        client: Initialized Bfabric client with _engine attribute
-        endpoint: Name of the endpoint to inspect (e.g., "importresource")
-        method_name: Name of the method to inspect (e.g., "read")
-        max_depth: Maximum recursion depth for nested types
-
-    Returns:
-        Dictionary mapping parameter names to ParameterModel instances.
-
-    Raises:
-        RuntimeError: If the client is not configured to use the SUDS engine.
-        AttributeError: If endpoint or method doesn't exist
+    :raises RuntimeError: If the client is not configured to use the SUDS engine.
+    :raises AttributeError: If the endpoint or method does not exist.
     """
     # The WSDL introspection below is written against SUDS internals, so reject any other engine up
     # front instead of leaking an AttributeError from the private engine.
@@ -73,20 +55,15 @@ def parse_method_signature(
             f"Set engine: SUDS in your bfabricpy config."
         )
 
-    # Get the SUDS service
     service = client._engine._get_suds_service(endpoint)  # type: ignore[attr-defined]  # pyright: ignore[reportPrivateUsage,reportAttributeAccessIssue,reportUnknownVariableType,reportUnknownMemberType]
 
-    # Get the specified method
     method = getattr(service, method_name)  # pyright: ignore[reportAny,reportUnknownArgumentType]
 
-    # Get parameter definitions
     binding = method.method.binding.input  # pyright: ignore[reportAny]
     param_defs = binding.param_defs(method.method)  # pyright: ignore[reportAny]
 
-    # Get schema for type resolution
     schema = method.method.binding.input.wsdl.schema  # pyright: ignore[reportAny]
 
-    # Parse each parameter
     result: dict[str, ParameterModel] = {}
     for param_name, param_schema in param_defs:  # pyright: ignore[reportAny]
         resolved_type = param_schema.resolve()  # pyright: ignore[reportAny]
@@ -96,7 +73,6 @@ def parse_method_signature(
             else str(resolved_type)  # pyright: ignore[reportAny]
         )
 
-        # Parse nested fields
         children: list[FieldModel] = []
         if hasattr(resolved_type, "children"):  # pyright: ignore[reportAny]
             fields = resolved_type.children()  # pyright: ignore[reportAny]
@@ -123,18 +99,7 @@ def _parse_field_recursive(
     current_depth: int,
     max_depth: int,
 ) -> FieldModel:
-    """Recursively parse a field and its nested types.
-
-    Args:
-        field: SUDS field object
-        schema: SUDS schema object for type resolution
-        current_depth: Current recursion depth
-        max_depth: Maximum recursion depth
-
-    Returns:
-        FieldModel with fully resolved nested structure
-    """
-    # Extract field information
+    """Recursively parses a field and its nested types."""
     field_name: str = field.name if hasattr(field, "name") else "unknown"  # pyright: ignore[reportAny]
     field_type: str | tuple[str, str] = field.type if hasattr(field, "type") else "N/A"  # pyright: ignore[reportAny]
     # Use SUDS built-in method to check if required, fallback to True (XSD default when minOccurs not specified)
@@ -146,15 +111,12 @@ def _parse_field_recursive(
 
     children: list[FieldModel] = []
 
-    # Recurse into nested types if within depth limit
     if current_depth < max_depth and hasattr(field, "type"):  # pyright: ignore[reportAny]
         type_ref = field.type  # pyright: ignore[reportAny]
 
-        # Skip built-in XML types
         if isinstance(type_ref, tuple):
             _type_name, type_ns = type_ref  # pyright: ignore[reportUnknownVariableType]
             if type_ns != NAMESPACES["xs"]:
-                # Look up the type in the schema
                 query = TypeQuery(type_ref)
                 type_def = query.execute(
                     schema

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Literal, overload
+from typing import Any, Literal
 
 from pydantic import BaseModel, model_validator
 
@@ -35,25 +35,15 @@ class Query(BaseModel):
         """Remove all instances of the specified key."""
         self.pairs = [(k, v) for k, v in self.pairs if k != key]
 
-    @overload
-    def to_dict(self, duplicates: Literal["drop"]) -> dict[str, str]: ...
+    def to_dict(self, duplicates: Literal["error", "collect"]) -> dict[str, str | list[str]]:
+        """Converts the query to a dictionary, mapping a repeated key to the list of its values.
 
-    @overload
-    def to_dict(self, duplicates: Literal["collect"]) -> dict[str, str | list[str]]: ...
-
-    @overload
-    def to_dict(self, duplicates: Literal["error"]) -> dict[str, str]: ...
-
-    def to_dict(self, duplicates: Literal["drop", "error", "collect"]) -> dict[str, str] | dict[str, str | list[str]]:
-        """Convert the query to a dictionary."""
-        if duplicates == "collect" or duplicates == "error":
-            collect: dict[str, list[str]] = defaultdict(list)
-            for key, value in self.pairs:
-                collect[key].append(value)
-            if duplicates == "collect":
-                return {key: (values[0] if len(values) == 1 else values) for key, values in collect.items()}
-            if duplicates == "error" and len(collect) != len(self.pairs):
-                duplicate_keys = [key for key, values in collect.items() if len(values) > 1]
-                msg = f"Duplicate keys found in query: {duplicate_keys}"
-                raise ValueError(msg)
-        return dict(self.pairs)
+        :param duplicates: ``"error"`` rejects a repeated key instead of collecting it.
+        """
+        collect: dict[str, list[str]] = defaultdict(list)
+        for key, value in self.pairs:
+            collect[key].append(value)
+        if duplicates == "error" and (repeated := [key for key, values in collect.items() if len(values) > 1]):
+            msg = f"Duplicate keys found in query: {repeated}"
+            raise ValueError(msg)
+        return {key: (values[0] if len(values) == 1 else values) for key, values in collect.items()}

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/read.py
@@ -8,14 +8,10 @@ from pydantic import BaseModel
 from rich.console import Console
 
 from bfabric import Bfabric
-from bfabric.typing import ApiResponseObjectType
+from bfabric.results.result_container import ResultContainer
 from bfabric.utils.cli_integration import use_client
 from bfabric_scripts.cli.api.output_format import OutputFormat, render_output
 from bfabric_scripts.cli.api.query_repr import Query
-
-# Re-export so that existing callers (e.g. tests) can still do:
-#   from bfabric_scripts.cli.api.read import OutputFormat, render_output
-__all__ = ["OutputFormat", "render_output"]
 
 
 class Params(BaseModel):
@@ -42,11 +38,13 @@ class Params(BaseModel):
         return value[0].split(",") if (len(value) == 1 and "," in value[0]) else value
 
 
-def perform_query(params: Params, client: Bfabric) -> list[ApiResponseObjectType]:
+def perform_query(params: Params, client: Bfabric) -> ResultContainer:
     """Performs the query and returns the results."""
     query = params.query.to_dict(duplicates="collect")
     query_stmt = f"client.read(endpoint={params.endpoint!r}, obj={query!r}, max_results={params.limit!r}, return_id_only={params.return_id_only!r})"
-    results = eval(query_stmt)
+    results = client.read(
+        endpoint=params.endpoint, obj=query, max_results=params.limit, return_id_only=params.return_id_only
+    )
 
     # Log query and results meta information
     python_code = (

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
@@ -1,11 +1,12 @@
+from collections.abc import Mapping
+
 import rich
 import rich.prompt
-from bfabric_scripts.cli.api.output_format import OutputFormat, render_output
+from bfabric_scripts.cli.api.output_format import OutputFormat, render_saved
 from bfabric_scripts.cli.api.query_repr import Query
 from cyclopts import Parameter
 from loguru import logger
 from pydantic import BaseModel, model_validator
-from rich.console import Console
 from rich.panel import Panel
 from rich.pretty import Pretty
 
@@ -52,16 +53,10 @@ def cmd_api_update(params: Params, *, client: Bfabric) -> None:
 
     result = client.save(params.endpoint, {"id": params.entity_id, **attributes_dict})
     logger.info(f"Entity with ID {params.entity_id} updated successfully.")
-    _ = render_output(
-        result.to_list_dict(),
-        output_format=params.format,
-        endpoint=params.endpoint,
-        client=client,
-        console=Console(),
-    )
+    render_saved(result, output_format=params.format, endpoint=params.endpoint, client=client)
 
 
-def _confirm_action(attributes_dict: dict[str, str], client: Bfabric, endpoint: str, entity_id: int) -> bool:
+def _confirm_action(attributes_dict: Mapping[str, object], client: Bfabric, endpoint: str, entity_id: int) -> bool:
     logger.info(f"Updating {endpoint} entity with ID {entity_id} with attributes {attributes_dict}")
     result_read = client.read(endpoint, {"id": entity_id}, max_results=1)
     if not result_read:

--- a/tests/bfabric_cli/test_query_repr.py
+++ b/tests/bfabric_cli/test_query_repr.py
@@ -13,15 +13,10 @@ def input_with_duplicates():
     return ["a", "x", "b", "y", "a", "z"]
 
 
-@pytest.mark.parametrize("duplicates_method", ["drop", "collect", "error"])
+@pytest.mark.parametrize("duplicates_method", ["collect", "error"])
 def test_to_dict_when_no_duplicates(input_without_duplicates, duplicates_method):
     query = Query.model_validate(input_without_duplicates)
     assert query.to_dict(duplicates_method) == {"a": "x", "b": "y", "c": "z"}
-
-
-def test_to_dict_when_duplicates_drop(input_with_duplicates):
-    query = Query.model_validate(input_with_duplicates)
-    assert query.to_dict("drop") == {"a": "z", "b": "y"}
 
 
 def test_to_dict_when_duplicates_collect(input_with_duplicates):


### PR DESCRIPTION
Internal cleanup of `bfabric_scripts/cli/api/`, no behaviour change. Drops the Google-style docstring blocks and code-narrating comments AGENTS.md rules out, `to_dict`'s unused `duplicates="drop"` mode and its three overloads, a dead `__all__` re-export shim, and an `eval()` that built a `client.read` call as an f-string only to log it. Net -70 production lines.

That `eval` was also masking `perform_query`'s return type, annotated `list[ApiResponseObjectType]` while returning a `ResultContainer`.

Groundwork for #159, whose PR is stacked on this one.

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.