### PR TITLE
feat(bfabric_scripts): JSON input for the api commands

### DIFF
--- a/.basedpyright/baseline.bfabric_scripts.json
+++ b/.basedpyright/baseline.bfabric_scripts.json
@@ -2170,56 +2170,6 @@
                 }
             }
         ],
-        "./bfabric_scripts/src/bfabric_scripts/cli/api/create.py": [
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownParameterType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./bfabric_scripts/src/bfabric_scripts/cli/api/delete.py": [
             {
                 "code": "reportUnusedCallResult",
@@ -2320,22 +2270,6 @@
                 }
             },
             {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnknownVariableType",
                 "range": {
                     "startColumn": 15,
@@ -2350,16 +2284,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 38,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./bfabric_scripts/src/bfabric_scripts/cli/api/update.py": [
-            {
-                "code": "reportUnnecessaryComparison",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 44,
                     "lineCount": 1
                 }
             }

--- a/bfabric/docs/user_guides/bfabric-cli/api_operations.md
+++ b/bfabric/docs/user_guides/bfabric-cli/api_operations.md
@@ -34,6 +34,8 @@ bfabric-cli api read [ENDPOINT] [QUERY] [OPTIONS]
 | ----------- | -------- | ------------------------------------------------------------------- |
 | `endpoint` | Yes | Entity type (e.g., `resource`, `sample`, `workunit`, `dataset`) |
 | `query` | No | Key-value pairs to filter results |
+| `--json` | No | Query as a JSON object, merged with the key-value pairs |
+| `--json-file` | No | Path to a file containing that JSON object |
 | `--format` | No | Output: `json`, `yaml`, `tsv`, `table-rich` (default: `table-rich`) |
 | `--limit` | No | Maximum results (default: 100) |
 | `--columns` | No | Comma-separated columns to display |
@@ -53,6 +55,10 @@ bfabric-cli api read resource createdby pfeeder createdafter 2024-05-01
 
 # Query multiple IDs
 bfabric-cli api read resource id 2784586 id 2784576
+
+# Query as JSON, from the command line or a file
+bfabric-cli api read resource --json '{"createdby": "pfeeder", "createdafter": "2024-05-01"}'
+bfabric-cli api read resource --json-file query.json
 
 # Output formats
 bfabric-cli api read resource --limit 10 --format json
@@ -78,7 +84,14 @@ bfabric-cli api create resource name "hello.txt" workunitid 321802 base64 aGVsbG
 
 # Create a sample
 bfabric-cli api create sample name "My Sample" containerid 1234
+
+# Create from JSON — the only way to pass nested or non-string values
+bfabric-cli api create sample --json '{"name": "My Sample", "containerid": 1234}'
+bfabric-cli api create sample --json-file sample.json
 ```
+
+`--json` and `--json-file` work the same way for `read` and `update`. Both are merged with any
+key-value pairs given alongside them, and a key present in both is an error.
 
 ## Updating Entities
 

--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -10,6 +10,14 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 ## \[Unreleased\]
 
+### Added
+
+- `api read`, `api create` and `api update` accept `--json` and `--json-file`, which is the only way to pass nested or non-string attribute values. Both are merged with any key-value pairs, and a key given in both is an error.
+
+### Fixed
+
+- `api create` now rejects an `id` attribute as documented; the check never fired before.
+
 ## \[1.17.0\] - 2026-08-20
 
 ### Added

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/create.py
@@ -21,11 +21,9 @@ class Params(BaseModel):
     """Output format."""
 
     @field_validator("attributes")
-    def _must_not_contain_id(cls, value):
-        if value:
-            for attribute, _ in value:
-                if attribute == "id":
-                    raise ValueError("Attribute 'id' is not allowed in the attributes.")
+    def _must_not_contain_id(cls, value: Query) -> Query:
+        if "id" in value.to_dict("collect"):
+            raise ValueError("Attribute 'id' is not allowed in the attributes.")
         return value
 
 

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/query_repr.py
@@ -1,7 +1,12 @@
+import json
 from collections import defaultdict
-from typing import Any, Literal
+from pathlib import Path
+from typing import Annotated, Any, Literal, cast
 
+from cyclopts import Parameter
 from pydantic import BaseModel, model_validator
+
+from bfabric.typing import ApiRequestDataType
 
 
 class Query(BaseModel):
@@ -11,6 +16,10 @@ class Query(BaseModel):
     """
 
     pairs: list[tuple[str, str]] = []
+    json_input: Annotated[str | None, Parameter(name="--json")] = None
+    """A JSON object of attribute-value pairs, merged with ``pairs``; values may be nested."""
+    json_file: Annotated[Path | None, Parameter(name="--json-file")] = None
+    """Path to a file containing a JSON object, as for ``--json``."""
 
     @staticmethod
     def _convert_flat_list_to_pairs(flat_list: list) -> list[tuple[str, str]]:
@@ -28,14 +37,29 @@ class Query(BaseModel):
         if isinstance(data, list):
             return {"pairs": cls._convert_flat_list_to_pairs(data)}
         if isinstance(data, dict) and "pairs" in data:
-            return {"pairs": cls._convert_flat_list_to_pairs(data["pairs"])}
+            obj = cast("dict[str, object]", data)
+            flat = cast("list[str] | list[tuple[str, str]]", obj["pairs"])
+            return {**obj, "pairs": cls._convert_flat_list_to_pairs(flat)}  # pyright: ignore[reportUnknownMemberType]
         return data
 
     def drop_key_inplace(self, key: str) -> None:
         """Remove all instances of the specified key."""
         self.pairs = [(k, v) for k, v in self.pairs if k != key]
 
-    def to_dict(self, duplicates: Literal["error", "collect"]) -> dict[str, str | list[str]]:
+    def _json_dict(self) -> dict[str, ApiRequestDataType]:
+        """Parses the JSON inputs, where ``--json`` takes precedence over ``--json-file``."""
+        merged: dict[str, ApiRequestDataType] = {}
+        for text in (self.json_file.read_text() if self.json_file else None, self.json_input):
+            if text is None:
+                continue
+            parsed = cast("object", json.loads(text))
+            if not isinstance(parsed, dict):
+                msg = f"JSON input must be an object, got {type(parsed).__name__}"
+                raise ValueError(msg)
+            merged.update(cast("dict[str, ApiRequestDataType]", parsed))
+        return merged
+
+    def to_dict(self, duplicates: Literal["error", "collect"]) -> dict[str, ApiRequestDataType]:
         """Converts the query to a dictionary, mapping a repeated key to the list of its values.
 
         :param duplicates: ``"error"`` rejects a repeated key instead of collecting it.
@@ -46,4 +70,9 @@ class Query(BaseModel):
         if duplicates == "error" and (repeated := [key for key, values in collect.items() if len(values) > 1]):
             msg = f"Duplicate keys found in query: {repeated}"
             raise ValueError(msg)
-        return {key: (values[0] if len(values) == 1 else values) for key, values in collect.items()}
+        result: dict[str, ApiRequestDataType] = {k: (v[0] if len(v) == 1 else v) for k, v in collect.items()}
+        json_dict = self._json_dict()
+        if overlap := sorted(set(result) & set(json_dict)):
+            msg = f"Keys specified both as pairs and in JSON input: {overlap}"
+            raise ValueError(msg)
+        return {**result, **json_dict}

--- a/tests/bfabric_cli/test_cli_api_create.py
+++ b/tests/bfabric_cli/test_cli_api_create.py
@@ -23,6 +23,13 @@ def save_result():
     )
 
 
+class TestCreateRejectsId:
+    @pytest.mark.parametrize("attributes", [[("name", "foo"), ("id", "5")], {"json_input": '{"name": "foo", "id": 5}'}])
+    def test_id_in_attributes_is_rejected(self, attributes):
+        with pytest.raises(ValueError, match="not allowed in the attributes"):
+            Params(endpoint="workunit", attributes=attributes)
+
+
 class TestCreateOutputFormat:
     def test_default_format_is_json(self):
         params = Params(endpoint="workunit", attributes=[("name", "foo")])
@@ -64,6 +71,14 @@ class TestCreateOutputFormat:
         parsed = yaml.safe_load(captured.out)
         assert isinstance(parsed, list)
         assert parsed[0]["id"] == 42
+
+    def test_create_passes_json_attributes_to_save(self, mock_client, save_result):
+        mock_client.save.return_value = save_result
+        params = Params(endpoint="workunit", attributes={"json_input": '{"containerid": 1234}'})
+
+        cmd_api_create(params, client=mock_client)
+
+        mock_client.save.assert_called_once_with("workunit", {"containerid": 1234})
 
     def test_create_passes_correct_args_to_save(self, mock_client, save_result):
         mock_client.save.return_value = save_result

--- a/tests/bfabric_cli/test_cli_api_update.py
+++ b/tests/bfabric_cli/test_cli_api_update.py
@@ -94,3 +94,20 @@ class TestUpdateOutputFormat:
         cmd_api_update(params, client=mock_client)
 
         mock_client.save.assert_called_once_with("workunit", {"id": 42, "status": "available"})
+
+    def test_update_passes_json_attributes_to_save(self, mock_client, save_result):
+        mock_client.save.return_value = save_result
+        params = Params(
+            endpoint="workunit",
+            entity_id=42,
+            attributes={"json_input": '{"parameter": {"id": 7}}'},
+            no_confirm=True,
+        )
+
+        cmd_api_update(params, client=mock_client)
+
+        mock_client.save.assert_called_once_with("workunit", {"id": 42, "parameter": {"id": 7}})
+
+    def test_update_rejects_json_id_that_contradicts_entity_id(self):
+        with pytest.raises(ValueError, match="does not match the entity_id"):
+            Params(endpoint="workunit", entity_id=42, attributes={"json_input": '{"id": 99}'})

--- a/tests/bfabric_cli/test_query_repr.py
+++ b/tests/bfabric_cli/test_query_repr.py
@@ -35,3 +35,34 @@ def test_drop_key_inplace(input_without_duplicates):
     query = Query.model_validate(input_without_duplicates)
     query.drop_key_inplace("b")
     assert query.pairs == [("a", "x"), ("c", "z")]
+
+
+class TestJsonInput:
+    def test_json_is_merged_with_pairs(self):
+        query = Query.model_validate({"pairs": ["name", "x"], "json_input": '{"containerid": 1234}'})
+        assert query.to_dict("error") == {"name": "x", "containerid": 1234}
+
+    def test_json_keeps_nested_and_typed_values(self):
+        query = Query(json_input='{"container": {"id": 7}, "tags": [1, 2], "active": true}')
+        assert query.to_dict("error") == {"container": {"id": 7}, "tags": [1, 2], "active": True}
+
+    def test_json_file_is_read_and_json_wins(self, tmp_path):
+        path = tmp_path / "attributes.json"
+        _ = path.write_text('{"name": "from-file", "other": 1}')
+        query = Query(json_input='{"name": "from-flag"}', json_file=path)
+        assert query.to_dict("error") == {"name": "from-flag", "other": 1}
+
+    @pytest.mark.parametrize("payload", ["[1, 2]", '"scalar"'])
+    def test_json_that_is_not_an_object_raises(self, payload):
+        with pytest.raises(ValueError, match="JSON input must be an object"):
+            Query(json_input=payload).to_dict("error")
+
+    def test_malformed_json_raises(self):
+        with pytest.raises(ValueError):
+            Query(json_input="{oops").to_dict("error")
+
+    @pytest.mark.parametrize("duplicates", ["collect", "error"])
+    def test_key_in_both_pairs_and_json_raises(self, duplicates):
+        query = Query.model_validate({"pairs": ["name", "x"], "json_input": '{"name": "y"}'})
+        with pytest.raises(ValueError, match="both as pairs and in JSON input"):
+            query.to_dict(duplicates)


### PR DESCRIPTION
- Add `--json` and `--json-file` to `api read`, `api create` and `api update` — the only way to pass a nested or non-string attribute value.
- Merge the JSON object over the key-value pairs, rejecting a key given in both.
- Fix `api create` rejecting an `id` attribute; the check never fired before.

Stacked on #616 — review that one first, and expect this diff to shrink once it merges.

Closes #159

🤖 Prepared with assistance from Claude Opus 5 via Claude Code.