### PR TITLE
fix(bfabric_scripts): refuse api update/delete confirmation without a terminal

### DIFF
--- a/bfabric_scripts/docs/changelog.md
+++ b/bfabric_scripts/docs/changelog.md
@@ -14,6 +14,10 @@ Versioning currently follows `X.Y.Z` semantic versioning, independent of the `bf
 
 - `auth login` / `auth pat` complete a bare host with `/bfabric` for any instance, not just the four known ones, so `bfabric-cli login my-instance.example.com` works. A URL whose path is something else is now refused instead of used as given.
 
+### Fixed
+
+- `bfabric-cli api update` and `api delete` explain that there is no terminal to confirm on, and name `--no-confirm`, instead of failing with an `EOFError` traceback when run from a script or cron job.
+
 ## \[1.17.0\] - 2026-08-20
 
 ### Added

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/delete.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/delete.py
@@ -1,3 +1,5 @@
+import sys
+
 import cyclopts
 import rich
 from loguru import logger
@@ -8,6 +10,7 @@ from rich.prompt import Confirm
 
 from bfabric import Bfabric
 from bfabric.utils.cli_integration import use_client
+from bfabric_scripts.cli.interactive import is_interactive
 
 
 @cyclopts.Parameter(name="*")
@@ -34,6 +37,13 @@ def cmd_api_delete(params: Params, *, client: Bfabric) -> None:
     if params.no_confirm:
         _perform_delete(client=client, endpoint=params.endpoint, id=params.id)
     else:
+        if not is_interactive():
+            print(
+                f"Refusing to delete from {params.endpoint} without confirmation: there is no "
+                f"terminal to confirm on. Pass --no-confirm to proceed.",
+                file=sys.stderr,
+            )
+            return
         existing_entities = client.read(params.endpoint, {"id": params.id})
 
         for id in params.id:

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
@@ -50,8 +50,6 @@ def cmd_api_update(params: Params, *, client: Bfabric) -> None:
         return
 
     if not params.no_confirm:
-        # Checked before the read: rich would raise EOFError on the prompt, and the round-trip is
-        # wasted either way.
         if not is_interactive():
             print(
                 f"Refusing to update {params.endpoint} {params.entity_id} without confirmation: "

--- a/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
+++ b/bfabric_scripts/src/bfabric_scripts/cli/api/update.py
@@ -1,6 +1,9 @@
+import sys
+
 import rich
 import rich.prompt
 from bfabric_scripts.cli.api.output_format import OutputFormat, render_output
+from bfabric_scripts.cli.interactive import is_interactive
 from bfabric_scripts.cli.api.query_repr import Query
 from cyclopts import Parameter
 from loguru import logger
@@ -47,6 +50,15 @@ def cmd_api_update(params: Params, *, client: Bfabric) -> None:
         return
 
     if not params.no_confirm:
+        # Checked before the read: rich would raise EOFError on the prompt, and the round-trip is
+        # wasted either way.
+        if not is_interactive():
+            print(
+                f"Refusing to update {params.endpoint} {params.entity_id} without confirmation: "
+                f"there is no terminal to confirm on. Pass --no-confirm to proceed.",
+                file=sys.stderr,
+            )
+            return
         if not _confirm_action(attributes_dict, client, params.endpoint, params.entity_id):
             return
 

--- a/tests/bfabric_cli/test_cli_api_delete.py
+++ b/tests/bfabric_cli/test_cli_api_delete.py
@@ -1,0 +1,41 @@
+import pytest
+from bfabric import Bfabric
+from bfabric_scripts.cli.api.delete import Params, cmd_api_delete
+
+
+@pytest.fixture
+def mock_client(mocker):
+    client = mocker.Mock(spec=Bfabric)
+    client.config.base_url = "http://test-bfabric.com"
+    return client
+
+
+class TestDeleteNonInteractiveConfirmation:
+    """Without a terminal the confirmation cannot be answered, so say what to pass instead of
+    letting rich raise EOFError from a traceback."""
+
+    def test_refuses_and_names_no_confirm(self, mocker, mock_client, capsys):
+        mocker.patch("bfabric_scripts.cli.api.delete.is_interactive", return_value=False)
+        params = Params(endpoint="resource", id=[42])
+
+        cmd_api_delete(params, client=mock_client)
+
+        mock_client.delete.assert_not_called()
+        assert "--no-confirm" in capsys.readouterr().err
+
+    def test_does_not_read_the_entities_first(self, mocker, mock_client):
+        """The refusal is about the missing terminal, so it should not cost an API round-trip."""
+        mocker.patch("bfabric_scripts.cli.api.delete.is_interactive", return_value=False)
+        params = Params(endpoint="resource", id=[42])
+
+        cmd_api_delete(params, client=mock_client)
+
+        mock_client.read.assert_not_called()
+
+    def test_no_confirm_still_deletes_without_a_terminal(self, mocker, mock_client):
+        mocker.patch("bfabric_scripts.cli.api.delete.is_interactive", return_value=False)
+        params = Params(endpoint="resource", id=[42], no_confirm=True)
+
+        cmd_api_delete(params, client=mock_client)
+
+        mock_client.delete.assert_called_once_with(endpoint="resource", id=[42])

--- a/tests/bfabric_cli/test_cli_api_update.py
+++ b/tests/bfabric_cli/test_cli_api_update.py
@@ -94,3 +94,40 @@ class TestUpdateOutputFormat:
         cmd_api_update(params, client=mock_client)
 
         mock_client.save.assert_called_once_with("workunit", {"id": 42, "status": "available"})
+
+
+class TestUpdateNonInteractiveConfirmation:
+    """Without a terminal the confirmation cannot be answered, so say what to pass instead of
+    letting rich raise EOFError from a traceback."""
+
+    def test_refuses_and_names_no_confirm(self, mocker, mock_client, capsys):
+        mocker.patch("bfabric_scripts.cli.api.update.is_interactive", return_value=False)
+        params = Params(endpoint="workunit", entity_id=42, attributes=[("status", "available")])
+
+        cmd_api_update(params, client=mock_client)
+
+        mock_client.save.assert_not_called()
+        assert "--no-confirm" in capsys.readouterr().err
+
+    def test_does_not_read_the_entity_first(self, mocker, mock_client):
+        """The refusal is about the missing terminal, so it should not cost an API round-trip."""
+        mocker.patch("bfabric_scripts.cli.api.update.is_interactive", return_value=False)
+        params = Params(endpoint="workunit", entity_id=42, attributes=[("status", "available")])
+
+        cmd_api_update(params, client=mock_client)
+
+        mock_client.read.assert_not_called()
+
+    def test_no_confirm_still_writes_without_a_terminal(self, mocker, mock_client, save_result):
+        mocker.patch("bfabric_scripts.cli.api.update.is_interactive", return_value=False)
+        mock_client.save.return_value = save_result
+        params = Params(
+            endpoint="workunit",
+            entity_id=42,
+            attributes=[("status", "available")],
+            no_confirm=True,
+        )
+
+        cmd_api_update(params, client=mock_client)
+
+        mock_client.save.assert_called_once()


### PR DESCRIPTION
- Fix `bfabric-cli api update` and `api delete` to explain that there is no terminal to confirm on and name `--no-confirm`, instead of failing with an `EOFError` traceback when run from a script or cron job.